### PR TITLE
Run as singletons

### DIFF
--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -15,6 +15,7 @@ analysis-runner \
     --config_json gs://cpg-acute-care-test/reanalysis/reanalysis_conf.json \
     --input_path gs://cpg-acute-care-test/reanalysis/2011-11-11/prior_to_annotation.vcf.bgz \
     --panel_genes gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json \
-    --plink_file gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam
+    --plink_file gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam \
+    --singletons gs://cpg-acute-care-test/reanalysis/acute_care_singletons_pedigree.fam
 
 #    --input_path gs://cpg-acute-care-test/reanalysis/2021-09-03/hail_105_ac.mt/ \

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -70,7 +70,13 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
     or for a direct parser...
     """
 
-    def __init__(self, var: Variant, samples: List[str], config: Dict[str, Any]):
+    def __init__(
+        self,
+        var: Variant,
+        samples: List[str],
+        config: Dict[str, Any],
+        as_singletons=False,
+    ):
 
         # extract the coordinates into a separate object
         self.coords = Coordinates(
@@ -82,12 +88,17 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
         self.category_2: bool = var.INFO.get('Category2') == 1
         self.category_3: bool = var.INFO.get('Category3') == 1
 
-        # de novo class is not an integer - list of strings or empty list
-        self.category_4: List[str] = (
-            var.INFO.get('Category4').split(',')
-            if var.INFO.get('Category4') != 'missing'
-            else []
-        )
+        # de novo category is a list of strings or empty list
+        # if cohort runs as singletons, remove possibility of de novo
+        if as_singletons:
+            self.category_4 = False
+        else:
+            self.category_4: List[str] = (
+                var.INFO.get('Category4').split(',')
+                if var.INFO.get('Category4') != 'missing'
+                else []
+            )
+
         self.category_support: bool = var.INFO.get('CategorySupport') == 1
 
         # get all zygosities once per variant
@@ -247,6 +258,7 @@ def gather_gene_dict_from_contig(
     variant_source: cyvcf2.VCFReader,
     config: Dict[str, Any],
     panelapp_data: PanelAppDict,
+    singletons: bool,
     blacklist: Optional[List[str]] = None,
 ) -> Dict[str, Dict[str, AbstractVariant]]:
     """
@@ -263,6 +275,7 @@ def gather_gene_dict_from_contig(
     :param variant_source: VCF reader instance
     :param config: configuration file
     :param panelapp_data:
+    :param singletons:
     :param blacklist:
     :return: populated lookup dict
     """
@@ -278,7 +291,10 @@ def gather_gene_dict_from_contig(
     # if contig has no variants, prints an error and returns []
     for variant in variant_source(contig):
         abs_var = AbstractVariant(
-            var=variant, samples=variant_source.samples, config=config
+            var=variant,
+            samples=variant_source.samples,
+            config=config,
+            as_singletons=singletons,
         )
 
         if abs_var.coords.string_format in blacklist:

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -91,7 +91,7 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
         # de novo category is a list of strings or empty list
         # if cohort runs as singletons, remove possibility of de novo
         if as_singletons:
-            self.category_4 = False
+            self.category_4 = []
         else:
             self.category_4: List[str] = (
                 var.INFO.get('Category4').split(',')

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -231,6 +231,9 @@ def main(
     :param pedigree:
     """
 
+    # check if this is a singleton pedigree
+    singletons = pedigree.__contains__('singletons')
+
     # parse the pedigree from the file (via write to temp)
     with open('i_am_a_temporary.ped', 'w', encoding='utf-8') as handle:
         handle.write(AnyPath(pedigree).read_text())
@@ -276,6 +279,7 @@ def main(
             variant_source=vcf_opened,
             config=config_dict,
             panelapp_data=panelapp_data,
+            singletons=singletons,
             blacklist=variant_blacklist,
         )
         results.extend(


### PR DESCRIPTION
# Fixes

  - fixes #32 

## Proposed Changes

allow for a second Pedigree file to be provided - this second file is optional, and is for a singleton representation of the same callset. This changes the following behaviours:
  - results processing module is called twice, once with each pedigree file
  - final results are written to different paths, depending on the pedigree used to generate them: [ singleton | summary ]_results.[ html / json ]
  - The VCF processing module still takes only one Pedigree file. If that input file name contains 'singletons', the `de novo` category value is removed as each variant is read. That, in combination with the singleton structure in the pedigree means that analysis is done as a cohort of individuals, instead of families.

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
