### PR TITLE
Drop cpg-pipes dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: test
-      run: PYTHONPATH="." pytest -n auto .
+      run: PYTHONPATH="." pytest -n auto -m "not gcp" .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    gcp: requires GCP adapter to run

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -45,10 +45,9 @@ def apply_annotations(
     Hail Query function to convert VCF to a MatrixTable, and add annotations
     based on reference data: VEP, ClinVar, etc.
     """
-
     # path gs://cpg-reference/seqr/all_reference_data/combined_reference_data_grch38.ht/
     ref_ht_path = ref_ht_path or reference_path(
-        'seqr/all_reference_data/combined_reference_data_grch38-2.0.3.ht'
+        'seqr/all_reference_data/combined_reference_data_grch38.ht'
     )
 
     # path gs://cpg-seqr-reference-data/GRCh38/clinvar/clinvar.GRCh38.2020-06-15.ht/

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -46,9 +46,12 @@ def apply_annotations(
     based on reference data: VEP, ClinVar, etc.
     """
 
+    # path gs://cpg-reference/seqr/all_reference_data/combined_reference_data_grch38.ht/
     ref_ht_path = ref_ht_path or reference_path(
-        'seqr/all_reference_data/v2/combined_reference_data_grch38-2.0.3.ht'
+        'seqr/all_reference_data/combined_reference_data_grch38-2.0.3.ht'
     )
+
+    # path gs://cpg-seqr-reference-data/GRCh38/clinvar/clinvar.GRCh38.2020-06-15.ht/
     clinvar_ht_path = clinvar_ht_path or reference_path(
         'seqr/clinvar/clinvar.GRCh38.2020-06-15.ht'
     )

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -50,13 +50,11 @@ def apply_annotations(
 
     # path gs://cpg-reference/seqr/all_reference_data/combined_reference_data_grch38.ht/
     ref_ht_path = ref_ht_path or reference_path(
-        'seqr/all_reference_data/combined_reference_data_grch38.ht'
+        'seqr/v0-1/combined_reference_data_grch38-2.0.4.ht'
     )
 
     # path gs://cpg-seqr-reference-data/GRCh38/clinvar/clinvar.GRCh38.2020-06-15.ht/
-    clinvar_ht_path = clinvar_ht_path or reference_path(
-        'seqr/clinvar/clinvar.GRCh38.2020-06-15.ht'
-    )
+    clinvar_ht_path = clinvar_ht_path or reference_path('seqr/v0-1/clinvar.GRCh38.ht')
 
     def _checkpoint(t: hl.Table, filename: str):
         """

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -10,22 +10,6 @@ import hail as hl
 
 from cpg_utils.hail_batch import reference_path
 
-from hail_scripts.computed_fields.variant_id import (
-    get_expr_for_contig,
-    get_expr_for_variant_id,
-    get_expr_for_variant_ids,
-    get_expr_for_xpos,
-)
-
-# custom imports to reduce line lengths
-from hail_scripts.computed_fields.vep import (
-    get_expr_for_vep_sorted_transcript_consequences_array as vep_array,
-    get_expr_for_vep_transcript_ids_set as vep_set,
-    get_expr_for_worst_transcript_consequence_annotations_struct as worst_csq,
-    get_expr_for_vep_consequence_terms_set as vep_csq_set,
-    get_expr_for_vep_gene_ids_set as vep_gene_id_set,
-    get_expr_for_vep_protein_domains_set_from_sorted as vep_prot,
-)
 
 logger = logging.getLogger(__file__)
 
@@ -45,6 +29,25 @@ def apply_annotations(
     Hail Query function to convert VCF to a MatrixTable, and add annotations
     based on reference data: VEP, ClinVar, etc.
     """
+    # pylint: disable=C0415
+    from hail_scripts.computed_fields.variant_id import (
+        get_expr_for_contig,
+        get_expr_for_variant_id,
+        get_expr_for_variant_ids,
+        get_expr_for_xpos,
+    )
+
+    # custom imports to reduce line lengths
+    # pylint disable:C0415
+    from hail_scripts.computed_fields.vep import (
+        get_expr_for_vep_sorted_transcript_consequences_array as vep_array,
+        get_expr_for_vep_transcript_ids_set as vep_set,
+        get_expr_for_worst_transcript_consequence_annotations_struct as worst_csq,
+        get_expr_for_vep_consequence_terms_set as vep_csq_set,
+        get_expr_for_vep_gene_ids_set as vep_gene_id_set,
+        get_expr_for_vep_protein_domains_set_from_sorted as vep_prot,
+    )
+
     # path gs://cpg-reference/seqr/all_reference_data/combined_reference_data_grch38.ht/
     ref_ht_path = ref_ht_path or reference_path(
         'seqr/all_reference_data/combined_reference_data_grch38.ht'

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -37,9 +37,9 @@ def apply_annotations(
     overwrite: bool = False,
     genome_build: str = 'GRCh38',
     sequencing_type: str = 'WGS',
+    checkpoints_bucket=None,
     ref_ht_path=None,
     clinvar_ht_path=None,
-    checkpoints_bucket=None,
 ):
     """
     Hail Query function to convert VCF to a MatrixTable, and add annotations

--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -1,14 +1,15 @@
 """
-Creates a Hail Batch job to run the command line VEP tool.
+Hail Query function to convert VCF to a MatrixTable, and add annotations
+based on reference data: VEP, ClinVar, etc.
 """
 
 
 import logging
-from typing import Literal, Optional
 
 import hail as hl
 
-# grouped imports from elastic-search-pipelines
+from cpg_utils.hail_batch import reference_path
+
 from hail_scripts.computed_fields.variant_id import (
     get_expr_for_contig,
     get_expr_for_variant_id,
@@ -25,221 +26,8 @@ from hail_scripts.computed_fields.vep import (
     get_expr_for_vep_gene_ids_set as vep_gene_id_set,
     get_expr_for_vep_protein_domains_set_from_sorted as vep_prot,
 )
-import hailtop.batch as hb
-from hailtop.batch.job import Job
-from hailtop.batch import Batch
-
-from cpg_pipes import images, utils as cpg_pipe_utils, Path, to_path
-from cpg_pipes.hb.resources import STANDARD
-from cpg_pipes.hb.command import wrap_command, python_command
-from cpg_pipes.jobs import split_intervals
-from cpg_pipes.jobs.vcf import gather_vcfs, subset_vcf
-from cpg_pipes.query import vep as vep_module
-from cpg_pipes.refdata import RefData
-from cpg_pipes.types import SequencingType
-
 
 logger = logging.getLogger(__file__)
-
-
-def vep_jobs(  # pylint: disable=too-many-arguments
-    b: Batch,
-    vcf_path: Path,
-    refs: RefData,
-    hail_billing_project: str,
-    hail_bucket: Path,
-    tmp_bucket: Path,
-    out_path: Path | None = None,
-    overwrite: bool = False,
-    scatter_count: int | None = RefData.number_of_vep_intervals,
-    sequencing_type: SequencingType = SequencingType.GENOME,
-    intervals_path: Path | None = None,
-    job_attrs: dict | None = None,
-) -> list[Job]:
-    """
-    Runs VEP on provided VCF. Writes a VCF into `out_path` by default,
-    unless `out_path` ends with ".ht", in which case writes a Hail table.
-    """
-    to_hail_table = out_path and out_path.suffix == '.ht'
-    if not to_hail_table:
-        assert str(out_path).endswith('.vcf.gz'), out_path
-
-    if out_path and cpg_pipe_utils.can_reuse(out_path, overwrite):
-        return [b.new_job('VEP [reuse]', job_attrs)]
-
-    jobs: list[Job] = []
-    intervals_j, intervals = split_intervals.get_intervals(
-        b=b,
-        refs=refs,
-        sequencing_type=sequencing_type,
-        intervals_path=intervals_path,
-        scatter_count=scatter_count,
-    )
-    jobs.append(intervals_j)
-
-    vcf = b.read_input_group(
-        **{'vcf.gz': str(vcf_path), 'vcf.gz.tbi': str(vcf_path) + '.tbi'}
-    )
-
-    parts_bucket = tmp_bucket / 'vep' / 'parts'
-    part_files = []
-
-    # Splitting variant calling by intervals
-    for idx in range(scatter_count):
-        subset_j = subset_vcf(
-            b,
-            vcf=vcf,
-            interval=intervals[idx],
-            refs=refs,
-            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
-        )
-        jobs.append(subset_j)
-        if to_hail_table:
-            part_path = parts_bucket / f'part{idx + 1}.json_list'
-        else:
-            part_path = None
-        # noinspection PyTypeChecker
-        j = vep_one(
-            b,
-            vcf=subset_j.output_vcf['vcf.gz'],
-            out_format='json' if to_hail_table else 'vcf',
-            out_path=part_path,
-            refs=refs,
-            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
-            overwrite=overwrite,
-        )
-        jobs.append(j)
-        if to_hail_table:
-            part_files.append(part_path)
-        else:
-            part_files.append(j.output['vcf.gz'])
-
-    if to_hail_table:
-        gather_j = gather_vep_json_to_ht(
-            b=b,
-            vep_results_paths=part_files,
-            hail_billing_project=hail_billing_project,
-            hail_bucket=hail_bucket,
-            out_path=out_path,
-            job_attrs=job_attrs,
-        )
-    else:
-        assert len(part_files) == scatter_count
-        gather_j, _gather_vcf = gather_vcfs(
-            b=b,
-            input_vcfs=part_files,
-            out_vcf_path=out_path,
-        )
-    gather_j.depends_on(*jobs)
-    jobs.append(gather_j)
-    return jobs
-
-
-def gather_vep_json_to_ht(
-    b: Batch,
-    vep_results_paths: list[Path],
-    hail_billing_project: str,
-    hail_bucket: Path,
-    out_path: Path,
-    job_attrs: dict | None = None,
-):
-    """
-    Parse results from VEP with annotations formatted in JSON,
-    and write into a Hail Table using a Batch job.
-    """
-    j = b.new_job('VEP json to Hail table', job_attrs)
-    j.image(images.DRIVER_IMAGE)
-    cmd = python_command(
-        vep_module,
-        vep_module.vep_json_to_ht.__name__,
-        [str(p) for p in vep_results_paths],
-        str(out_path),
-        setup_gcp=True,
-        hail_billing_project=hail_billing_project,
-        hail_bucket=str(hail_bucket),
-        default_reference=RefData.genome_build,
-    )
-    j.command(cmd)
-    return j
-
-
-def vep_one(
-    b: Batch,
-    vcf: Path | hb.Resource,
-    refs: RefData,
-    out_path: Path | None = None,
-    out_format: Literal['vcf', 'json'] = 'vcf',
-    job_attrs: dict | None = None,
-    overwrite: bool = False,
-) -> Job:
-    """
-    Run a single VEP job.
-    """
-    j = b.new_job('VEP', job_attrs)
-    if out_path and cpg_pipe_utils.can_reuse(out_path, overwrite):
-        j.name += ' [reuse]'
-        return j
-
-    j.image(images.VEP_IMAGE)
-    STANDARD.set_resources(j, storage_gb=50, mem_gb=50, ncpu=16)
-
-    if not isinstance(vcf, hb.Resource):
-        vcf = b.read_input(str(vcf))
-
-    if out_format == 'vcf':
-        j.declare_resource_group(
-            output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
-        )
-        output = j.output['vcf.gz']
-    else:
-        output = j.output
-
-    # gcsfuse works only with the root bucket, without prefix:
-    base_bucket_name = refs.vep_bucket.drive
-    data_mount = to_path(f'/{base_bucket_name}')
-    j.cloudfuse(base_bucket_name, str(data_mount), read_only=True)
-    vep_dir = data_mount / 'vep' / 'GRCh38'
-    loftee_conf = {
-        'loftee_path': '$LOFTEE_PLUGIN_PATH',
-        'gerp_bigwig': f'{vep_dir}/gerp_conservation_scores.homo_sapiens.GRCh38.bw',
-        'human_ancestor_fa': f'{vep_dir}/human_ancestor.fa.gz',
-        'conservation_file': f'{vep_dir}/loftee.sql',
-    }
-
-    cmd = f"""\
-    ls {vep_dir}
-    ls {vep_dir}/vep
-
-    LOFTEE_PLUGIN_PATH=/root/micromamba/share/ensembl-vep-105.0-1
-    FASTA={vep_dir}/vep/homo_sapiens/105_GRCh38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
-
-    vep \\
-    --format vcf \\
-    --{out_format} {'--compress_output bgzip' if out_format == 'vcf' else ''} \\
-    -o {output} \\
-    -i {vcf} \\
-    --everything \\
-    --allele_number \\
-    --minimal \\
-    --cache --offline --assembly GRCh38 \\
-    --dir_cache {vep_dir}/vep/ \\
-    --dir_plugins $LOFTEE_PLUGIN_PATH \\
-    --fasta $FASTA \\
-    --plugin LoF,{','.join(f'{k}:{v}' for k, v in loftee_conf.items())}
-    """
-    if out_format == 'vcf':
-        cmd += f'tabix -p vcf {output}'
-
-    j.command(
-        wrap_command(
-            cmd,
-            setup_gcp=True,
-            monitor_space=True,
-        )
-    )
-    if out_path:
-        b.write_output(j.output, str(out_path).replace('.vcf.gz', ''))
-    return j
 
 
 def apply_annotations(
@@ -249,11 +37,21 @@ def apply_annotations(
     overwrite: bool = False,
     genome_build: str = 'GRCh38',
     sequencing_type: str = 'WGS',
-    checkpoints_bucket: Optional[str] = None,
+    ref_ht_path=None,
+    clinvar_ht_path=None,
+    checkpoints_bucket=None,
 ):
     """
-    Convert VCF to mt, add VEP annotations.
+    Hail Query function to convert VCF to a MatrixTable, and add annotations
+    based on reference data: VEP, ClinVar, etc.
     """
+
+    ref_ht_path = ref_ht_path or reference_path(
+        'seqr/all_reference_data/v2/combined_reference_data_grch38-2.0.3.ht'
+    )
+    clinvar_ht_path = clinvar_ht_path or reference_path(
+        'seqr/clinvar/clinvar.GRCh38.2020-06-15.ht'
+    )
 
     def _checkpoint(t: hl.Table, filename: str):
         """
@@ -298,12 +96,8 @@ def apply_annotations(
     logger.info('Adding dummy GRCh37 loci')
     mt = mt.annotate_rows(rg37_locus=mt.locus)
 
-    seqr_ref_bucket = 'gs://cpg-seqr-reference-data'
-    ref_ht_path = 'GRCh38/all_reference_data/v2/combined_reference_data_grch38-2.0.3.ht'
-    ref_ht = hl.read_table(f'{seqr_ref_bucket}/{ref_ht_path}')
-    clinvar_ht = hl.read_table(
-        f'{seqr_ref_bucket}/GRCh38/clinvar/clinvar.GRCh38.2020-06-15.ht'
-    )
+    ref_ht = hl.read_table(str(ref_ht_path))
+    clinvar_ht = hl.read_table(str(clinvar_ht_path))
 
     logger.info('Annotating with seqr-loader fields: round 1')
     mt = mt.annotate_rows(

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -28,9 +28,6 @@ import click
 from cloudpathlib import AnyPath, CloudPath
 import hailtop.batch as hb
 
-from cpg_pipes.types import SequencingType
-from cpg_pipes.refdata import RefData
-
 from cpg_utils.git import (
     prepare_git_job,
     get_git_commit_ref_of_current_repository,
@@ -45,7 +42,7 @@ from cpg_utils.hail_batch import (
     remote_tmpdir,
 )
 
-from reanalysis.vep.jobs import vep_jobs
+from reanalysis.vep.jobs import vep_jobs, SequencingType
 
 
 # static paths to write outputs
@@ -74,9 +71,6 @@ QUERY_PANELAPP = os.path.join(os.path.dirname(__file__), 'query_panelapp.py')
 RESULTS_SCRIPT = os.path.join(os.path.dirname(__file__), 'validate_categories.py')
 HTML_SCRIPT = os.path.join(os.path.dirname(__file__), 'html_builder.py')
 MT_TO_VCF_SCRIPT = os.path.join(os.path.dirname(__file__), 'mt_to_vcf.py')
-
-# create a default RefData object, root bucket to be customisable in future
-runtime_ref_data = RefData(bucket=CloudPath('gs://cpg-reference'))
 
 
 def read_json_dict_from_path(bucket_path: str) -> Dict[str, Any]:

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -425,6 +425,12 @@ def main(
         # uses default values from RefData
         annotation_jobs = annotate_vcf(input_path, batch=batch)
 
+        # if the conversion to VCF job exists, assign as a dependency
+        # for all annotation jobs
+        if prior_job:
+            for job in annotation_jobs:
+                job.depends_on(prior_job)
+
         # take the last job in this batch, and use for future dependencies
         prior_job = annotation_jobs[-1]
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -24,8 +24,6 @@ from pathlib import Path
 import os
 import sys
 
-from shlex import quote
-
 import click
 from cloudpathlib import AnyPath, CloudPath
 import hailtop.batch as hb
@@ -130,14 +128,15 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     """
     mt_to_vcf_job = batch.new_job(name='Convert MT to VCF')
     set_job_resources(mt_to_vcf_job, git=True, auth=True)
-    newline = '##FILTER=<ID=VQSR,Description="VQSR triggered">'
+
+    additional_header = 'gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt'
+    header = batch.read_input(path=additional_header)
 
     job_cmd = (
-        f'echo {quote(newline)} > $(pwd)/head_file.txt; '
         f'PYTHONPATH=$(pwd) python3 {MT_TO_VCF_SCRIPT} '
         f'--input {input_file} '
         f'--output {INPUT_AS_VCF} '
-        f'--additional_header $(pwd)/head_file.txt'
+        f'--additional_header {header}'
     )
     logging.info(f'Command used to convert MT: {job_cmd}')
     copy_common_env(mt_to_vcf_job)

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -50,7 +50,6 @@ PANELAPP_JSON_OUT = output_path('panelapp_137_data.json')
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
 COMP_HET_JSON = output_path('hail_categorised.json')
 REHEADERED_OUT = output_path('hail_categories_reheadered.vcf.bgz')
-VQSR_ID_PREFIX = output_path('vqsr_line_in_header')
 REHEADERED_PREFIX = output_path('hail_categories_reheadered')
 MT_OUT_PATH = output_path('hail_105_ac.mt')
 RESULTS_JSON = output_path('summary_results.json')
@@ -169,7 +168,7 @@ def annotate_vcf(
         hail_bucket=AnyPath(remote_tmpdir()),
         tmp_bucket=AnyPath(VEP_STAGE_TMP),
         out_path=AnyPath(VEP_HT_TMP),
-        overwrite=True,
+        overwrite=False,  # don't re-run annotation on completed chunks
         sequencing_type=seq_type,
         job_attrs={},
     )
@@ -439,9 +438,6 @@ def main(
 
         # take the last job in this batch, and use for future dependencies
         prior_job = annotation_jobs[-1]
-
-    # hold for linter
-    _do_nothing = prior_job, config_dict, panelapp_version, panel_genes, pedigree
 
     # -------------------------------- #
     # query panelapp for panel details #

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -42,7 +42,7 @@ from cpg_utils.hail_batch import (
     remote_tmpdir,
 )
 
-from .vep.jobs import vep_jobs, SequencingType
+from vep.jobs import vep_jobs, SequencingType
 
 
 # static paths to write outputs

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -24,6 +24,8 @@ from pathlib import Path
 import os
 import sys
 
+from shlex import quote
+
 import click
 from cloudpathlib import AnyPath, CloudPath
 import hailtop.batch as hb
@@ -262,7 +264,7 @@ def vqsr_reheader(
     reheader.command(
         'set -ex;'
         f'bcftools view -h {vcf} | head -2 > hdr;'
-        f'echo {newline} >> hdr;'
+        f'echo {quote(newline)} >> hdr;'
         f'bcftools view -h {vcf} | tail -3 >> hdr;'
         f'bcftools reheader -h hdr --threads 4 -o {reheader.vcf["vcf.bgz"]} {vcf};'
         f'tabix {reheader.vcf["vcf.bgz"]}'

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -130,7 +130,6 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     set_job_resources(mt_to_vcf_job, git=True, auth=True)
 
     additional_header = 'gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt'
-    # header = batch.read_input(path=additional_header)
 
     job_cmd = (
         f'PYTHONPATH=$(pwd) python3 {MT_TO_VCF_SCRIPT} '

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -467,6 +467,7 @@ def main(
     )
     batch.write_output(header_job.vcf, VQSR_ID_PREFIX)
     input_path = f'{VQSR_ID_PREFIX}.vcf.bgz'
+    prior_job = header_job
 
     # ------------------------------------- #
     # split the VCF, and annotate using VEP #

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -50,6 +50,7 @@ PANELAPP_JSON_OUT = output_path('panelapp_137_data.json')
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
 COMP_HET_JSON = output_path('hail_categorised.json')
 REHEADERED_OUT = output_path('hail_categories_reheadered.vcf.bgz')
+VQSR_ID_PREFIX = output_path('vqsr_line_in_header')
 REHEADERED_PREFIX = output_path('hail_categories_reheadered')
 MT_OUT_PATH = output_path('hail_105_ac.mt')
 RESULTS_JSON = output_path('summary_results.json')
@@ -236,6 +237,38 @@ def handle_hail_filtering(
     return labelling_job
 
 
+def vqsr_reheader(
+    batch: hb.Batch,
+    vcf: str,
+    prior_job: Optional[hb.batch.job.Job] = None,
+) -> hb.batch.job.Job:
+    """
+    add VQSR line into VCF header
+    :param batch:
+    :param vcf:
+    :param prior_job:
+    :return:
+    """
+
+    reheader = batch.new_job(name='bcftools_reheader_stage')
+    set_job_resources(reheader, image=BCFTOOLS_IMAGE, prior_job=prior_job)
+
+    reheader.declare_resource_group(
+        vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
+    )
+
+    newline = '##FILTER=<ID=PASS,Description="All filters passed">'
+
+    reheader.command(
+        'set -ex;'
+        f'bcftools view -h {vcf} | head -2 > hdr;'
+        f'echo {newline} >> hdr;'
+        f'bcftools view -h {vcf} | tail -3 >> hdr;'
+        f'bcftools reheader -h hdr --threads 4 -o {reheader.vcf["vcf.bgz"]} {vcf};'
+    )
+    return reheader
+
+
 def handle_reheader_job(
     batch: hb.Batch,
     local_vcf: str,
@@ -416,6 +449,25 @@ def main(
         prior_job = mt_to_vcf(batch=batch, input_file=input_path)
         input_path = INPUT_AS_VCF
 
+    # ----------------------------- #
+    # Add VQSR Header line into VCF #
+    # ----------------------------- #
+    # Hail doesn't export a header line for VQSR AFAIK
+
+    # copy the input VCF file into batch
+    vcf_in_batch = batch.read_input_group(
+        **{'vcf.bgz': input_path, 'vcf.bgz.tbi': input_path + '.tbi'}
+    )
+
+    # add ID field for VQSR
+    header_job = vqsr_reheader(
+        batch=batch,
+        vcf=vcf_in_batch['vcf.bgz'],
+        prior_job=prior_job,
+    )
+    batch.write_output(header_job.vcf, VQSR_ID_PREFIX)
+    input_path = f'{VQSR_ID_PREFIX}.vcf.bgz'
+
     # ------------------------------------- #
     # split the VCF, and annotate using VEP #
     # ------------------------------------- #
@@ -438,75 +490,75 @@ def main(
     # hold for linter
     _do_nothing = prior_job, config_dict, panelapp_version, panel_genes, pedigree
 
-    # # -------------------------------- #
-    # # query panelapp for panel details #
-    # # -------------------------------- #
-    # # no need to launch in a separate batch, minimal dependencies
-    # prior_job = handle_panelapp_job(
-    #     batch=batch,
-    #     gene_list=panel_genes,
-    #     prev_version=panelapp_version,
-    #     prior_job=prior_job,
-    # )
-    #
-    # # ----------------------- #
-    # # run hail categorisation #
-    # # ----------------------- #
-    # # only run if the output VCF doesn't already exist
-    # if not AnyPath(REHEADERED_OUT).exists():
-    #     logging.info(
-    #         f'The Reheadered VCF "{REHEADERED_OUT}" doesn\'t exist; regenerating'
-    #     )
-    #
-    #     if not AnyPath(HAIL_VCF_OUT).exists():
-    #         logging.info(
-    #             f'The Labelled VCF "{HAIL_VCF_OUT}" doesn\'t exist; regenerating'
-    #         )
-    #
-    #         prior_job = handle_hail_filtering(
-    #             batch=batch,
-    #             matrix_path=input_path,
-    #             config=config_json,
-    #             prior_job=prior_job,
-    #         )
-    #
-    #     # --------------------------------- #
-    #     # bcftools re-headering of hail VCF #
-    #     # --------------------------------- #
-    #     # copy the labelled output file into the remaining batch jobs
-    #     hail_output_in_batch = batch.read_input_group(
-    #         **{'vcf.bgz': HAIL_VCF_OUT, 'vcf.bgz.tbi': HAIL_VCF_OUT + '.tbi'}
-    #     )
-    #
-    #     # this is no longer explicitly required...
-    #     # it was required to run slivar: geneId, consequences, and transcript
-    #     # keeping in to ensure the VCF can be interpreted without the config
-    #     bcftools_job = handle_reheader_job(
-    #         batch=batch,
-    #         local_vcf=hail_output_in_batch['vcf.bgz'],
-    #         config_dict=config_dict,
-    #         prior_job=prior_job,
-    #     )
-    #     batch.write_output(bcftools_job.vcf, REHEADERED_PREFIX)
-    #     reheadered_vcf_in_batch = bcftools_job.vcf['vcf.bgz']
-    #
-    # # if it exists remotely, read into a batch
-    # else:
-    #     vcf_in_batch = batch.read_input_group(
-    #         **{'vcf.bgz': REHEADERED_OUT, 'vcf.bgz.tbi': REHEADERED_OUT + '.tbi'}
-    #     )
-    #     reheadered_vcf_in_batch = vcf_in_batch['vcf.bgz']
-    #
-    # # use compound-hets and labelled VCF to identify plausibly pathogenic
-    # # variants where the MOI is viable compared to the PanelApp expectation
-    # _results_job = handle_results_job(
-    #     batch=batch,
-    #     config=config_json,
-    #     comp_het=COMP_HET_JSON,
-    #     reheadered_vcf=reheadered_vcf_in_batch,
-    #     pedigree=pedigree,
-    #     prior_job=prior_job,
-    # )
+    # -------------------------------- #
+    # query panelapp for panel details #
+    # -------------------------------- #
+    # no need to launch in a separate batch, minimal dependencies
+    prior_job = handle_panelapp_job(
+        batch=batch,
+        gene_list=panel_genes,
+        prev_version=panelapp_version,
+        prior_job=prior_job,
+    )
+
+    # ----------------------- #
+    # run hail categorisation #
+    # ----------------------- #
+    # only run if the output VCF doesn't already exist
+    if not AnyPath(REHEADERED_OUT).exists():
+        logging.info(
+            f'The Reheadered VCF "{REHEADERED_OUT}" doesn\'t exist; regenerating'
+        )
+
+        if not AnyPath(HAIL_VCF_OUT).exists():
+            logging.info(
+                f'The Labelled VCF "{HAIL_VCF_OUT}" doesn\'t exist; regenerating'
+            )
+
+            prior_job = handle_hail_filtering(
+                batch=batch,
+                matrix_path=input_path,
+                config=config_json,
+                prior_job=prior_job,
+            )
+
+        # --------------------------------- #
+        # bcftools re-headering of hail VCF #
+        # --------------------------------- #
+        # copy the labelled output file into the remaining batch jobs
+        hail_output_in_batch = batch.read_input_group(
+            **{'vcf.bgz': HAIL_VCF_OUT, 'vcf.bgz.tbi': HAIL_VCF_OUT + '.tbi'}
+        )
+
+        # this is no longer explicitly required...
+        # it was required to run slivar: geneId, consequences, and transcript
+        # keeping in to ensure the VCF can be interpreted without the config
+        bcftools_job = handle_reheader_job(
+            batch=batch,
+            local_vcf=hail_output_in_batch['vcf.bgz'],
+            config_dict=config_dict,
+            prior_job=prior_job,
+        )
+        batch.write_output(bcftools_job.vcf, REHEADERED_PREFIX)
+        reheadered_vcf_in_batch = bcftools_job.vcf['vcf.bgz']
+
+    # if it exists remotely, read into a batch
+    else:
+        vcf_in_batch = batch.read_input_group(
+            **{'vcf.bgz': REHEADERED_OUT, 'vcf.bgz.tbi': REHEADERED_OUT + '.tbi'}
+        )
+        reheadered_vcf_in_batch = vcf_in_batch['vcf.bgz']
+
+    # use compound-hets and labelled VCF to identify plausibly pathogenic
+    # variants where the MOI is viable compared to the PanelApp expectation
+    _results_job = handle_results_job(
+        batch=batch,
+        config=config_json,
+        comp_het=COMP_HET_JSON,
+        reheadered_vcf=reheadered_vcf_in_batch,
+        pedigree=pedigree,
+        prior_job=prior_job,
+    )
     batch.run(wait=False)
 
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -197,6 +197,7 @@ def annotated_mt_from_ht_and_vcf(
         hail_billing_project=os.getenv('HAIL_BILLING_PROJECT'),
         hail_bucket=str(remote_tmpdir()),
         default_reference='GRCh38',
+        packages=['seqr-loader==1.2.5'],
     )
     apply_anno_job.command(cmd)
     return apply_anno_job

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -406,7 +406,7 @@ def main(
         name='run reanalysis (AIP)',
         backend=service_backend,
         cancel_after_n_failures=1,
-        default_timeout=3200,
+        default_timeout=6000,
     )
 
     # set a first job in this batch

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -133,6 +133,7 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
         f'--output {INPUT_AS_VCF}'
     )
     logging.info(f'Command used to convert MT: {job_cmd}')
+    copy_common_env(mt_to_vcf_job)
     mt_to_vcf_job.command(job_cmd)
     return mt_to_vcf_job
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -44,7 +44,7 @@ from cpg_utils.hail_batch import (
 )
 
 from vep.jobs import vep_jobs, SequencingType
-from reanalysis import annotation
+from . import annotation
 
 
 # static paths to write outputs

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -44,7 +44,7 @@ from cpg_utils.hail_batch import (
 )
 
 from vep.jobs import vep_jobs, SequencingType
-from . import annotation
+import annotation
 
 
 # static paths to write outputs

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -133,7 +133,7 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     newline = '##FILTER=<ID=PASS,Description="All filters passed">'
 
     job_cmd = (
-        f'echo {quote(newline)} > head_file.txt'
+        f'echo {quote(newline)} > head_file.txt; '
         f'PYTHONPATH=$(pwd) python3 {MT_TO_VCF_SCRIPT} '
         f'--input {input_file} '
         f'--output {INPUT_AS_VCF} '

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -186,7 +186,10 @@ def annotated_mt_from_ht_and_vcf(
     :return:
     """
     apply_anno_job = batch.new_job('HT + VCF = MT', job_attrs)
+
+    copy_common_env(apply_anno_job)
     apply_anno_job.image(os.getenv('CPG_DRIVER_IMAGE'))
+
     cmd = query_command(
         annotation,
         annotation.apply_annotations.__name__,

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -385,7 +385,7 @@ def main(
     :param pedigree:
     """
 
-    if not AnyPath(input_path.rstrip('/') + '/').exists():
+    if not AnyPath(input_path).exists():
         raise Exception(
             f'The provided path "{input_path}" does not exist or is inaccessible'
         )

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -406,6 +406,7 @@ def main(
         name='run reanalysis (AIP)',
         backend=service_backend,
         cancel_after_n_failures=1,
+        default_timeout=3200,
     )
 
     # set a first job in this batch

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -42,7 +42,7 @@ from cpg_utils.hail_batch import (
     remote_tmpdir,
 )
 
-from reanalysis.vep.jobs import vep_jobs, SequencingType
+from .vep.jobs import vep_jobs, SequencingType
 
 
 # static paths to write outputs

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -130,7 +130,7 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     """
     mt_to_vcf_job = batch.new_job(name='Convert MT to VCF')
     set_job_resources(mt_to_vcf_job, git=True, auth=True)
-    newline = '##FILTER=<ID=PASS,Description="All filters passed">'
+    newline = '##FILTER=<ID=VQSR,Description="VQSR triggered">'
 
     job_cmd = (
         f'echo {quote(newline)} > head_file.txt; '

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -254,6 +254,8 @@ def vqsr_reheader(
 
     reheader = batch.new_job(name='add_vqsr_into_header')
     set_job_resources(reheader, image=BCFTOOLS_IMAGE, prior_job=prior_job)
+    reheader.storage('50G')
+    reheader.memory('16G')
 
     reheader.declare_resource_group(
         vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
@@ -262,11 +264,11 @@ def vqsr_reheader(
     newline = '##FILTER=<ID=PASS,Description="All filters passed">'
 
     reheader.command(
-        'set -ex;'
-        f'bcftools view -h {vcf} | head -2 > hdr;'
-        f'echo {quote(newline)} >> hdr;'
-        f'bcftools view -h {vcf} | tail -3 >> hdr;'
-        f'bcftools reheader -h hdr --threads 4 -o {reheader.vcf["vcf.bgz"]} {vcf};'
+        'set -ex;  '
+        f'bcftools view -h {vcf} | head -2 > hdr; '
+        f'echo {quote(newline)} >> hdr; '
+        f'bcftools view -h {vcf} | tail -3 >> hdr; '
+        f'bcftools reheader -h hdr --threads 2 -o {reheader.vcf["vcf.bgz"]} {vcf}; '
         f'tabix {reheader.vcf["vcf.bgz"]}'
     )
     return reheader

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -133,11 +133,11 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     newline = '##FILTER=<ID=VQSR,Description="VQSR triggered">'
 
     job_cmd = (
-        f'echo {quote(newline)} > head_file.txt; '
+        f'echo {quote(newline)} > $(pwd)/head_file.txt; '
         f'PYTHONPATH=$(pwd) python3 {MT_TO_VCF_SCRIPT} '
         f'--input {input_file} '
         f'--output {INPUT_AS_VCF} '
-        f'--additional_header head_file.txt'
+        f'--additional_header $(pwd)/head_file.txt'
     )
     logging.info(f'Command used to convert MT: {job_cmd}')
     copy_common_env(mt_to_vcf_job)

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -130,13 +130,13 @@ def mt_to_vcf(batch: hb.Batch, input_file: str):
     set_job_resources(mt_to_vcf_job, git=True, auth=True)
 
     additional_header = 'gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt'
-    header = batch.read_input(path=additional_header)
+    # header = batch.read_input(path=additional_header)
 
     job_cmd = (
         f'PYTHONPATH=$(pwd) python3 {MT_TO_VCF_SCRIPT} '
         f'--input {input_file} '
         f'--output {INPUT_AS_VCF} '
-        f'--additional_header {header}'
+        f'--additional_header {additional_header}'
     )
     logging.info(f'Command used to convert MT: {job_cmd}')
     copy_common_env(mt_to_vcf_job)

--- a/reanalysis/mt_to_vcf.py
+++ b/reanalysis/mt_to_vcf.py
@@ -38,6 +38,9 @@ def main(input_mt: str, output_path: str, additional_header: Optional[str] = Non
             additional_header = None
             sys.exit()
 
+    with open(additional_header, encoding='utf-8') as handle:
+        print(handle.readlines())
+
     matrix = hl.read_matrix_table(input_mt)
 
     hl.export_vcf(

--- a/reanalysis/mt_to_vcf.py
+++ b/reanalysis/mt_to_vcf.py
@@ -14,8 +14,6 @@ within the VCF specification
 
 from typing import Optional
 from argparse import ArgumentParser
-import os
-import sys
 
 import hail as hl
 from cpg_utils.hail_batch import init_batch
@@ -31,15 +29,15 @@ def main(input_mt: str, output_path: str, additional_header: Optional[str] = Non
     """
     init_batch()
 
-    # check for existence, fail is specified and absent
-    if additional_header is not None:
-        if not os.path.exists(additional_header):
-            print(f'header file does not exist: {additional_header}')
-            additional_header = None
-            sys.exit()
-
-    with open(additional_header, encoding='utf-8') as handle:
-        print(handle.readlines())
+    # # check for existence, fail is specified and absent
+    # if additional_header is not None:
+    #     if not os.path.exists(additional_header):
+    #         print(f'header file does not exist: {additional_header}')
+    #         additional_header = None
+    #         sys.exit()
+    #
+    # with open(additional_header, encoding='utf-8') as handle:
+    #     print(handle.readlines())
 
     matrix = hl.read_matrix_table(input_mt)
 

--- a/reanalysis/mt_to_vcf.py
+++ b/reanalysis/mt_to_vcf.py
@@ -41,5 +41,12 @@ if __name__ == '__main__':
         help='input MatrixTable path',
     )
     parser.add_argument('--output', type=str, help='path to write VCF out to')
+    parser.add_argument(
+        '--additional_header',
+        type=str,
+        help='path to file containing any additional header lines',
+        required=False,
+        default=None,
+    )
     args = parser.parse_args()
     main(input_mt=args.input, output_path=args.output)

--- a/reanalysis/mt_to_vcf.py
+++ b/reanalysis/mt_to_vcf.py
@@ -29,16 +29,6 @@ def main(input_mt: str, output_path: str, additional_header: Optional[str] = Non
     """
     init_batch()
 
-    # # check for existence, fail is specified and absent
-    # if additional_header is not None:
-    #     if not os.path.exists(additional_header):
-    #         print(f'header file does not exist: {additional_header}')
-    #         additional_header = None
-    #         sys.exit()
-    #
-    # with open(additional_header, encoding='utf-8') as handle:
-    #     print(handle.readlines())
-
     matrix = hl.read_matrix_table(input_mt)
 
     hl.export_vcf(

--- a/reanalysis/mt_to_vcf.py
+++ b/reanalysis/mt_to_vcf.py
@@ -2,26 +2,33 @@
 takes an input file, works out the format, and
 """
 
-
+from typing import Optional
 from argparse import ArgumentParser
+import os
 import hail as hl
 from cpg_utils.hail_batch import init_batch
 
 
-def main(input_mt: str, output_path: str):
+def main(input_mt: str, output_path: str, additional_header: Optional[str] = None):
     """
     takes an input MT, and reads it out as a VCF
     :param input_mt:
     :param output_path:
+    :param additional_header: file containing lines to append to header
     :return:
     """
     init_batch()
+
+    # double check for existence, and set to None if not
+    if additional_header is None or not os.path.exists(additional_header):
+        additional_header = None
 
     matrix = hl.read_matrix_table(input_mt)
 
     hl.export_vcf(
         matrix,
         output_path,
+        append_to_header=additional_header,
         tabix=True,
     )
 

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -13,6 +13,8 @@ analysis-runner \
   --access-level test \
   reanalysis/interpretation_runner.py \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
-    --input_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
+    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/prior_to_annotation.vcf.bgz \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
     --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam
+
+# --input_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # set the date, or provide a default
-PAP_DATE=${1:-"2021-09-03"}
+PAP_DATE=${1:-"2011-11-11"}
 
 # run
 analysis-runner \
@@ -13,8 +13,7 @@ analysis-runner \
   --access-level test \
   reanalysis/interpretation_runner.py \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
-    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/prior_to_annotation.vcf.bgz \
+    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/hail_105_ac.mt/ \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
     --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam
-
-# --input_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
+#    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/prior_to_annotation.vcf.bgz \

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -13,6 +13,6 @@ analysis-runner \
   --access-level test \
   reanalysis/interpretation_runner.py \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
-    --matrix_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
+    --input_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
     --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -13,7 +13,8 @@ analysis-runner \
   --access-level test \
   reanalysis/interpretation_runner.py \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
-    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/hail_105_ac.mt/ \
+    --input_path gs://cpg-acute-care-test/reanalysis/2011-11-11/prior_to_annotation.vcf.bgz \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
     --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam
-#    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/prior_to_annotation.vcf.bgz \
+
+#    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/hail_105_ac.mt/ \

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -15,4 +15,4 @@ analysis-runner \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
     --matrix_path gs://cpg-acute-care-test/reanalysis/${PAP_DATE}/hail_105_ac.mt/ \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
-    --pedigree gs://cpg-acute-care-test/reanalysis/family_pedigree.ped
+    --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -1,0 +1,409 @@
+"""
+Hail Batch jobs to run VEP on a VCF in parallel.
+"""
+
+import logging
+import os
+from enum import Enum
+from typing import Literal, Optional, Union, Dict, Tuple, List
+
+from cloudpathlib import CloudPath
+
+import hailtop.batch as hb
+from hailtop.batch.job import Job
+from hailtop.batch import Batch
+
+from cpg_utils.hail_batch import (
+    image_path,
+    reference_path,
+    authenticate_cloud_credentials_in_job,
+    query_command,
+)
+
+from . import query
+
+logger = logging.getLogger(__file__)
+
+
+class SequencingType(Enum):
+    """
+    Type (scope) of a sequencing experiment.
+    """
+
+    GENOME = 'genome'
+    EXOME = 'exome'
+
+
+def vep_jobs(  # pylint: disable=too-many-arguments
+    b: Batch,
+    vcf_path: CloudPath,
+    hail_billing_project: str,
+    hail_bucket: CloudPath,
+    tmp_bucket: CloudPath,
+    out_path: Optional[CloudPath] = None,
+    overwrite: bool = False,
+    scatter_count: Optional[int] = 50,
+    sequencing_type: SequencingType = SequencingType.GENOME,
+    intervals_path: Optional[CloudPath] = None,
+    job_attrs: Optional[dict] = None,
+) -> List[Job]:
+    """
+    Runs VEP on provided VCF. Writes a VCF into `out_path` by default,
+    unless `out_path` ends with ".ht", in which case writes a Hail table.
+    """
+    to_hail_table = out_path and out_path.suffix == '.ht'
+    if not to_hail_table:
+        assert str(out_path).endswith('.vcf.gz'), out_path
+
+    if out_path and not overwrite and out_path.exists():
+        return [b.new_job('VEP [reuse]', job_attrs)]
+
+    jobs: List[Job] = []
+    intervals_j, intervals = get_intervals(
+        b=b,
+        cache_bucket=reference_path('intervals')
+        / sequencing_type.value
+        / f'{scatter_count}intervals',
+        sequencing_type=sequencing_type,
+        intervals_path=intervals_path,
+        scatter_count=scatter_count,
+    )
+    jobs.append(intervals_j)
+
+    vcf = b.read_input_group(
+        **{'vcf.gz': str(vcf_path), 'vcf.gz.tbi': str(vcf_path) + '.tbi'}
+    )
+
+    parts_bucket = tmp_bucket / 'vep' / 'parts'
+    part_files = []
+
+    # Splitting variant calling by intervals
+    for idx in range(scatter_count):
+        subset_j = subset_vcf(
+            b,
+            vcf=vcf,
+            interval=intervals[idx],
+            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
+        )
+        jobs.append(subset_j)
+        if to_hail_table:
+            part_path = parts_bucket / f'part{idx + 1}.json_list'
+        else:
+            part_path = None
+        # noinspection PyTypeChecker
+        j = vep_one(
+            b,
+            vcf=subset_j.output_vcf['vcf.gz'],
+            out_format='json' if to_hail_table else 'vcf',
+            out_path=part_path,
+            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
+            overwrite=overwrite,
+        )
+        jobs.append(j)
+        if to_hail_table:
+            part_files.append(part_path)
+        else:
+            part_files.append(j.output['vcf.gz'])
+
+    if to_hail_table:
+        gather_j = gather_vep_json_to_ht(
+            b=b,
+            vep_results_paths=part_files,
+            hail_billing_project=hail_billing_project,
+            hail_bucket=hail_bucket,
+            out_path=out_path,
+            job_attrs=job_attrs,
+        )
+    else:
+        assert len(part_files) == scatter_count
+        gather_j, _gather_vcf = gather_vcfs(
+            b=b,
+            input_vcfs=part_files,
+            out_vcf_path=out_path,
+        )
+    gather_j.depends_on(*jobs)
+    jobs.append(gather_j)
+    return jobs
+
+
+def get_intervals(
+    b: hb.Batch,
+    scatter_count: int,
+    intervals_path: Optional[CloudPath] = None,
+    cache_bucket: Optional[CloudPath] = None,
+    sequencing_type: SequencingType = SequencingType.GENOME,
+    job_attrs: dict | None = None,
+    samtools_image: str = 'picard_samtools:v0',
+) -> tuple[Job, list[hb.Resource]]:
+    """
+    Add a job that split genome into partitions for variant calling parallelisation.
+
+    Takes `intervals_path` if provided, otherwise calls `reference_path()`
+    for the intervals of provided `sequencing_type`.
+
+    Caches intervals for each partition into `cache_bucket`, if provided.
+
+    This job calls picard's IntervalListTools to scatter the input interval list
+    into scatter_count sub-interval lists, inspired by this WARP task :
+    https://github.com/broadinstitute/warp/blob
+    /bc90b0db0138747685b459c83ce52c8576ce03cd/tasks/broad/Utilities.wdl
+
+    Note that we use the mode INTERVAL_SUBDIVISION instead of
+    BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW. Modes other than
+    INTERVAL_SUBDIVISION produce an unpredicted number of intervals. WDL can handle
+    that, but Hail Batch is not dynamic and have to expect certain number of output
+    files.
+    """
+    job_attrs = (job_attrs or {}) | dict(tool='picard_IntervalListTools')
+    j = b.new_job(f'Make {scatter_count} intervals', job_attrs)
+
+    if cache_bucket:
+        # Checking previously cached split intervals.
+        if (cache_bucket / '1.interval_list').exists():
+            j.name += ' [use cached]'
+            return j, [
+                b.read_input(str(cache_bucket / f'{idx + 1}.interval_list'))
+                for idx in range(scatter_count)
+            ]
+
+    # Taking intervals file for the sequencing_type.
+    intervals_path = intervals_path or reference_path(
+        {
+            SequencingType.GENOME: 'hg38/v0/wgs_calling_regions.hg38.interval_list',
+            SequencingType.EXOME: 'hg38/v0/exome_calling_regions.v1.interval_list',
+        }[sequencing_type]
+    )
+
+    j.image(image_path(samtools_image))
+    j.cpu(4)
+
+    break_bands_at_multiples_of = {
+        SequencingType.GENOME: 100000,
+        SequencingType.EXOME: 0,
+    }.get(sequencing_type, 0)
+
+    cmd = f"""
+    mkdir /io/batch/out
+
+    picard -Xms1000m -Xmx1500m \
+    IntervalListTools \
+    SCATTER_COUNT={scatter_count} \
+    SUBDIVISION_MODE=INTERVAL_SUBDIVISION \
+    UNIQUE=true \
+    SORT=true \
+    BREAK_BANDS_AT_MULTIPLES_OF={break_bands_at_multiples_of} \
+    INPUT={b.read_input(str(intervals_path))} \
+    OUTPUT=/io/batch/out
+    ls /io/batch/out
+    ls /io/batch/out/*
+    """
+    for idx in range(scatter_count):
+        name = f'temp_{str(idx + 1).zfill(4)}_of_{scatter_count}'
+        cmd += f"""
+        ln /io/batch/out/{name}/scattered.interval_list {j[f'{idx + 1}.interval_list']}
+        """
+
+    j.command(cmd)
+    if cache_bucket:
+        for idx in range(scatter_count):
+            b.write_output(
+                j[f'{idx + 1}.interval_list'],
+                str(cache_bucket / f'{idx + 1}.interval_list'),
+            )
+    return j, [j[f'{idx + 1}.interval_list'] for idx in range(scatter_count)]
+
+
+def subset_vcf(
+    b: hb.Batch,
+    vcf: hb.ResourceGroup,
+    interval: hb.Resource,
+    job_attrs: Optional[Dict] = None,
+    output_vcf_path: Optional[CloudPath] = None,
+) -> Job:
+    """
+    Subset VCF to provided intervals.
+    """
+    job_name = 'Subset VCF'
+    j = b.new_job(job_name, job_attrs)
+    j.image(image_path('gatk:4.2.6.1'))
+    j.ncpu(2)
+
+    j.declare_resource_group(
+        output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
+    )
+    fasta_path = reference_path('hg38/v0/Homo_sapiens_assembly38.fasta')
+    fasta_resource = b.read_input_group(
+        **{
+            'base': str(fasta_path),
+            'fai': str(fasta_path) + '.fai',
+            'dict': str(fasta_path.with_suffix('.dict')),
+        }
+    )
+
+    cmd = f"""
+    gatk SelectVariants \\
+    -R {fasta_resource.base} \\
+    -V {vcf['vcf.gz']} \\
+    -L {interval} \\
+    -O {j.output_vcf['vcf.gz']}
+    """
+    j.command(cmd)
+    if output_vcf_path:
+        b.write_output(j.output_vcf, str(output_vcf_path).replace('.vcf.gz', ''))
+    return j
+
+
+def gather_vcfs(
+    b: hb.Batch,
+    input_vcfs: List[hb.ResourceFile],
+    overwrite: bool = True,
+    out_vcf_path: Optional[CloudPath] = None,
+    site_only: bool = False,
+    gvcf_count: Optional[int] = None,
+    job_attrs: Optional[dict] = None,
+) -> Tuple[Job, hb.ResourceGroup]:
+    """
+    Combines per-interval scattered VCFs into a single VCF.
+    Saves the output VCF to a bucket `output_vcf_path`
+    """
+    job_name = f'Gather {len(input_vcfs)} {"site-only " if site_only else ""}VCFs'
+    j = b.new_job(job_name, job_attrs)
+    j.image(image_path('gatk:4.2.6.1'))
+    if out_vcf_path and out_vcf_path.exists() and not overwrite:
+        j.name += ' [reuse]'
+        return j, b.read_input_group(
+            **{
+                'vcf.gz': str(out_vcf_path),
+                'vcf.gz.tbi': f'{out_vcf_path}.tbi',
+            }
+        )
+
+    j.ncpu(16)
+    if gvcf_count:
+        j.storage((1 if site_only else 2) * gvcf_count)
+
+    j.declare_resource_group(
+        output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
+    )
+
+    input_cmdl = ' '.join([f'--input {v}' for v in input_vcfs])
+    cmd = f"""
+    # --ignore-safety-checks makes a big performance difference so we include it in
+    # our invocation. This argument disables expensive checks that the file headers
+    # contain the same set of genotyped samples and that files are in order
+    # by position of first record.
+    gatk --java-options -Xms25g \\
+    GatherVcfsCloud \\
+    --ignore-safety-checks \\
+    --gather-type BLOCK \\
+    {input_cmdl} \\
+    --output {j.output_vcf['vcf.gz']}
+
+    tabix {j.output_vcf['vcf.gz']}
+    """
+    j.command(cmd)
+    if out_vcf_path:
+        b.write_output(j.output_vcf, str(out_vcf_path).replace('.vcf.gz', ''))
+    return j, j.output_vcf
+
+
+def gather_vep_json_to_ht(
+    b: Batch,
+    vep_results_paths: list[CloudPath],
+    hail_billing_project: str,
+    hail_bucket: CloudPath,
+    out_path: CloudPath,
+    job_attrs: Optional[dict] = None,
+):
+    """
+    Parse results from VEP with annotations formatted in JSON,
+    and write into a Hail Table using a Batch job.
+    """
+    j = b.new_job('VEP json to Hail table', job_attrs)
+    j.image(os.getenv('CPG_DRIVER_IMAGE'))
+    cmd = query_command(
+        query,
+        query.vep_json_to_ht.__name__,
+        [str(p) for p in vep_results_paths],
+        str(out_path),
+        setup_gcp=True,
+        hail_billing_project=hail_billing_project,
+        hail_bucket=str(hail_bucket),
+        default_reference='hg38',
+    )
+    j.command(cmd)
+    return j
+
+
+def vep_one(
+    b: Batch,
+    vcf: Union[CloudPath, hb.Resource],
+    out_path: Optional[CloudPath, None] = None,
+    out_format: Literal['vcf', 'json'] = 'vcf',
+    job_attrs: Optional[Dict] = None,
+    overwrite: bool = False,
+) -> Job:
+    """
+    Run a single VEP job.
+    """
+    j = b.new_job('VEP', job_attrs)
+    if out_path and out_path.exists() and not overwrite:
+        j.name += ' [reuse]'
+        return j
+
+    j.image(image_path('vep:105'))
+    j.storage('50G')
+    j.ncpu(16)
+
+    if not isinstance(vcf, hb.Resource):
+        vcf = b.read_input(str(vcf))
+
+    if out_format == 'vcf':
+        j.declare_resource_group(
+            output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
+        )
+        output = j.output['vcf.gz']
+    else:
+        output = j.output
+
+    # gcsfuse works only with the root bucket, without prefix:
+    base_bucket_name = reference_path('vep/GRCh38').drive
+    data_mount = f'/{base_bucket_name}'
+    j.cloudfuse(base_bucket_name, str(data_mount))
+    vep_dir = f'{data_mount}/vep/GRCh38'
+    loftee_conf = {
+        'loftee_path': '$LOFTEE_PLUGIN_PATH',
+        'gerp_bigwig': f'{vep_dir}/gerp_conservation_scores.homo_sapiens.GRCh38.bw',
+        'human_ancestor_fa': f'{vep_dir}/human_ancestor.fa.gz',
+        'conservation_file': f'{vep_dir}/loftee.sql',
+    }
+
+    cmd = f"""\
+    ls {vep_dir}
+    ls {vep_dir}/vep
+
+    LOFTEE_PLUGIN_PATH=/root/micromamba/share/ensembl-vep-105.0-1
+    FASTA={vep_dir}/vep/homo_sapiens/105_GRCh38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
+
+    vep \\
+    --format vcf \\
+    --{out_format} {'--compress_output bgzip' if out_format == 'vcf' else ''} \\
+    -o {output} \\
+    -i {vcf} \\
+    --everything \\
+    --allele_number \\
+    --minimal \\
+    --cache --offline --assembly GRCh38 \\
+    --dir_cache {vep_dir}/vep/ \\
+    --dir_plugins $LOFTEE_PLUGIN_PATH \\
+    --fasta $FASTA \\
+    --plugin LoF,{','.join(f'{k}:{v}' for k, v in loftee_conf.items())}
+    """
+    if out_format == 'vcf':
+        cmd += f'tabix -p vcf {output}'
+
+    authenticate_cloud_credentials_in_job(j)
+    j.command(cmd)
+    if out_path:
+        b.write_output(j.output, str(out_path).replace('.vcf.gz', ''))
+    return j

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -83,7 +83,7 @@ def vep_jobs(  # pylint: disable=too-many-arguments
             b,
             vcf=vcf,
             interval=intervals[idx],
-            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
+            job_attrs=job_attrs or dict(part=f'{idx + 1}/{scatter_count}'),
         )
         jobs.append(subset_j)
         if to_hail_table:
@@ -96,7 +96,7 @@ def vep_jobs(  # pylint: disable=too-many-arguments
             vcf=subset_j.output_vcf['vcf.gz'],
             out_format='json' if to_hail_table else 'vcf',
             out_path=part_path,
-            job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
+            job_attrs=job_attrs or dict(part=f'{idx + 1}/{scatter_count}'),
             overwrite=overwrite,
         )
         jobs.append(j)
@@ -154,7 +154,7 @@ def get_intervals(
     that, but Hail Batch is not dynamic and have to expect certain number of output
     files.
     """
-    job_attrs = (job_attrs or {}) | dict(tool='picard_IntervalListTools')
+    job_attrs = job_attrs or dict(tool='picard_IntervalListTools')
     j = b.new_job(f'Make {scatter_count} intervals', job_attrs)
 
     if cache_bucket:

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -226,7 +226,7 @@ def subset_vcf(
     job_name = 'Subset VCF'
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk:4.2.6.1'))
-    j.ncpu(2)
+    j.cpu(2)
 
     j.declare_resource_group(
         output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
@@ -278,7 +278,7 @@ def gather_vcfs(
             }
         )
 
-    j.ncpu(16)
+    j.cpu(16)
     if gvcf_count:
         j.storage((1 if site_only else 2) * gvcf_count)
 
@@ -353,7 +353,7 @@ def vep_one(
 
     j.image(image_path('vep:105'))
     j.storage('50G')
-    j.ncpu(16)
+    j.cpu(16)
 
     if not isinstance(vcf, hb.Resource):
         vcf = b.read_input(str(vcf))

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -5,7 +5,6 @@ Hail Batch jobs to run VEP on a VCF in parallel.
 import logging
 import os
 from enum import Enum
-from random import randint
 from typing import Literal, Optional, Union, Dict, Tuple, List
 
 from cloudpathlib import CloudPath
@@ -420,8 +419,6 @@ def vep_one(
     """
     if out_format == 'vcf':
         cmd += f'tabix -p vcf {output} '
-
-    cmd += f'sleep{randint(15, 150)}'
 
     j.command(cmd)
     if out_path:

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -396,6 +396,7 @@ def vep_one(
         'conservation_file': f'{vep_dir}/loftee.sql',
     }
 
+    authenticate_cloud_credentials_in_job(j)
     cmd = f"""\
     ls {vep_dir}
     ls {vep_dir}/vep
@@ -420,9 +421,8 @@ def vep_one(
     if out_format == 'vcf':
         cmd += f'tabix -p vcf {output}'
 
-    cmd += f'; sleep{randint(15, 150)}'
+    cmd += f' && sleep{randint(15, 150)}'
 
-    authenticate_cloud_credentials_in_job(j)
     j.command(cmd)
     if out_path:
         b.write_output(j.output, str(out_path).replace('.vcf.gz', ''))

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -5,6 +5,7 @@ Hail Batch jobs to run VEP on a VCF in parallel.
 import logging
 import os
 from enum import Enum
+from random import randint
 from typing import Literal, Optional, Union, Dict, Tuple, List
 
 from cloudpathlib import CloudPath
@@ -418,6 +419,8 @@ def vep_one(
     """
     if out_format == 'vcf':
         cmd += f'tabix -p vcf {output}'
+
+    cmd += f'; sleep{randint(15, 150)}'
 
     authenticate_cloud_credentials_in_job(j)
     j.command(cmd)

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -357,7 +357,6 @@ def gather_vep_json_to_ht(
         setup_gcp=True,
         hail_billing_project=hail_billing_project,
         hail_bucket=str(hail_bucket),
-        default_reference='GRCh38',
     )
     j.command(cmd)
     return j

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -239,9 +239,10 @@ def subset_vcf(
     output_vcf_path: Optional[CloudPath] = None,
 ) -> Job:
     """
-    Subset VCF to provided intervals.
+    Subset VCF to provided intervals, and drop sample/genotype
+    information (e.g. outputs sites-only VCF).
     """
-    job_name = 'Subset VCF'
+    job_name = 'VEP: subset VCF'
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk:4.2.6.1'))
     j.memory('16Gi')
@@ -265,7 +266,12 @@ def subset_vcf(
     -R {fasta_resource.base} \\
     -V {vcf['vcf.gz']} \\
     -L {interval} \\
-    -O {j.output_vcf['vcf.gz']}
+    -O /io/batch/tmp.vcf.gz
+
+    gatk MakeSitesOnlyVcf \\
+    -I /io/batch/tmp.vcf.gz \\
+    -O {j.output_vcf['vcf.gz']} \\
+    --CREATE_INDEX
     """
     j.command(cmd)
     if output_vcf_path:

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -338,7 +338,7 @@ def gather_vep_json_to_ht(
 def vep_one(
     b: Batch,
     vcf: Union[CloudPath, hb.Resource],
-    out_path: Optional[CloudPath, None] = None,
+    out_path: Optional[CloudPath] = None,
     out_format: Literal['vcf', 'json'] = 'vcf',
     job_attrs: Optional[Dict] = None,
     overwrite: bool = False,

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -175,6 +175,7 @@ def get_intervals(
     )
 
     j.image(image_path(samtools_image))
+    j.memory('12Gi')
     j.cpu(4)
 
     break_bands_at_multiples_of = {

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -175,7 +175,7 @@ def get_intervals(
     )
 
     j.image(image_path(samtools_image))
-    j.memory('12Gi')
+    j.memory('16Gi')
     j.cpu(4)
 
     break_bands_at_multiples_of = {
@@ -227,6 +227,7 @@ def subset_vcf(
     job_name = 'Subset VCF'
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk:4.2.6.1'))
+    j.memory('16Gi')
     j.cpu(2)
 
     j.declare_resource_group(
@@ -279,6 +280,7 @@ def gather_vcfs(
             }
         )
 
+    j.memory('16Gi')
     j.cpu(16)
     if gvcf_count:
         j.storage((1 if site_only else 2) * gvcf_count)

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -419,9 +419,9 @@ def vep_one(
     --plugin LoF,{','.join(f'{k}:{v}' for k, v in loftee_conf.items())}
     """
     if out_format == 'vcf':
-        cmd += f'tabix -p vcf {output}'
+        cmd += f'tabix -p vcf {output} '
 
-    cmd += f' && sleep{randint(15, 150)}'
+    cmd += f'sleep{randint(15, 150)}'
 
     j.command(cmd)
     if out_path:

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -134,7 +134,7 @@ def get_intervals(
     sequencing_type: SequencingType = SequencingType.GENOME,
     job_attrs: Optional[dict] = None,
     samtools_image: str = 'picard_samtools:v0',
-) -> tuple[Job, list[hb.Resource]]:
+) -> Tuple[Job, List[hb.Resource]]:
     """
     Add a job that split genome into partitions for variant calling parallelisation.
 
@@ -309,7 +309,7 @@ def gather_vcfs(
 
 def gather_vep_json_to_ht(
     b: Batch,
-    vep_results_paths: list[CloudPath],
+    vep_results_paths: List[CloudPath],
     hail_billing_project: str,
     hail_bucket: CloudPath,
     out_path: CloudPath,

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -176,6 +176,7 @@ def get_intervals(
 
     j.image(image_path(samtools_image))
     j.memory('16Gi')
+    j.storage('50G')
     j.cpu(4)
 
     break_bands_at_multiples_of = {
@@ -228,6 +229,7 @@ def subset_vcf(
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk:4.2.6.1'))
     j.memory('16Gi')
+    j.storage('50G')
     j.cpu(2)
 
     j.declare_resource_group(
@@ -281,6 +283,7 @@ def gather_vcfs(
         )
 
     j.memory('16Gi')
+    j.storage('50G')
     j.cpu(16)
     if gvcf_count:
         j.storage((1 if site_only else 2) * gvcf_count)

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -132,7 +132,7 @@ def get_intervals(
     intervals_path: Optional[CloudPath] = None,
     cache_bucket: Optional[CloudPath] = None,
     sequencing_type: SequencingType = SequencingType.GENOME,
-    job_attrs: dict | None = None,
+    job_attrs: Optional[dict] = None,
     samtools_image: str = 'picard_samtools:v0',
 ) -> tuple[Job, list[hb.Resource]]:
     """

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -346,7 +346,7 @@ def gather_vep_json_to_ht(
         setup_gcp=True,
         hail_billing_project=hail_billing_project,
         hail_bucket=str(hail_bucket),
-        default_reference='hg38',
+        default_reference='GRCh38',
     )
     j.command(cmd)
     return j

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -117,6 +117,11 @@ def vep_jobs(  # pylint: disable=too-many-arguments
             part_files.append(j.output['vcf.gz'])
 
     if to_hail_table:
+
+        # if already generated, don't regen
+        if out_path and CloudPath(out_path).exists() and not overwrite:
+            return jobs
+
         gather_j = gather_vep_json_to_ht(
             b=b,
             vep_results_paths=part_files,

--- a/reanalysis/vep/jobs.py
+++ b/reanalysis/vep/jobs.py
@@ -88,7 +88,10 @@ def vep_jobs(  # pylint: disable=too-many-arguments
 
         # here we assume that if the eventual path exists, the subset and
         # annotation were both done and can be re-used
+        # the subset-vcf is not persisted, so we can skip either both jobs,
+        # or neither
         if part_path and part_path.exists() and not overwrite:
+            part_files.append(part_path)
             continue
 
         subset_j = subset_vcf(

--- a/reanalysis/vep/query.py
+++ b/reanalysis/vep/query.py
@@ -75,9 +75,7 @@ def vep_json_to_ht(vep_results_paths, out_path):
         json_schema = json_schema.replace(k, v)
 
     schema = hl.dtype(json_schema)
-    ht = hl.import_table(
-        vep_results_paths, no_header=True, types={'f0': schema}
-    )
+    ht = hl.import_table(vep_results_paths, no_header=True, types={'f0': schema})
     ht = ht.transmute(vep=ht.f0)
     # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it
     # happens for indels). So instead parsing POS from the original VCF line stored

--- a/reanalysis/vep/query.py
+++ b/reanalysis/vep/query.py
@@ -12,69 +12,42 @@ def vep_json_to_ht(vep_results_paths, out_path):
     """
     # Defining schema inside the function, so we can submit
     # the function to the Batch Job:
-    json_schema = (
-        'Struct{assembly_name:String,allele_string:String,ancestral:String,'
-        'colocated_variants:Array[Struct{aa_allele:String,aa_maf:Float64,'
-        'afr_allele:String,afr_maf:Float64,allele_string:String,'
-        'amr_allele:String,amr_maf:Float64,clin_sig:Array[String],'
-        'end:Int32,eas_allele:String,eas_maf:Float64,ea_allele:String,'
-        'ea_maf:Float64,eur_allele:String,eur_maf:Float64,'
-        'exac_adj_allele:String,exac_adj_maf:Float64,exac_allele:String,'
-        'exac_afr_allele:String,exac_afr_maf:Float64,'
-        'exac_amr_allele:String,exac_amr_maf:Float64,'
-        'exac_eas_allele:String,exac_eas_maf:Float64,'
-        'exac_fin_allele:String,exac_fin_maf:Float64,exac_maf:Float64,'
-        'exac_nfe_allele:String,exac_nfe_maf:Float64,'
-        'exac_oth_allele:String,exac_oth_maf:Float64,'
-        'exac_sas_allele:String,exac_sas_maf:Float64,id:String,'
-        'minor_allele:String,minor_allele_freq:Float64,'
-        'phenotype_or_disease:Int32,pubmed:Array[Int32],sas_allele:String,'
-        'sas_maf:Float64,somatic:Int32,start:Int32,strand:Int32}],'
-        'context:String,end:Int32,id:String,input:String,'
-        'intergenic_consequences:Array[Struct{allele_num:Int32,'
-        'consequence_terms:Array[String],impact:String,minimised:Int32,'
-        'variant_allele:String}],most_severe_consequence:String,'
-        'motif_feature_consequences:Array[Struct{allele_num:Int32,'
-        'consequence_terms:Array[String],high_inf_pos:String,impact:String,'
-        'minimised:Int32,motif_feature_id:String,motif_name:String,'
-        'motif_pos:Int32,motif_score_change:Float64,strand:Int32,'
-        'variant_allele:String}],regulatory_feature_consequences:Array['
-        'Struct{allele_num:Int32,biotype:String,consequence_terms:Array['
-        'String],impact:String,minimised:Int32,'
-        'regulatory_feature_id:String,variant_allele:String}],'
-        'seq_region_name:String,start:Int32,strand:Int32,'
-        'transcript_consequences:Array[Struct{allele_num:Int32,'
-        'amino_acids:String,appris:String,biotype:String,canonical:Int32,'
-        'mane_select:String,mane_plus_clinical:String,ccds:String,'
-        'cdna_start:Int32,cdna_end:Int32,cds_end:Int32,cds_start:Int32,'
-        'codons:String,consequence_terms:Array[String],distance:Int32,'
-        'domains:Array[Struct{db:String,name:String}],exon:String,'
-        'gene_id:String,gene_pheno:Int32,gene_symbol:String,'
-        'gene_symbol_source:String,hgnc_id:String,hgvsc:String,'
-        'hgvsp:String,hgvs_offset:Int32,impact:String,intron:String,'
-        'lof:String,lof_flags:String,lof_filter:String,lof_info:String,'
-        'minimised:Int32,polyphen_prediction:String,polyphen_score:Float64,'
-        'protein_end:Int32,protein_start:Int32,protein_id:String,'
-        'sift_prediction:String,sift_score:Float64,strand:Int32,'
-        'swissprot:String,transcript_id:String,trembl:String,tsl:Int32,'
-        'uniparc:String,variant_allele:String}],variant_class:String}'
+    schema = hl.dtype(
+        'struct{assembly_name:str,allele_string:str,ancestral:str,'
+        'colocated_variants:array<struct{aa_allele:str,aa_maf:float64,'
+        'afr_allele:str,afr_maf:float64,allele_string:str,amr_allele:str,'
+        'amr_maf:float64,clin_sig:array<str>,end:int32,eas_allele:str,'
+        'eas_maf:float64,ea_allele:str,ea_maf:float64,eur_allele:str,'
+        'eur_maf:float64,exac_adj_allele:str,exac_adj_maf:float64,'
+        'exac_allele:str,exac_afr_allele:str,exac_afr_maf:float64,'
+        'exac_amr_allele:str,exac_amr_maf:float64,exac_eas_allele:str,'
+        'exac_eas_maf:float64,exac_fin_allele:str,exac_fin_maf:float64,'
+        'exac_maf:float64,exac_nfe_allele:str,exac_nfe_maf:float64,'
+        'exac_oth_allele:str,exac_oth_maf:float64,exac_sas_allele:str,'
+        'exac_sas_maf:float64,id:str,minor_allele:str,minor_allele_freq:float64,'
+        'phenotype_or_disease:int32,pubmed:array<int32>,sas_allele:str,'
+        'sas_maf:float64,somatic:int32,start:int32,strand:int32}>,context:str,'
+        'end:int32,id:str,input:str,intergenic_consequences:array<struct{'
+        'allele_num:int32,consequence_terms:array<str>,impact:str,minimised:int32,'
+        'variant_allele:str}>,most_severe_consequence:str,motif_feature_consequences'
+        ':array<struct{allele_num:int32,consequence_terms:array<str>,high_inf_pos:str,'
+        'impact:str,minimised:int32,motif_feature_id:str,motif_name:str,motif_pos:'
+        'int32,motif_score_change:float64,strand:int32,variant_allele:str}>,'
+        'regulatory_feature_consequences:array<struct{allele_num:int32,biotype:str,'
+        'consequence_terms:array<str>,impact:str,minimised:int32,regulatory_feature_id:'
+        'str,variant_allele:str}>,seq_region_name:str,start:int32,strand:int32,'
+        'transcript_consequences:array<struct{allele_num:int32,amino_acids:str,'
+        'appris:str,biotype:str,canonical:int32,mane_select:str,mane_plus_clinical:str,'
+        'ccds:str,cdna_start:int32,cdna_end:int32,cds_end:int32,cds_start:int32,codons:'
+        'str,consequence_terms:array<str>,distance:int32,domains:array<struct{db:str,'
+        'name:str}>,exon:str,gene_id:str,gene_pheno:int32,gene_symbol:str,'
+        'gene_symbol_source:str,hgnc_id:str,hgvsc:str,hgvsp:str,hgvs_offset:int32,'
+        'impact:str,intron:str,lof:str,lof_flags:str,lof_filter:str,lof_info:str,'
+        'minimised:int32,polyphen_prediction:str,polyphen_score:float64,protein_end:'
+        'int32,protein_start:int32,protein_id:str,sift_prediction:str,sift_score:'
+        'float64,strand:int32,swissprot:str,transcript_id:str,trembl:str,tsl:int32,'
+        'uniparc:str,variant_allele:str}>,variant_class:str}'
     )
-    for k, v in [
-        ('String', 'str'),
-        ('Array', 'array'),
-        ('Set', 'set'),
-        ('Tuple', 'tuple'),
-        ('Struct', 'struct'),
-        ('[', '<'),
-        (']', '>'),
-        ('Int32', 'int32'),
-        ('Int64', 'int64'),
-        ('Float64', 'float64'),
-        ('Float32', 'float32'),
-    ]:
-        json_schema = json_schema.replace(k, v)
-
-    schema = hl.dtype(json_schema)
     ht = hl.import_table(vep_results_paths, no_header=True, types={'f0': schema})
     ht = ht.transmute(vep=ht.f0)
     # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it

--- a/reanalysis/vep/query.py
+++ b/reanalysis/vep/query.py
@@ -1,0 +1,90 @@
+"""
+Hail Query function to parse JSON VEP results.
+"""
+
+import hail as hl
+
+
+def vep_json_to_ht(vep_results_paths, out_path):
+    """
+    Parse results from VEP with annotations formatted in JSON,
+    and write into a Hail Table.
+    """
+    # Defining schema inside the function, so we can submit
+    # the function to the Batch Job:
+    json_schema = (
+        'Struct{assembly_name:String,allele_string:String,ancestral:String,'
+        'colocated_variants:Array[Struct{aa_allele:String,aa_maf:Float64,'
+        'afr_allele:String,afr_maf:Float64,allele_string:String,'
+        'amr_allele:String,amr_maf:Float64,clin_sig:Array[String],'
+        'end:Int32,eas_allele:String,eas_maf:Float64,ea_allele:String,'
+        'ea_maf:Float64,eur_allele:String,eur_maf:Float64,'
+        'exac_adj_allele:String,exac_adj_maf:Float64,exac_allele:String,'
+        'exac_afr_allele:String,exac_afr_maf:Float64,'
+        'exac_amr_allele:String,exac_amr_maf:Float64,'
+        'exac_eas_allele:String,exac_eas_maf:Float64,'
+        'exac_fin_allele:String,exac_fin_maf:Float64,exac_maf:Float64,'
+        'exac_nfe_allele:String,exac_nfe_maf:Float64,'
+        'exac_oth_allele:String,exac_oth_maf:Float64,'
+        'exac_sas_allele:String,exac_sas_maf:Float64,id:String,'
+        'minor_allele:String,minor_allele_freq:Float64,'
+        'phenotype_or_disease:Int32,pubmed:Array[Int32],sas_allele:String,'
+        'sas_maf:Float64,somatic:Int32,start:Int32,strand:Int32}],'
+        'context:String,end:Int32,id:String,input:String,'
+        'intergenic_consequences:Array[Struct{allele_num:Int32,'
+        'consequence_terms:Array[String],impact:String,minimised:Int32,'
+        'variant_allele:String}],most_severe_consequence:String,'
+        'motif_feature_consequences:Array[Struct{allele_num:Int32,'
+        'consequence_terms:Array[String],high_inf_pos:String,impact:String,'
+        'minimised:Int32,motif_feature_id:String,motif_name:String,'
+        'motif_pos:Int32,motif_score_change:Float64,strand:Int32,'
+        'variant_allele:String}],regulatory_feature_consequences:Array['
+        'Struct{allele_num:Int32,biotype:String,consequence_terms:Array['
+        'String],impact:String,minimised:Int32,'
+        'regulatory_feature_id:String,variant_allele:String}],'
+        'seq_region_name:String,start:Int32,strand:Int32,'
+        'transcript_consequences:Array[Struct{allele_num:Int32,'
+        'amino_acids:String,appris:String,biotype:String,canonical:Int32,'
+        'mane_select:String,mane_plus_clinical:String,ccds:String,'
+        'cdna_start:Int32,cdna_end:Int32,cds_end:Int32,cds_start:Int32,'
+        'codons:String,consequence_terms:Array[String],distance:Int32,'
+        'domains:Array[Struct{db:String,name:String}],exon:String,'
+        'gene_id:String,gene_pheno:Int32,gene_symbol:String,'
+        'gene_symbol_source:String,hgnc_id:String,hgvsc:String,'
+        'hgvsp:String,hgvs_offset:Int32,impact:String,intron:String,'
+        'lof:String,lof_flags:String,lof_filter:String,lof_info:String,'
+        'minimised:Int32,polyphen_prediction:String,polyphen_score:Float64,'
+        'protein_end:Int32,protein_start:Int32,protein_id:String,'
+        'sift_prediction:String,sift_score:Float64,strand:Int32,'
+        'swissprot:String,transcript_id:String,trembl:String,tsl:Int32,'
+        'uniparc:String,variant_allele:String}],variant_class:String}'
+    )
+    for k, v in [
+        ('String', 'str'),
+        ('Array', 'array'),
+        ('Set', 'set'),
+        ('Tuple', 'tuple'),
+        ('Struct', 'struct'),
+        ('[', '<'),
+        (']', '>'),
+        ('Int32', 'int32'),
+        ('Int64', 'int64'),
+        ('Float64', 'float64'),
+        ('Float32', 'float32'),
+    ]:
+        json_schema = json_schema.replace(k, v)
+
+    schema = hl.dtype(json_schema)
+    ht = hl.import_table(
+        vep_results_paths, no_header=True, types={'f0': schema}
+    )
+    ht = ht.transmute(vep=ht.f0)
+    # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it
+    # happens for indels). So instead parsing POS from the original VCF line stored
+    # as ht.vep.input field.
+    original_vcf_line = ht.vep.input
+    start = hl.parse_int(original_vcf_line.split('\t')[1])
+    chrom = ht.vep.seq_region_name
+    ht = ht.annotate(locus=hl.locus(chrom, start))
+    ht = ht.key_by(ht.locus)
+    ht.write(str(out_path), overwrite=True)

--- a/reanalysis/vep/query.py
+++ b/reanalysis/vep/query.py
@@ -85,4 +85,8 @@ def vep_json_to_ht(vep_results_paths, out_path):
     chrom = ht.vep.seq_region_name
     ht = ht.annotate(locus=hl.locus(chrom, start))
     ht = ht.key_by(ht.locus)
+
+    # drop the huge input field?
+    ht = ht.drop(ht.vep.input)
+
     ht.write(str(out_path), overwrite=True)

--- a/reanalysis/vep/query.py
+++ b/reanalysis/vep/query.py
@@ -86,7 +86,4 @@ def vep_json_to_ht(vep_results_paths, out_path):
     ht = ht.annotate(locus=hl.locus(chrom, start))
     ht = ht.key_by(ht.locus)
 
-    # drop the huge input field?
-    ht = ht.drop(ht.vep.input)
-
     ht.write(str(out_path), overwrite=True)

--- a/reanalysis/vep/transform_schema.py
+++ b/reanalysis/vep/transform_schema.py
@@ -1,0 +1,29 @@
+"""
+extracting out method for altering schema, for future use
+"""
+
+
+def transform_schema(json_schema: str):
+    """
+    example input format:
+        'Struct{assembly_name:String,allele_string:String...'
+    example output format:
+        'struct{assembly_name:str,allele_string:str...'
+    :param json_schema:
+    :return:
+    """
+    for k, v in [
+        ('String', 'str'),
+        ('Array', 'array'),
+        ('Set', 'set'),
+        ('Tuple', 'tuple'),
+        ('Struct', 'struct'),
+        ('[', '<'),
+        (']', '>'),
+        ('Int32', 'int32'),
+        ('Int64', 'int64'),
+        ('Float64', 'float64'),
+        ('Float32', 'float32'),
+    ]:
+        json_schema = json_schema.replace(k, v)
+    return json_schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.0.4
 cloudpathlib[azure,gs]==0.7.0
-cpg-utils==4.0.0
+cpg-utils==4.0.1
 cyvcf2==0.30.14
 dill==0.3.4
 hail==0.2.93

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 click==8.0.4
 cloudpathlib[azure,gs]==0.7.0
-cpg-pipes==0.3.0
 cpg-utils==4.0.0
 cyvcf2==0.30.14
 dill==0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.0.4
 cloudpathlib[azure,gs]==0.7.0
-cpg-utils==4.0.1
+cpg-utils==4.1.0
 cyvcf2==0.30.14
 dill==0.3.4
 hail==0.2.93

--- a/test/test_apply_annotations.py
+++ b/test/test_apply_annotations.py
@@ -1,0 +1,45 @@
+import string
+import time
+from random import choices
+import hail as hl
+
+from reanalysis.annotation import apply_annotations
+
+
+def timestamp():
+    """
+    Generate a timestamp plus a short random string for guaranteed uniqueness.
+    """
+    rand_bit = ''.join(choices(string.ascii_uppercase + string.digits, k=3))
+    return time.strftime('%Y-%m%d-%H%M') + rand_bit
+
+
+TMP_BUCKET = (
+    f'gs://cpg-fewgenomes-test/unittest/tmp/test_apply_annotations/{timestamp()}'
+)
+
+
+def test_apply_annotations(self):
+    """
+    Test annotation.apply_annotations: convert VCF to a MatrixTable,
+    and add VEP and other annotations.
+    """
+    vcf_path = (
+        f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/'
+        f'joint-called-{self.interval}.vcf.gz'
+    )
+    vep_ht_path = (
+        f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/vep/{self.interval}.ht'
+    )
+    out_mt_path = f'{TMP_BUCKET}/cohort-{self.interval}.mt'
+    apply_annotations(
+        vcf_path=vcf_path,
+        vep_ht_path=vep_ht_path,
+        out_mt_path=str(out_mt_path),
+        checkpoints_bucket=f'{TMP_BUCKET}/checkpoints',
+    )
+    # Testing
+    mt = hl.read_matrix_table(str(out_mt_path))
+    mt.rows().show()
+    self.assertListEqual(mt.topmed.AC.collect(), [20555, 359, 20187])
+    self.assertSetEqual(set(mt.geneIds.collect()[0]), {'ENSG00000089063'})

--- a/test/test_apply_annotations.py
+++ b/test/test_apply_annotations.py
@@ -1,13 +1,21 @@
 """
 tests for the annotation module
+
+pytest in GitHub can't read the GS paths - needs local data
+or mocking?
 """
 
 
 import string
 import time
+import os
 from random import choices
 import hail as hl
 from reanalysis.annotation import apply_annotations
+
+
+PWD = os.path.dirname(__file__)
+INPUT = os.path.join(PWD, 'input')
 
 
 def timestamp():
@@ -34,13 +42,17 @@ def test_apply_annotations(monkeypatch):
         f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/'
         f'joint-called-{INTERVAL}.vcf.gz'
     )
-    vep_ht_path = f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/vep/{INTERVAL}.ht'
+    vep_ht_path = (
+        f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/vep/chr20-5111495-5111607.ht'
+    )
     out_mt_path = f'{TMP_BUCKET}/cohort-{INTERVAL}.mt'
     apply_annotations(
         vcf_path=vcf_path,
         vep_ht_path=vep_ht_path,
         out_mt_path=str(out_mt_path),
         checkpoints_bucket=f'{TMP_BUCKET}/checkpoints',
+        clinvar_ht_path='gs://cpg-seqr-reference-data/GRCh38/clinvar/'
+        'clinvar.GRCh38.2020-06-15.ht/',
     )
     # Testing
     mt = hl.read_matrix_table(str(out_mt_path))

--- a/test/test_apply_annotations.py
+++ b/test/test_apply_annotations.py
@@ -11,6 +11,8 @@ import time
 import os
 from random import choices
 import hail as hl
+import pytest
+
 from reanalysis.annotation import apply_annotations
 
 
@@ -32,6 +34,7 @@ TMP_BUCKET = (
 INTERVAL = 'chr20-5111495-5111607'
 
 
+@pytest.mark.gcp
 def test_apply_annotations(monkeypatch):
     """
     Test annotation.apply_annotations: convert VCF to a MatrixTable,

--- a/test/test_apply_annotations.py
+++ b/test/test_apply_annotations.py
@@ -1,8 +1,12 @@
+"""
+tests for the annotation module
+"""
+
+
 import string
 import time
 from random import choices
 import hail as hl
-
 from reanalysis.annotation import apply_annotations
 
 
@@ -17,21 +21,21 @@ def timestamp():
 TMP_BUCKET = (
     f'gs://cpg-fewgenomes-test/unittest/tmp/test_apply_annotations/{timestamp()}'
 )
+INTERVAL = 'chr20-5111495-5111607'
 
 
-def test_apply_annotations(self):
+def test_apply_annotations(monkeypatch):
     """
     Test annotation.apply_annotations: convert VCF to a MatrixTable,
     and add VEP and other annotations.
     """
+    monkeypatch.setenv('CPG_REFERENCE_PREFIX', 'gs://cpg-reference')
     vcf_path = (
         f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/'
-        f'joint-called-{self.interval}.vcf.gz'
+        f'joint-called-{INTERVAL}.vcf.gz'
     )
-    vep_ht_path = (
-        f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/vep/{self.interval}.ht'
-    )
-    out_mt_path = f'{TMP_BUCKET}/cohort-{self.interval}.mt'
+    vep_ht_path = f'gs://cpg-fewgenomes-test/unittest/inputs/chr20/vep/{INTERVAL}.ht'
+    out_mt_path = f'{TMP_BUCKET}/cohort-{INTERVAL}.mt'
     apply_annotations(
         vcf_path=vcf_path,
         vep_ht_path=vep_ht_path,
@@ -40,6 +44,6 @@ def test_apply_annotations(self):
     )
     # Testing
     mt = hl.read_matrix_table(str(out_mt_path))
-    mt.rows().show()
-    self.assertListEqual(mt.topmed.AC.collect(), [20555, 359, 20187])
-    self.assertSetEqual(set(mt.geneIds.collect()[0]), {'ENSG00000089063'})
+    # mt.rows().show()
+    assert mt.topmed.AC.collect() == [20555, 359, 20187]
+    assert set(mt.geneIds.collect()[0]) == {'ENSG00000089063'}


### PR DESCRIPTION
# Fixes

Avoiding importing `cpg_pipes`.

## Proposed Changes

1. Requires `python_command` and `reference_path` to be in `cpg_utils.hail_batch`, added in this PR: https://github.com/populationgenomics/cpg-utils/pull/32
2. Moved command to run VEP on a VCF into a separate module `vep/jobs.py`.
3. Moved function that collects VEP results into a Hail Table into a separate module `vep/query.py`, to be submitted with `python_command`.
4. Original `annotation` module only has the `apply_annotations` function, to be submitted with  `python_command`.

## Checklist

- [ ] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
