### PR TITLE
allow annotation skipping (+ tests)

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -267,7 +267,7 @@ def handle_hail_filtering(
         f'--out_vcf {HAIL_VCF_OUT} '
     )
 
-    logging.info(f'PanelApp Command: {labelling_command}')
+    logging.info(f'Labelling Command: {labelling_command}')
     labelling_job.command(labelling_command)
     copy_common_env(labelling_job)
     return labelling_job

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -400,7 +400,11 @@ def main(
     # -------------------------- #
     # determine the input type - if MT, decompose to VCF prior to annotation
     input_file_type = identify_file_type(input_path)
-    assert input_file_type in [FileTypes.VCF_GZ, FileTypes.VCF_BGZ], (
+    assert input_file_type in [
+        FileTypes.VCF_GZ,
+        FileTypes.VCF_BGZ,
+        FileTypes.MATRIX_TABLE,
+    ], (
         f'inappropriate input type provided: {input_file_type}; '
         f'this is designed for MT or compressed VCF only'
     )

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -3,10 +3,12 @@ a collection of classes and methods
 which may be shared across reanalysis components
 """
 
-from typing import Any, Union
 from collections import defaultdict
 from dataclasses import dataclass, is_dataclass
+from enum import Enum
 from itertools import combinations_with_replacement
+from pathlib import Path
+from typing import Any, Union
 
 import json
 import logging
@@ -29,6 +31,45 @@ BAD_GENOTYPES: set[int] = {HOMREF, UNKNOWN}
 PHASE_SET_DEFAULT = -2147483648
 X_CHROMOSOME = {'X'}
 NON_HOM_CHROM = {'Y', 'MT', 'M'}
+
+
+class FileTypes(Enum):
+    """
+    enumeration of permitted input file types
+    """
+
+    HAIL_TABLE = '.ht'
+    MATRIX_TABLE = '.mt'
+    VCF = '.vcf'
+    VCF_GZ = '.vcf.gz'
+    VCF_BGZ = '.vcf.bgz'
+
+
+def identify_file_type(file_path: str) -> FileTypes | Exception:
+    """
+    return type of the file, if present in FileTypes enum
+
+    :param file_path:
+    :return:
+    """
+    pl_filepath = Path(file_path)
+
+    # pull all extensions (e.g. .vcf.bgz will be split into [.vcf, .bgz]
+    extensions = pl_filepath.suffixes
+
+    assert len(extensions) > 0, 'cannot identify input type from extensions'
+
+    if extensions[-1] == '.ht':
+        return FileTypes.HAIL_TABLE
+    if extensions[-1] == '.mt':
+        return FileTypes.MATRIX_TABLE
+    if extensions == ['.vcf']:
+        return FileTypes.VCF
+    if extensions == ['.vcf', '.gz']:
+        return FileTypes.VCF_GZ
+    if extensions == ['.vcf', '.bgz']:
+        return FileTypes.VCF_BGZ
+    raise Exception(f'File cannot be definitively typed: {str(extensions)}')
 
 
 @dataclass

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,7 +12,39 @@ from reanalysis.utils import (
     get_non_ref_samples,
     get_simple_moi,
     read_json_from_path,
+    identify_file_type,
+    FileTypes,
 )
+
+
+def test_file_types():
+    """
+    check 'em
+    :return:
+    """
+    assert identify_file_type('this/is/my/matrixtable.mt') == FileTypes.MATRIX_TABLE
+    assert identify_file_type('this/is/my/hailtable.ht') == FileTypes.HAIL_TABLE
+    assert identify_file_type('this/is/a/varfile.vcf') == FileTypes.VCF
+    assert identify_file_type('this/is/a/varfile.vcf.gz') == FileTypes.VCF_GZ
+    assert identify_file_type('this/is/a/varfile.vcf.bgz') == FileTypes.VCF_BGZ
+
+
+def test_file_types_assert_error():
+    """
+    check 'em
+    :return:
+    """
+    with pytest.raises(AssertionError):
+        identify_file_type('no/extensions')
+
+
+def test_file_types_exception():
+    """
+    check 'em
+    :return:
+    """
+    with pytest.raises(Exception):
+        identify_file_type('i/am/a/mystery.file.type')
 
 
 def test_read_json(conf_json_path):


### PR DESCRIPTION
# Fixes

  - closes #56 

## Proposed Changes

  - adds a CLI flag to signal annotation skipping
  - creates an enumeration to specifically identify different file types
  - changes the `is this a VCF` test to `what file type is this`
  - tests if an input is MT - if True, and annotation skipping flag is passed, the expected path of the annotated MT will be overwritten with the current input MT path
    - this will be read during the category assignment phase

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
