### PR TITLE
Html representation

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -353,14 +353,9 @@ class HTMLBuilder:
 
     def category_2_table(self, category_2_variants: Set[str]) -> str:
         """
-        takes all Cat. 2 variants, and documents the panel changes
-        this is either a new entity, or an altered MOI
-
-        Redraft this completely to take into account changes to Cat. 2
-          - only for 'new' genes relative to a reference point
-          - therefore no changed MOI
-          - potentially a high number of genes
-            - bootstrap in an extensible table?
+        takes all Cat. 2 variants, and documents relevant genes
+        cat. 2 is now 'new genes', not 'new, or altered MOI'
+        table altered to account for this changed purpose
 
         :param category_2_variants:
         :return:
@@ -368,13 +363,6 @@ class HTMLBuilder:
         current_key = (
             f'MOI in v{self.panelapp["panel_metadata"].get("current_version")}'
         )
-        previous_key = (
-            f'MOI in v{self.panelapp["panel_metadata"].get("previous_version")}'
-        )
-
-        # if we don't have version differences, don't do anything
-        if previous_key is None:
-            return ''
 
         gene_dicts = []
         for gene in category_2_variants:
@@ -383,9 +371,6 @@ class HTMLBuilder:
                 {
                     'gene': gene,
                     'symbol': PANELAPP_TEMPLATE.format(symbol=gene_data.get('symbol')),
-                    previous_key: 'Gene Not Present'
-                    if gene_data.get('new')
-                    else gene_data.get('old_moi'),
                     current_key: gene_data.get('moi'),
                 }
             )

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -1,0 +1,434 @@
+"""
+Methods for taking the final output and generating static report content
+"""
+
+from typing import Any, Dict, List, Set, Tuple
+from argparse import ArgumentParser
+from cloudpathlib import AnyPath
+import pandas as pd
+from peddy.peddy import Ped
+
+from reanalysis.utils import read_json_dict_from_path
+
+
+SEQR_TEMPLATE = (
+    '<a href="https://seqr.populationgenomics.org.au/variant_search/'
+    'variant/{variant}/family/{family}" target="_blank">{variant}</a>'
+)
+
+GNOMAD_TEMPLATE = (
+    '<a href="https://gnomad.broadinstitute.org/variant/'
+    '{variant}?dataset=gnomad_r3" target="_blank">{value:.5f}</a>'
+)
+PANELAPP_TEMPLATE = (
+    '<a href="https://panelapp.agha.umccr.org/panels/137/gene/{symbol}/"'
+    ' target="_blank">{symbol}</a>'
+)
+
+STRONG_STRING = '<strong>{content}</strong>'
+COLOR_STRING = '<span style="color: {color}">{content}</span>'
+
+
+def numerical_categories(var_data: Dict[str, Any]) -> List[str]:
+    """
+    get a list of ints representing the classes present on this variant
+    for each numerical class, append that number if the class is present
+    """
+    return [
+        str(integer)
+        for integer, category_bool in enumerate(
+            [
+                var_data['category_1'],
+                var_data['category_2'],
+                var_data['category_3'],
+                var_data['category_4'],
+            ],
+            1,
+        )
+        if category_bool
+    ]
+
+
+def string_format_coords(coords: Dict[str, Any]):
+    """
+    forms a string representation
+    chr-pos-ref-alt
+    """
+    return f'{coords["chrom"]}-{coords["pos"]}-{coords["ref"]}-{coords["alt"]}'
+
+
+class HTMLBuilder:
+    """
+    takes the input, makes the output
+    """
+
+    def __init__(
+        self,
+        results_dict: str,
+        panelapp_data: str,
+        config: str,
+        pedigree: Ped,
+    ):
+        """
+
+        :param results_dict:
+        :param panelapp_data:
+        :param config:
+        :param pedigree:
+        """
+        self.results = read_json_dict_from_path(results_dict)
+        self.config = read_json_dict_from_path(config)['output']
+
+        # map of internal:external IDs for translation in results
+        self.external_map = (
+            read_json_dict_from_path(self.config['external_lookup']) or {}
+        )
+
+        # use config to find CPG-to-Seqr ID JSON; allow to fail
+        try:
+            self.seqr = read_json_dict_from_path(self.config.get('seqr_lookup'))
+        except AttributeError:
+            self.seqr = {}
+
+        self.panelapp = read_json_dict_from_path(panelapp_data)
+
+        # peddy can't read cloudpaths, so create a local copy
+        with open('i_am_a_temporary.ped', 'w', encoding='utf-8') as handle:
+            handle.write(AnyPath(pedigree).read_text())
+        self.pedigree = Ped('i_am_a_temporary.ped')
+        self.colors = self.set_up_colors()
+
+    def set_up_colors(self):
+        """
+        generates the dictionary of color strings
+        """
+
+        return {
+            key: COLOR_STRING.format(
+                color=value, content=STRONG_STRING.format(content=f'Cat{key}')
+            )
+            for key, value in self.config['colors'].items()
+        }
+
+    def get_summary_stats(
+        self,
+    ) -> Tuple[str, List[str]]:  # pylint: disable=too-many-locals
+        """
+        run the numbers across all variant categories
+        :return:
+        """
+
+        category_count = {'1': [], '2': [], '3': [], 'all': []}
+        category_strings = {'1': set(), '2': set(), '3': set(), 'all': set()}
+
+        samples_with_no_variants = []
+
+        for sample in self.pedigree.samples():
+            if not sample.affected:
+                continue
+            if sample.sample_id not in self.results.keys():
+                samples_with_no_variants.append(
+                    self.external_map.get(sample.sample_id, sample.sample_id)
+                )
+
+                # update all indices; 0 variants for this sample
+                for category_list in category_count.values():
+                    category_list.append(0)
+                continue
+
+            # get variants for this sample
+            sample_variants = self.results.get(sample.sample_id)
+
+            # how many variants were attached to this sample?
+            category_count['all'].append(len(sample_variants))
+
+            # create a per-sample object to track variants for each class
+            sample_count = {'1': 0, '2': 0, '3': 0}
+
+            # iterate over the variants
+            for variant in sample_variants.values():
+
+                var_string = string_format_coords(variant['var_data']['coords'])
+
+                # find all classes associated with this variant
+                # for each class, add to corresponding list and set
+                for category_value in numerical_categories(variant['var_data']):
+                    if category_value == '4':
+                        continue
+                    sample_count[category_value] += 1
+                    category_strings[category_value].add(var_string)
+
+                # update the set of all unique variants
+                category_strings['all'].add(var_string)
+
+            # update the global lists with per-sample counts
+            for key, value in sample_count.items():
+                category_count[key].append(value)
+
+        summary_dicts = [
+            {
+                'Category': title,
+                'Total': sum(category_count[key]),
+                'Unique': len(category_strings[key]),
+                'Peak #/sample': max(category_count[key]),
+                'Mean/sample': sum(category_count[key]) / len(category_count[key]),
+            }
+            for title, key in [
+                ('Total', 'all'),
+                ('Class1', '1'),
+                ('Class2', '2'),
+                ('Class3', '3'),
+            ]
+        ]
+
+        return (
+            pd.DataFrame(summary_dicts).to_html(index=False, escape=False),
+            samples_with_no_variants,
+        )
+
+    def write_html(self, output_path: str):
+        """
+        uses the class objects to create the HTML tables
+        writes all content to the output path
+        """
+
+        summary_table, zero_classified_samples = self.get_summary_stats()
+        html_tables, category_2_genes = self.create_html_tables()
+        category_2_table = self.category_2_table(category_2_genes)
+
+        html_lines = [
+            '<head>\n</head>\n<body>\n',
+            '<h3>MOI changes used for Class 2</h3>',
+            category_2_table,
+            '<br/>',
+            f'<h3>Samples without Classified Variants '
+            f'({len(zero_classified_samples)})</h3>',
+        ]
+
+        if len(zero_classified_samples) > 0:
+            html_lines.append(f'<h5>{", ".join(zero_classified_samples)}</h3>')
+        html_lines.append('<br/>')
+
+        html_lines.append('<h3>Per-Class summary</h3>')
+        html_lines.append(summary_table)
+        html_lines.append('<br/>')
+
+        html_lines.append('<h1>Per Sample Results</h1>')
+        html_lines.append(
+            '<br/>Note: "csq" shows all unique csq from all protein_coding txs'
+        )
+        html_lines.append('<br/>Any black "csq" appear on a MANE transcript')
+        html_lines.append('<br/>Any red "csq" don\'t appear on a MANE transcript<br/>')
+
+        for sample, table in html_tables.items():
+            html_lines.append(
+                fr'<h3>Sample: {self.external_map.get(sample, sample)}</h3>'
+            )
+            html_lines.append(table)
+        html_lines.append('\n</body>')
+
+        # write all HTML content to the output file in one go
+        # fix formatting later
+        AnyPath(output_path).write_text(''.join(html_lines))
+
+    def color_csq(self, all_csq: Set[str], mane_csq: Set[str]) -> str:
+        """
+        takes the collection of all consequences, and MANE csqs
+        if a CSQ occurs on MANE, write in bold,
+        if non-MANE, write in red
+        return the concatenated string
+
+        NOTE: I really hate how I've implemented this
+        :param all_csq:
+        :param mane_csq:
+        :return: the string filling the consequence box in the HTML
+        """
+        csq_strings = []
+        for csq in all_csq:
+            # bold, in Black
+            if csq in mane_csq:
+                csq_strings.append(STRONG_STRING.format(content=csq))
+
+            # bold, and red
+            else:
+                csq_strings.append(
+                    self.colors['red_consequence'].replace('Classred_consequence', csq)
+                )
+
+        return ', '.join(csq_strings)
+
+    def get_csq_details(self, variant: Dict[str, Any]) -> Tuple[str, str]:
+        """
+        populates a single string of all relevant consequences
+        UPDATE - take MANE into account
+        """
+
+        csq_set = set()
+        mane_transcript = set()
+        mane_csq = set()
+
+        # iterate over all consequences, special care for MANE
+        for each_csq in variant['var_data']['transcript_consequences']:
+            row_csq = set(each_csq['consequence'].split('&'))
+
+            # record the transcript ID(s), and CSQ(s)
+            # we only expect 1, but set operations are useful
+            mane_trans = each_csq.get('mane_select', '')
+            if mane_trans != '':
+                mane_csq.update(row_csq)
+                mane_transcript.add(mane_trans)
+            csq_set.update(row_csq)
+
+        # we expect one... but this would make the addition of MANE plus_clinical easy
+        mane_string = STRONG_STRING.format(content=', '.join(mane_transcript))
+
+        return self.color_csq(csq_set, mane_csq), mane_string
+
+    def create_html_tables(self):
+        """
+        make a table describing the outputs
+        :return:
+        """
+        candidate_dictionaries = {}
+        sample_tables = {}
+
+        category_2_genes = set()
+
+        for sample, variants in self.results.items():
+            for variant in variants.values():
+
+                # pull out the string representation
+                var_string = string_format_coords(variant['var_data']['coords'])
+
+                # find list of all int categories assigned
+                variant_category_ints = numerical_categories(variant['var_data'])
+
+                if '2' in variant_category_ints:
+                    category_2_genes.add(variant['gene'])
+
+                csq_string, mane_string = self.get_csq_details(variant)
+                candidate_dictionaries.setdefault(variant['sample'], []).append(
+                    {
+                        'variant': self.make_seqr_link(
+                            var_string=var_string, sample=sample
+                        ),
+                        'classes': ', '.join(
+                            list(
+                                map(
+                                    lambda x: self.colors[str(x)],
+                                    variant_category_ints,
+                                )
+                            )
+                        ),
+                        'symbol': PANELAPP_TEMPLATE.format(
+                            symbol=self.panelapp[variant['gene']]['symbol']
+                        ),
+                        'csq': csq_string,
+                        'mane_select': mane_string,
+                        'gnomad': GNOMAD_TEMPLATE.format(
+                            variant=var_string,
+                            value=float(variant['var_data']['info']['gnomad_af']),
+                        ),
+                        'gnomad_AC': variant['var_data']['info']['gnomad_ac'],
+                        'exac:hom': variant['var_data']['info']['exac_ac_hom'],
+                        'g_exome:hom': variant['var_data']['info']['gnomad_ex_hom'],
+                        'g_genome:hom': variant['var_data']['info']['gnomad_hom'],
+                        'MOIs': ','.join(variant['reasons']),
+                        'support': self.make_seqr_link(
+                            var_string=var_string,
+                            sample=sample,
+                        )
+                        if variant['supported']
+                        else 'N/A',
+                    }
+                )
+
+        for sample, variants in candidate_dictionaries.items():
+            sample_tables[sample] = pd.DataFrame(variants).to_html(
+                index=False, render_links=True, escape=False
+            )
+
+        return sample_tables, category_2_genes
+
+    def category_2_table(self, category_2_variants: Set[str]) -> str:
+        """
+        takes all class 2 variants, and documents the panel changes
+        this is either a new entity, or an altered MOI
+
+        Redraft this completely to take into account changes to Cat. 2
+          - only for 'new' genes relative to a reference point
+          - therefore no changed MOI
+          - potentially a high number of genes
+            - bootstrap in an extensible table?
+
+        :param category_2_variants:
+        :return:
+        """
+        current_key = (
+            f'MOI in v{self.panelapp["panel_metadata"].get("current_version")}'
+        )
+        previous_key = (
+            f'MOI in v{self.panelapp["panel_metadata"].get("previous_version")}'
+        )
+
+        # if we don't have version differences, don't do anything
+        if previous_key is None:
+            return ''
+
+        gene_dicts = []
+        for gene in category_2_variants:
+            gene_data = self.panelapp.get(gene)
+            gene_dicts.append(
+                {
+                    'gene': gene,
+                    'symbol': PANELAPP_TEMPLATE.format(symbol=gene_data.get('symbol')),
+                    previous_key: 'Gene Not Present'
+                    if gene_data.get('new')
+                    else gene_data.get('old_moi'),
+                    current_key: gene_data.get('moi'),
+                }
+            )
+        return pd.DataFrame(gene_dicts).to_html(
+            index=False, render_links=True, escape=False
+        )
+
+    def make_seqr_link(self, var_string: str, sample: str) -> str:
+        """
+        either return just the variant as a string, or a seqr link if possible
+        :param sample:
+        :param var_string:
+        :return:
+        """
+        if sample not in self.seqr:
+            return var_string
+        return SEQR_TEMPLATE.format(
+            variant=var_string,
+            family=self.seqr.get(sample),
+        )
+
+
+if __name__ == '__main__':
+
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--results', help='Path to JSON containing analysis results', required=True
+    )
+    parser.add_argument(
+        '--config_path', help='path to the runtime JSON config', required=True
+    )
+    parser.add_argument('--pedigree', help='Path to joint-call PED file', required=True)
+    parser.add_argument(
+        '--panelapp', help='Path to JSON file of PanelApp data', required=True
+    )
+    parser.add_argument(
+        '--out_path', help='Path to write JSON results to', required=True
+    )
+    args = parser.parse_args()
+
+    html_generator = HTMLBuilder(
+        results_dict=args.results,
+        panelapp_data=args.panelapp,
+        pedigree=args.pedigree,
+        config=args.config_path,
+    )
+    html_generator.write_html(output_path=args.out_path)

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -126,7 +126,11 @@ class HTMLBuilder:
         for sample in self.pedigree.samples():
             if not sample.affected:
                 continue
-            if sample.sample_id not in self.results.keys():
+
+            # get variants for this sample
+            sample_variants = self.results.get(sample.sample_id)
+
+            if len(sample_variants) == 0:
                 samples_with_no_variants.append(
                     self.external_map.get(sample.sample_id, sample.sample_id)
                 )
@@ -135,9 +139,6 @@ class HTMLBuilder:
                 for category_list in category_count.values():
                     category_list.append(0)
                 continue
-
-            # get variants for this sample
-            sample_variants = self.results.get(sample.sample_id)
 
             # how many variants were attached to this sample?
             category_count['all'].append(len(sample_variants))

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -31,8 +31,8 @@ COLOR_STRING = '<span style="color: {color}">{content}</span>'
 
 def numerical_categories(var_data: Dict[str, Any]) -> List[str]:
     """
-    get a list of ints representing the classes present on this variant
-    for each numerical class, append that number if the class is present
+    get a list of ints representing the categories present on this variant
+    for each numerical category, append that number if the cat. is present
     """
     return [
         str(integer)
@@ -142,7 +142,7 @@ class HTMLBuilder:
             # how many variants were attached to this sample?
             category_count['all'].append(len(sample_variants))
 
-            # create a per-sample object to track variants for each class
+            # create a per-sample object to track variants for each category
             sample_count = {'1': 0, '2': 0, '3': 0}
 
             # iterate over the variants
@@ -150,8 +150,8 @@ class HTMLBuilder:
 
                 var_string = string_format_coords(variant['var_data']['coords'])
 
-                # find all classes associated with this variant
-                # for each class, add to corresponding list and set
+                # find all categories associated with this variant
+                # for each category, add to corresponding list and set
                 for category_value in numerical_categories(variant['var_data']):
                     if category_value == '4':
                         continue
@@ -175,9 +175,9 @@ class HTMLBuilder:
             }
             for title, key in [
                 ('Total', 'all'),
-                ('Class1', '1'),
-                ('Class2', '2'),
-                ('Class3', '3'),
+                ('Cat1', '1'),
+                ('Cat2', '2'),
+                ('Cat3', '3'),
             ]
         ]
 
@@ -188,28 +188,28 @@ class HTMLBuilder:
 
     def write_html(self, output_path: str):
         """
-        uses the class objects to create the HTML tables
+        uses the results to create the HTML tables
         writes all content to the output path
         """
 
-        summary_table, zero_classified_samples = self.get_summary_stats()
+        summary_table, zero_categorised_samples = self.get_summary_stats()
         html_tables, category_2_genes = self.create_html_tables()
         category_2_table = self.category_2_table(category_2_genes)
 
         html_lines = [
             '<head>\n</head>\n<body>\n',
-            '<h3>MOI changes used for Class 2</h3>',
+            '<h3>MOI changes used for Cat.2</h3>',
             category_2_table,
             '<br/>',
-            f'<h3>Samples without Classified Variants '
-            f'({len(zero_classified_samples)})</h3>',
+            f'<h3>Samples without Categorised Variants '
+            f'({len(zero_categorised_samples)})</h3>',
         ]
 
-        if len(zero_classified_samples) > 0:
-            html_lines.append(f'<h5>{", ".join(zero_classified_samples)}</h3>')
+        if len(zero_categorised_samples) > 0:
+            html_lines.append(f'<h5>{", ".join(zero_categorised_samples)}</h3>')
         html_lines.append('<br/>')
 
-        html_lines.append('<h3>Per-Class summary</h3>')
+        html_lines.append('<h3>Per-Category summary</h3>')
         html_lines.append(summary_table)
         html_lines.append('<br/>')
 
@@ -312,7 +312,7 @@ class HTMLBuilder:
                         'variant': self.make_seqr_link(
                             var_string=var_string, sample=sample
                         ),
-                        'classes': ', '.join(
+                        'categories': ', '.join(
                             list(
                                 map(
                                     lambda x: self.colors[str(x)],
@@ -352,7 +352,7 @@ class HTMLBuilder:
 
     def category_2_table(self, category_2_variants: Set[str]) -> str:
         """
-        takes all class 2 variants, and documents the panel changes
+        takes all Cat. 2 variants, and documents the panel changes
         this is either a new entity, or an altered MOI
 
         Redraft this completely to take into account changes to Cat. 2

--- a/reanalysis/reanalysis_conf.json
+++ b/reanalysis/reanalysis_conf.json
@@ -49,7 +49,7 @@
     "output": {
         "description": "variables affecting how the final HTML report appears",
         "seqr_lookup": "gs://cpg-acute-care-test/reanalysis/parsed_seqr.json",
-        "colours": {
+        "colors": {
             "red_consequence": "#C70039",
             "1": "#C70039",
             "2": "#FF5733",

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -15,4 +15,4 @@ analysis-runner \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
     --matrix_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
-    --pedigree gs://cpg-acute-care-test/reanalysis/family_pedigree.ped
+    --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -230,6 +230,9 @@ def read_json_dict_from_path(bucket_path: str) -> Dict[str, Any]:
             f'AnyPpath could not be constructed from the supplied path "{bucket_path}"'
         )
         raise AttributeError from apt_error
+    except BaseException as be:
+        logging.error(f'Unknown exception when opening JSON path "{bucket_path}')
+        raise AttributeError from be
 
 
 def get_simple_moi(panel_app_moi: str) -> str:

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -13,6 +13,7 @@ import re
 
 import cyvcf2
 from cloudpathlib import AnyPath
+from cloudpathlib.exceptions import AnyPathTypeError
 from cyvcf2 import Variant
 
 
@@ -218,8 +219,17 @@ def read_json_dict_from_path(bucket_path: str) -> Dict[str, Any]:
     take a path to a JSON file, read into an object
     :param bucket_path:
     """
-    with open(AnyPath(bucket_path), encoding='utf-8') as handle:
-        return json.load(handle)
+    try:
+        with open(AnyPath(bucket_path), encoding='utf-8') as handle:
+            return json.load(handle)
+    except FileNotFoundError as fnf_error:
+        logging.error(f'No file could be found on the specified path "{bucket_path}"')
+        raise AttributeError from fnf_error
+    except AnyPathTypeError as apt_error:
+        logging.error(
+            f'AnyPpath could not be constructed from the supplied path "{bucket_path}"'
+        )
+        raise AttributeError from apt_error
 
 
 def get_simple_moi(panel_app_moi: str) -> str:

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -110,7 +110,7 @@ def get_moi_from_panelapp(
 
 # pylint: disable=too-many-locals
 def apply_moi_to_variants(
-    classified_variant_source: str,
+    variant_source: VCFReader,
     moi_lookup: Dict[str, MOIRunner],
     panelapp_data: Dict[str, Dict[str, Union[str, bool]]],
     config: Dict[str, Any],
@@ -120,7 +120,7 @@ def apply_moi_to_variants(
     find all variants/compound hets for all samples which fit within
     the PanelApp provided MOI
 
-    :param classified_variant_source:
+    :param variant_source:
     :param moi_lookup:
     :param panelapp_data:
     :param config:
@@ -128,9 +128,6 @@ def apply_moi_to_variants(
     """
 
     results = []
-
-    # open the VCF using a cyvcf2 reader
-    variant_source = VCFReader(classified_variant_source)
 
     # split here - process each contig separately
     # once the variants are parsed into plain dicts (pickle-able)
@@ -184,13 +181,14 @@ def apply_moi_to_variants(
 
 
 def clean_initial_results(
-    result_list: List[ReportedVariant],
+    result_list: List[ReportedVariant], samples: List[str]
 ) -> Dict[str, Dict[str, ReportedVariant]]:
     """
     Possibility 1 variant can be classified multiple ways
     This cleans those to unique for final report
     Join all possible classes for the condensed variants
     :param result_list:
+    :param samples: all samples in this joint call
     """
 
     clean_results: Dict[str, Dict[str, ReportedVariant]] = {}
@@ -220,6 +218,20 @@ def clean_initial_results(
         clean_results[each_instance.sample][
             var_uid
         ].reasons = variant_object.reasons.union(each_instance.reasons)
+
+    # create empty index if a sample has 0 variants
+    # as well as categorised variants, we want an explicit record of samples in this
+    # joint-call, but had no results.
+    # the PED could have more samples than a joint call, due to sub-setting or QC.
+    # When presenting results, we want all samples with negative findings, without
+    # returning to both VCF and PED files, and running an intersection
+    # this may not apply to all situations, removing a sample during the pipeline due
+    # to withdrawl, QC, or other reasons is possible, in which case parsing only the
+    # PED would list that sample incorrectly as a negative finding
+    for sample in samples:
+        if sample not in clean_results:
+            clean_results[sample] = {}
+
     return clean_results
 
 
@@ -290,16 +302,19 @@ def main(
         comp_het_lookup=read_json_dict_from_path(comp_het),
     )
 
+    # open the VCF using a cyvcf2 reader
+    vcf_opened = VCFReader(labelled_vcf)
+
     # find classification events
     results = apply_moi_to_variants(
-        classified_variant_source=labelled_vcf,
+        variant_source=vcf_opened,
         moi_lookup=moi_lookup,
         panelapp_data=panelapp_data,
         config=config_dict,
     )
 
     # remove duplicate variants
-    cleaned_results = clean_initial_results(results)
+    cleaned_results = clean_initial_results(results, samples=vcf_opened.samples)
 
     # dump the JSON-results to an AnyPath route
     # use the custom-encoder to print sets and DataClasses

--- a/test/test_html_generation.py
+++ b/test/test_html_generation.py
@@ -1,0 +1,48 @@
+"""
+tests for the results -> HTML module
+"""
+from typing import List
+import pytest
+
+from reanalysis.html_builder import numerical_categories, string_format_coords
+
+
+@pytest.mark.parametrize(
+    'one,two,three,four,result',
+    (
+        (True, True, True, True, ['1', '2', '3', '4']),
+        (True, False, False, False, ['1']),
+        (False, True, False, False, ['2']),
+        (False, False, True, True, ['3', '4']),
+        (False, False, False, False, []),
+    ),
+)
+def test_numerical_categories(
+    one: bool, two: bool, three: bool, four: bool, result: List[str]
+):
+    """
+    ronseal
+    :return:
+    """
+
+    var_data = {
+        'category_1': one,
+        'category_2': two,
+        'category_3': three,
+        'category_4': four,
+    }
+    assert numerical_categories(var_data) == result
+
+
+def test_string_format_coords():
+    """
+    ronseal
+    :return:
+    """
+    coords = {
+        'chrom': 'N',
+        'pos': 'I',
+        'ref': 'C',
+        'alt': 'E',
+    }
+    assert string_format_coords(coords) == 'N-I-C-E'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -30,7 +30,7 @@ def test_read_json():
     :return:
     """
     assert read_json_dict_from_path(JSON_STUB) == {'key': 'value'}
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(AttributeError):
         read_json_dict_from_path('not_a_real_path')
 
 


### PR DESCRIPTION
# Fixes

  - #11 
  - #22
  - Adds in the full HTML generation, and runs immediately after result generation (same environment)

## Proposed Changes

  - Updated minimal version of #21, post-rebase to `main`
  - Takes the JSON dump of the analysis results, and renders as a static HTML document summary

## Note

This is a good-enough version for the MVP, and is not expected to continue in use for long.

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
