### PR TITLE
Fresh branch with SM-API script

### DIFF
--- a/design_docs/Helpers.md
+++ b/design_docs/Helpers.md
@@ -26,9 +26,12 @@ The Pedigree data pulled directly from the SM-API contains all members and relat
 of the participants' external identifiers (PID). This can't be matched up with the VCF contents, as in
 sequence data files processing is instead done in the context of the Sample IDs (SID).
 
-To complicate things, there is no guarantee of a 1:1 relationship between participants and samples (e.g.
-replacement samples, but also Genome and Exome library preparations would be considered separate sequences
-derived from the same physical sample).
+There is no guarantee of a 1:1 relationship between participants and sequences:
+
+- a participant may have multiple separate samples, e.g. replacements, or for a time-series analysis
+- each physical sample may be processed into a number of different sequence datasets (e.g. Illumina/Nanopore,
+Exome/Genome)
+
 To overcome any potential ambiguity, this process uses the following steps:
 
 - obtain the Pedigree data with external identifiers

--- a/design_docs/Helpers.md
+++ b/design_docs/Helpers.md
@@ -1,0 +1,45 @@
+# Helpers
+
+The [helpers](../helpers) directory is designed to be a collection place for single purpose scripts, useful
+in setting up or configuring the analysis, but not a direct part of the end-to-end workflow.
+
+## Pedigree
+
+Running accurate genetic analysis is heavily dependent on an accurate representation of relationships between samples.
+For the CPG, this data is typically stored within the sample-metadata database, accessible through the corresponding API
+client.
+
+The [Pedigree-generation](../helpers/pedigree_from_sample_metadata.py) script has been included which
+will query the sample-metadata API for a given cohort, and rearrange the results into two outputs:
+
+- A Pedigree
+- A mapping of the external individual IDs to CPG sample IDs
+
+Additional options can be supplied to:
+
+- export the Pedigree as PLINK format instead of .ped format
+- export the Pedigree with all individuals as singletons
+
+### Pedigree manipulation
+
+The Pedigree data pulled directly from the SM-API contains all members and relationships in the context
+of the participants' external identifiers (PID). This can't be matched up with the VCF contents, as in
+sequence data files processing is instead done in the context of the Sample IDs (SID).
+
+To complicate things, there is no guarantee of a 1:1 relationship between participants and samples (e.g.
+replacement samples, but also Genome and Exome library preparations would be considered separate sequences
+derived from the same physical sample).
+To overcome any potential ambiguity, this process uses the following steps:
+
+- obtain the Pedigree data with external identifiers
+- obtain the mapping of PID:SID, allowing for multiple SID/PID
+- dump a dictionary to file, allowing lookup of all SID -> PID
+- for each PID, collect all possible SID as a list
+- when writing the translated pedigree:
+  - use itertools.product to generate intra-family combinations of the proband, father, & mother e.g.
+  - 1 sample per participant == 1^3 = 1 row
+  - 2 samples per participant == 2^3 = 8 rows for all possible combinations
+
+This pedigree will encompass all possible sample collections, and with a high level of sample replacement
+could expand massively. For an individual use case sample IDs could be taken from a joint-call or sample-list,
+and used to reduce the number of rows read from this PED to only those relevant to a current analysis

--- a/helpers/pedigree_from_sample_metadata.py
+++ b/helpers/pedigree_from_sample_metadata.py
@@ -1,0 +1,227 @@
+"""
+generate a ped file on the fly using the sample-metadata api client
+optional argument will remove all family associations
+    - family structure removal enforces singleton structure during this MVP
+optional argument will replace missing parents with '0' to be valid PLINK structure
+"""
+
+
+from collections import defaultdict
+from itertools import product
+import json
+import logging
+from typing import Dict, List, Union
+
+import click
+
+from sample_metadata.apis import FamilyApi, ParticipantApi
+
+
+# the keys provided by the SM API, in the order to write in output
+PED_KEYS = [
+    'family_id',
+    'individual_id',
+    'paternal_id',
+    'maternal_id',
+    'sex',
+    'affected',
+]
+
+
+def get_ped_with_permutations(
+    pedigree_dicts: List[Dict[str, Union[str, List[str]]]],
+    sample_to_cpg_dict: Dict[str, List[str]],
+    make_singletons: bool,
+    plink_format: bool,
+) -> List[Dict[str, List[str]]]:
+    """
+    Take the pedigree entry representations from the pedigree endpoint
+    translates sample IDs of all members to CPG values
+    sample IDs are replaced with lists, containing all permutations
+    where multiple samples exist
+
+    :param pedigree_dicts:
+    :param sample_to_cpg_dict:
+    :param make_singletons: make all members unrelated singletons
+    :param plink_format: substitute missing member IDs for '0'
+    :return:
+    """
+
+    new_entries = []
+    failures: List[str] = []
+
+    for counter, ped_entry in enumerate(pedigree_dicts, 1):
+
+        if ped_entry['individual_id'] not in sample_to_cpg_dict:
+            failures.append(ped_entry['individual_id'])
+
+        # update the sample IDs
+        ped_entry['individual_id'] = sample_to_cpg_dict[ped_entry['individual_id']]
+
+        # remove parents and assign an individual sample ID
+        if make_singletons:
+            ped_entry['paternal_id'] = ['0' if plink_format else '']
+            ped_entry['maternal_id'] = ['0' if plink_format else '']
+            ped_entry['family_id'] = str(counter)
+
+        else:
+            ped_entry['paternal_id'] = sample_to_cpg_dict.get(
+                ped_entry['paternal_id'], ['0' if plink_format else '']
+            )
+            ped_entry['maternal_id'] = sample_to_cpg_dict.get(
+                ped_entry['maternal_id'], ['0' if plink_format else '']
+            )
+
+        new_entries.append(ped_entry)
+
+    if failures:
+        raise Exception(
+            f'Samples were available from the Pedigree endpoint, '
+            f'but no ID translation was available: {",".join(failures)}'
+        )
+    return new_entries
+
+
+def write_ped_with_permutations(
+    ped_with_permutations: List[Dict[str, List[str]]], output: str
+):
+    """
+    take the pedigree data, and write out as a correctly formatted PED file
+    this permits the situation where we have multiple possible samples per individual
+
+    :param ped_with_permutations: the PED content with sample lists
+    :param output: file location to create
+    """
+    with open(output, 'w', encoding='utf-8') as handle:
+        handle.write('\t'.join(PED_KEYS) + '\n')
+        for entry in ped_with_permutations:
+            for sample, mother, father in product(
+                entry['individual_id'], entry['paternal_id'], entry['maternal_id']
+            ):
+                handle.write(
+                    '\t'.join(
+                        [
+                            entry['family_id'],
+                            sample,
+                            mother,
+                            father,
+                            str(entry['sex']),
+                            str(entry['affected']),
+                        ]
+                    )
+                    + '\n'
+                )
+
+
+def get_pedigree_for_project(project: str) -> List[Dict[str, str]]:
+    """
+    fetches the project pedigree from sample-metadata
+    list, one dict per participant
+    :param project:
+    :return: all content retrieved from API
+    """
+
+    return FamilyApi().get_pedigree(project=project)
+
+
+def ext_to_int_sample_map(project: str) -> Dict[str, List[str]]:
+    """
+    fetches the participant-sample mapping, so external IDs can be translated
+    to the corresponding CPG ID
+
+    This endpoint returns a list of tuples, each containing a participant ID
+    and corresponding sample ID
+
+    This originally had an expectation of a 1:1 participant:sample relationship
+    that will not hold in general, as numerous samples have multiple samples
+
+    for each participant, create a list of all possible samples
+
+    :param project:
+    :return: the mapping dictionary
+    """
+
+    sample_map = defaultdict(list)
+    for (
+        participant,
+        sample,
+    ) in ParticipantApi().get_external_participant_id_to_internal_sample_id(
+        project=project
+    ):
+        sample_map[participant].append(sample)
+    return sample_map
+
+
+def generate_reverse_lookup(mapping_digest: Dict[str, List[str]]) -> Dict[str, str]:
+    """
+    :param mapping_digest: created by ext_to_int_sample_map
+    :return:
+    """
+
+    return {
+        sample: participant
+        for participant, samples in mapping_digest.items()
+        for sample in samples
+    }
+
+
+@click.command()
+@click.option(
+    '--project',
+    help='the name of the project to use in API queries',
+)
+@click.option(
+    '--singletons',
+    default=False,
+    is_flag=True,
+    help='remake the pedigree as singletons',
+)
+@click.option(
+    '--plink',
+    default=False,
+    is_flag=True,
+    help='make a plink format file (.fam, .ped is the default)',
+)
+@click.option(
+    '--output',
+    help='prefix for writing all outputs to',
+)
+def main(project: str, singletons: bool, plink: bool, output: str):
+    """
+
+    :param project: may be able to retrieve this from the environment
+    :param singletons: whether to split the pedigree(s) into singletons
+    :param plink: whether to write the file as PLINK.fam format
+    :param output: path to write new PED file
+    """
+
+    # get the list of all pedigree members as list of dictionaries
+    logging.info('Pulling all pedigree members')
+    pedigree_dicts = get_pedigree_for_project(project=project)
+
+    # endpoint gives list of tuples e.g. [['A1234567_proband', 'CPG12341']]
+    # parser returns a dictionary, arbitrary # sample IDs per participant
+    logging.info('pulling internal-external sample mapping')
+    sample_to_cpg_dict = ext_to_int_sample_map(project=project)
+
+    # store a way of reversing this lookup in future
+    reverse_lookup = generate_reverse_lookup(sample_to_cpg_dict)
+    with open(f'{output}_reversed.json', 'w', encoding='utf-8') as handle:
+        json.dump(reverse_lookup, handle, indent=4)
+
+    logging.info('updating pedigree sample IDs to internal')
+    ped_with_permutations = get_ped_with_permutations(
+        pedigree_dicts=pedigree_dicts,
+        sample_to_cpg_dict=sample_to_cpg_dict,
+        make_singletons=singletons,
+        plink_format=plink,
+    )
+
+    pedigree_output_path = f'{output}_pedigree.{"fam" if plink else "ped"}'
+    logging.info('writing new PED file to "%s"', pedigree_output_path)
+    write_ped_with_permutations(ped_with_permutations, pedigree_output_path)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()  # pylint: disable=E1120

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.0.4
 cloudpathlib[azure,gs]==0.7.0
-cpg-utils==4.1.0
+cpg-utils==4.1.1
 cyvcf2==0.30.14
 dill==0.3.4
 hail==0.2.93
@@ -8,4 +8,5 @@ Jinja2==3.0.3
 pandas==1.3.5
 peddy==0.4.8
 requests==2.25.1
+sample-metadata==4.6.0
 seqr-loader==1.2.5

--- a/test/input/mock_pedigree.json
+++ b/test/input/mock_pedigree.json
@@ -1,0 +1,34 @@
+[
+  {
+    "family_id": "FAM1",
+    "individual_id": "FAM1_father",
+    "paternal_id": "",
+    "maternal_id": "",
+    "sex": 1,
+    "affected": 1
+  },
+  {
+    "family_id": "FAM1",
+    "individual_id": "FAM1_mother",
+    "paternal_id": "",
+    "maternal_id": "",
+    "sex": 2,
+    "affected": 1
+  },
+  {
+    "family_id": "FAM1",
+    "individual_id": "FAM1_proband",
+    "paternal_id": "FAM1_father",
+    "maternal_id": "FAM1_mother",
+    "sex": 1,
+    "affected": 2
+  },
+  {
+    "family_id": "FAM2",
+    "individual_id": "FAM2_proband",
+    "paternal_id": "",
+    "maternal_id": "",
+    "sex": 1,
+    "affected": 2
+  }
+]

--- a/test/input/mock_sm_lookup.json
+++ b/test/input/mock_sm_lookup.json
@@ -1,0 +1,18 @@
+[
+  [
+    "FAM1_father",
+    "CPG11"
+  ],
+  [
+    "FAM1_mother",
+    "CPG12"
+  ],
+  [
+    "FAM1_proband",
+    "CPG13"
+  ],
+  [
+    "FAM2_proband",
+    "CPG41"
+  ]
+]

--- a/test/test_generate_pedigree.py
+++ b/test/test_generate_pedigree.py
@@ -1,0 +1,152 @@
+"""
+methods for testing the sample-metadata API queries
+"""
+
+from copy import deepcopy
+
+from unittest.mock import patch
+
+import json
+import os
+
+import pytest
+
+from helpers.pedigree_from_sample_metadata import (
+    ext_to_int_sample_map,
+    get_ped_with_permutations,
+)
+
+
+PWD = os.path.dirname(__file__)
+PROJECT = 'fake-project'
+INPUT = os.path.join(PWD, 'input')
+JSON_PED = os.path.join(INPUT, 'mock_pedigree.json')
+LOOKUP_PED = os.path.join(INPUT, 'mock_sm_lookup.json')
+
+SAMPLE_TO_CPG = {
+    'sam1': ['cpg1'],
+    'sam2': ['cpg2'],
+    'sam3': ['cpg3'],
+}
+DIRTY_PED = [
+    {
+        'family_id': 'FAM1',
+        'individual_id': 'sam1',
+        'paternal_id': 'sam2',
+        'maternal_id': 'sam3',
+        'sex': 1,
+        'affected': 1,
+    }
+]
+
+
+@patch(
+    'helpers.pedigree_from_sample_metadata.ParticipantApi.'
+    'get_external_participant_id_to_internal_sample_id'
+)
+def test_ext_to_int_sample_map(
+    map_mock,
+):
+    """
+    fetch method using a mocked API endpoint
+    :param map_mock:
+    :return:
+    """
+
+    with open(LOOKUP_PED, 'r', encoding='utf-8') as handle:
+        payload = json.load(handle)
+
+    map_mock.return_value = payload
+    result = ext_to_int_sample_map(project=PROJECT)
+    assert isinstance(result, dict)
+    assert result == {
+        'FAM1_father': ['CPG11'],
+        'FAM1_mother': ['CPG12'],
+        'FAM1_proband': ['CPG13'],
+        'FAM2_proband': ['CPG41'],
+    }
+
+
+def test_get_clean_pedigree_fails():
+    """
+
+    :return:
+    """
+    ped = [{'individual_id': 'plink'}]
+
+    with pytest.raises(Exception):
+        get_ped_with_permutations(
+            pedigree_dicts=ped,
+            sample_to_cpg_dict={},
+            make_singletons=False,
+            plink_format=False,
+        )
+
+
+def test_get_clean_pedigree():
+    """
+
+    :return:
+    """
+    cleaned = get_ped_with_permutations(
+        pedigree_dicts=deepcopy(DIRTY_PED),
+        sample_to_cpg_dict=SAMPLE_TO_CPG,
+        make_singletons=False,
+        plink_format=False,
+    )
+    assert cleaned == [
+        {
+            'family_id': 'FAM1',
+            'individual_id': ['cpg1'],
+            'paternal_id': ['cpg2'],
+            'maternal_id': ['cpg3'],
+            'sex': 1,
+            'affected': 1,
+        }
+    ]
+
+
+def test_get_clean_pedigree_singles():
+    """
+
+    :return:
+    """
+    cleaned = get_ped_with_permutations(
+        pedigree_dicts=deepcopy(DIRTY_PED),
+        sample_to_cpg_dict=SAMPLE_TO_CPG,
+        make_singletons=True,
+        plink_format=False,
+    )
+    assert cleaned == [
+        {
+            'family_id': '1',
+            'individual_id': ['cpg1'],
+            'paternal_id': [''],
+            'maternal_id': [''],
+            'sex': 1,
+            'affected': 1,
+        }
+    ]
+
+
+def test_get_clean_pedigree_singles_plink():
+    """
+
+    :return:
+    """
+    cleaned = get_ped_with_permutations(
+        pedigree_dicts=deepcopy(DIRTY_PED),
+        sample_to_cpg_dict=SAMPLE_TO_CPG,
+        make_singletons=True,
+        plink_format=True,
+    )
+    assert cleaned == [
+        {
+            'family_id': '1',
+            'individual_id': ['cpg1'],
+            'paternal_id': ['0'],
+            'maternal_id': ['0'],
+            'sex': 1,
+            'affected': 1,
+        }
+    ]


### PR DESCRIPTION
# Fixes

  - This is a fresh version of #26 without the messy rebase

## Proposed Changes

  - helper script for generating family data from sample-metadata:
    1. Pedigree
    2. Pedigree in PLINK format
    3. sample -> participant reverse lookup

## Checklist

- [ ] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass

## Misc

Early version of this script (#1) made some incorrect assumptions about the relationship between participants and samples. This version allows for a 1 -> n relationship, and all possible variations will be present in the final PED file

Use of the de novo functionality in Hail required the generation of a Pedigree in PLINK format, so that has been added as an option. I've confirmed that Peddy also accepts PLINK and .ped files interchangeably, so .fam is the new default for this application.

The mapping back from samples to participants is required when formatting results for presentation back to clinical analysts, so creation of that mapping has been included as a step here.

### Rebase problems

I implemented the changes suggested by @illusional in #26, and forgot to commit them before trying to rebase against all the recent changes to `Main`. As the changes weren't committed, aborting the rebase and rolling back got rid of all the changes. Basically I made a mess of it, and this new branch isolates only the changes relevant to this script.

