### PR TITLE
Implement Checkpoints

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -674,7 +674,7 @@ def checkpoint_and_repartition(
     :param extra_logging: any additional context
     :return: repartitioned, post-checkpoint matrix
     """
-    checkpoint_extended = f'{TEMP_CHECKPOINT}_{CHECKPOINT_EXTENSION }'
+    checkpoint_extended = f'{TEMP_CHECKPOINT}_{CHECKPOINT_EXTENSION}'
     logging.info(f'Checkpointing MT to {checkpoint_extended}')
     matrix = matrix.checkpoint(checkpoint_extended, overwrite=True)
     checkpoint_num += 1

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -677,7 +677,7 @@ def checkpoint_and_repartition(
     checkpoint_extended = f'{TEMP_CHECKPOINT}_{CHECKPOINT_EXTENSION}'
     logging.info(f'Checkpointing MT to {checkpoint_extended}')
     matrix = matrix.checkpoint(checkpoint_extended, overwrite=True)
-    checkpoint_num += 1
+    checkpoint_num = checkpoint_num + 1
 
     # estimate partitions; fall back to 1 if low row count
     current_rows = matrix.count_rows()

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -701,6 +701,8 @@ def main(
     :param tmp_path: temporary checkpoint write path
     """
 
+    checkpoint_count = 0
+
     # initiate Hail with defined driver spec.
     init_batch(driver_cores=8, driver_memory='highmem')
 
@@ -746,7 +748,8 @@ def main(
     matrix = filter_by_ab_ratio(matrix)
 
     logging.info('checkpointing MT after applying quality filters')
-    matrix = matrix.checkpoint(tmp_path, overwrite=True)
+    matrix = matrix.checkpoint(f'{tmp_path}_{checkpoint_count}', overwrite=True)
+    checkpoint_count += 1
     logging.info(f'Rows remaining: {matrix.count_rows()}')
 
     # pull annotations into info and update if missing
@@ -759,7 +762,8 @@ def main(
     )
 
     logging.info('checkpointing MT after applying annotation filters')
-    matrix = matrix.checkpoint(tmp_path, overwrite=True)
+    matrix = matrix.checkpoint(f'{tmp_path}_{checkpoint_count}', overwrite=True)
+    checkpoint_count += 1
     matrix = informed_repartition(matrix=matrix)
     logging.info(
         f'Variants remaining after Rare & Green-Gene filter: {matrix.count_rows()}'
@@ -780,7 +784,8 @@ def main(
 
     # now restrict to only categorised variants
     matrix = filter_to_categorised(matrix)
-    matrix = matrix.checkpoint(tmp_path, overwrite=True)
+    matrix = matrix.checkpoint(f'{tmp_path}_{checkpoint_count}', overwrite=True)
+    checkpoint_count += 1
     matrix = informed_repartition(matrix=matrix)
     logging.info(f'Variants remaining after Category filter: {matrix.count_rows()}')
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -55,7 +55,6 @@ ANNOTATED_MT = output_path('annotated_variants.mt')
 PANELAPP_JSON_OUT = output_path('panelapp_137_data.json')
 
 # output of labelling task in Hail
-HAIL_TMP = output_path('hail_matrix.mt', 'tmp')
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
 
 # outputs for familial and singleton analysis
@@ -264,9 +263,7 @@ def handle_hail_filtering(
         f'--mt_input {ANNOTATED_MT} '
         f'--panelapp_path {PANELAPP_JSON_OUT} '
         f'--config_path {config} '
-        f'--plink_file {plink_file} '
-        f'--out_vcf {HAIL_VCF_OUT} '
-        f'--tmp_path {HAIL_TMP}'
+        f'--plink_file {plink_file}'
     )
 
     logging.info(f'Labelling Command: {labelling_command}')

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -55,6 +55,7 @@ ANNOTATED_MT = output_path('annotated_variants.mt')
 PANELAPP_JSON_OUT = output_path('panelapp_137_data.json')
 
 # output of labelling task in Hail
+HAIL_TMP = output_path('hail_matrix.mt')
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
 
 # outputs for familial and singleton analysis
@@ -265,6 +266,7 @@ def handle_hail_filtering(
         f'--config_path {config} '
         f'--plink_file {plink_file} '
         f'--out_vcf {HAIL_VCF_OUT} '
+        f'--tmp_path {HAIL_TMP}'
     )
 
     logging.info(f'Labelling Command: {labelling_command}')

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -55,7 +55,7 @@ ANNOTATED_MT = output_path('annotated_variants.mt')
 PANELAPP_JSON_OUT = output_path('panelapp_137_data.json')
 
 # output of labelling task in Hail
-HAIL_TMP = output_path('hail_matrix.mt')
+HAIL_TMP = output_path('hail_matrix.mt', 'tmp')
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
 
 # outputs for familial and singleton analysis

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
             'tabulate==0.8.9',
             'pytest-xdist==2.5.0',
             'requests_mock==1.9.3',
-        ],
-        'pre-commit': ['black==22.3.0', 'pre-commit>=2.19.0', 'pylint>=2.14.0'],
+        ]
     },
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,15 +28,10 @@ AIP_OUTPUT = os.path.join(INPUT, 'aip_output_example.json')
 SEQR_OUTPUT = os.path.join(INPUT, 'seqr_tags.tsv')
 PHASED_TRIO = os.path.join(INPUT, 'phased_trio.vcf.bgz')
 PANELAPP_CHANGES = os.path.join(INPUT, 'panel_changes_expected.json')
-CPG_CONFIG = os.path.join(INPUT, 'cpg_runtime_config.json')
+CPG_CONFIG = os.path.join(INPUT, 'cpg_runtime_config.toml')
 
-
-@pytest.fixture(name='cpg_config', scope='session')
-def fixture_cpg_config(monkeypatch):
-    """
-    :return:
-    """
-    monkeypatch.setenv('CPG_CONFIG_PATH', CPG_CONFIG)
+# can't use a session-scoped monkeypatch, so just override
+os.putenv('CPG_CONFIG_PATH', CPG_CONFIG)
 
 
 @pytest.fixture(name='panel_changes', scope='session')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,15 @@ AIP_OUTPUT = os.path.join(INPUT, 'aip_output_example.json')
 SEQR_OUTPUT = os.path.join(INPUT, 'seqr_tags.tsv')
 PHASED_TRIO = os.path.join(INPUT, 'phased_trio.vcf.bgz')
 PANELAPP_CHANGES = os.path.join(INPUT, 'panel_changes_expected.json')
+CPG_CONFIG = os.path.join(INPUT, 'cpg_runtime_config.json')
+
+
+@pytest.fixture(name='cpg_config', scope='session')
+def fixture_cpg_config(monkeypatch):
+    """
+    :return:
+    """
+    monkeypatch.setenv('CPG_CONFIG_PATH', CPG_CONFIG)
 
 
 @pytest.fixture(name='panel_changes', scope='session')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,10 +28,9 @@ AIP_OUTPUT = os.path.join(INPUT, 'aip_output_example.json')
 SEQR_OUTPUT = os.path.join(INPUT, 'seqr_tags.tsv')
 PHASED_TRIO = os.path.join(INPUT, 'phased_trio.vcf.bgz')
 PANELAPP_CHANGES = os.path.join(INPUT, 'panel_changes_expected.json')
-CPG_CONFIG = os.path.join(INPUT, 'cpg_runtime_config.toml')
 
-# can't use a session-scoped monkeypatch, so just override
-os.putenv('CPG_CONFIG_PATH', CPG_CONFIG)
+# can't use a session-scoped monkeypatch, so just set
+os.putenv('CPG_CONFIG_PATH', os.path.join(INPUT, 'cpg_runtime_config.toml'))
 
 
 @pytest.fixture(name='panel_changes', scope='session')

--- a/test/input/cpg_runtime_config.json
+++ b/test/input/cpg_runtime_config.json
@@ -1,5 +1,0 @@
-{
-    "workflow": {
-        "output_prefix": "OUTPUT"
-    }
-}

--- a/test/input/cpg_runtime_config.json
+++ b/test/input/cpg_runtime_config.json
@@ -1,0 +1,5 @@
+{
+    "workflow": {
+        "output_prefix": "OUTPUT"
+    }
+}

--- a/test/input/cpg_runtime_config.toml
+++ b/test/input/cpg_runtime_config.toml
@@ -1,0 +1,211 @@
+[workflow]
+# Access level (test, standard, full). Translates into the storage and inputs
+# namespace (test or main):
+access_level = 'standard'
+
+# Input provider type ('csv' or 'smdb' for the CPG sample-metadata database)
+input_provider = 'smdb'
+
+# For the first (not-skipped) stage, if the input for a target does
+# not exist, just skip this target instead of failing. E.g. if the first
+# stage is Align, and `sample.alignment_input` for a sample do not exist,
+# remove this sample, instead of failing. In order words, ignore samples
+# that are missing results from skipped stages
+skip_samples_with_missing_input = false
+
+# Check input file existence (e.g. FASTQ files). If they are missing
+# the --skip-samples-with-missing-input option controls whether such
+# should be ignored, or raise an error
+check_inputs = true
+
+# Within jobs, check all in-job intermediate files for possible reuse.
+# If set to False, will overwrite all intermediates
+check_intermediates = true
+
+# Before running a stage, check if its input already exists. If it exists,
+# submit a [reuse] job instead.
+check_expected_outputs = true
+
+# Local directory for temporary files. Usually takes a few kB.
+# If not provided, a temp folder will be created
+#local_tmp_dir =
+
+# Slack channel to send status reports with the CPG status reporter:
+#slack_channel = 'seqr-loader'
+
+# When the sample-metadata database API returns an error from the
+# database, only show the error and continue, instead of crashing
+smdb_errors_are_fatal = true
+
+# Prefix to find docker images referenced in `image_config_yaml_path`
+image_registry_prefix = 'australia-southeast1-docker.pkg.dev/cpg-common/images'
+
+# Prefix to find reference files referenced in `refdata_yaml_path`
+reference_prefix = 'gs://cpg-reference'
+
+# Template to build HTTP URLs matching the dataset_path of category
+# "web". Should be parametrised by namespace and dataset in Jinja format:
+web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
+
+# GCP project to activate and for requester-pays buckets. For CPG, will be determined
+# automatically if not provided, and analysis-runner service account is activated.
+#dataset_gcp_project =
+
+# Limit to data of this sequencing type
+sequencing_type = 'genome'
+
+# Realign CRAM when available, instead of using FASTQ.
+# The parameter value should correspond to CRAM version
+# (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPG01234.cram
+realign_from_cram_version = 'bwamem'
+
+# Number of shards for realignment from BAM/CRAM
+realignment_shards_num = 10
+
+# Number of intervals to partition sample genotyping
+hc_intervals_num = 50
+
+# Number of intervals to partition joint calling and VQSR
+jc_intervals_num = 50
+
+# Number of intervals to partition VEP annotation
+vep_intervals_num = 50
+
+# Use GnarlyGenotyper instead of GenotypeGVCFs
+use_gnarly = false
+
+# Use allele-specific annotations for VQSR
+use_as_vqsr = true
+
+# Run CRAM QC and PED checks
+cram_qc = true
+
+# Calling intervals (defauls to whole genome intervals)
+#intervals_path =
+
+# Create Seqr ElasticSearch indices for these datasets. If not specified, will
+# create indices for all input datasets.
+#create_es_index_for_datasets =
+
+[elasticsearch]
+# Configure access to ElasticSearch server
+es_port = 9243
+es_host = 'elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com'
+es_username = 'seqr'
+# Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
+es_password_secret_id = 'seqr-es-password'
+es_password_project_id = 'seqr-308602'
+
+[hail]
+#billing_project =
+#bucket =
+pool_label = 'seqr'
+keep_scratch = true
+dry_run = false
+
+[images]
+# Docker image URLs. Can be absolute or relative to `workflow.image_registry_prefix`.
+gatk = 'gatk:4.2.6.1'
+bcftools = 'bcftools:1.10.2--h4f4756c_2'
+sm-api = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:7d00c4871b2e96f50bae208e4184c3c4789a2fa4-hail-83056327f288917537531475ba475287b413db1c'
+bwa ='bwa:v0'
+bwamem2 = 'bwamem2:v0'
+dragmap = 'dragmap:1.3.0'
+samtools = 'picard_samtools:v0'
+picard = 'picard_samtools:v0'
+picard_samtools = 'picard_samtools:v0'
+somalier = 'somalier:v0.2.15'
+peddy = 'peddy:v0'
+vep ='vep:105'
+verify-bam-id = 'verify-bam-id:1.0.1'
+multiqc = 'multiqc:v1.12'
+fastqc = 'fastqc:v0.11.9_cv8'
+hail = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:7d00c4871b2e96f50bae208e4184c3c4789a2fa4-hail-83056327f288917537531475ba475287b413db1c'
+
+[references]
+# Genome build. Only GRCh38 is currently supported.
+genome_build = 'GRCh38'
+
+# Paths to reference files. Paths can be absolute
+# or relative to the `workflow.reference_prefix` config option.
+
+# Site list for somalier https://github.com/brentp/somalier/releases/tag/v0.2.15
+somalier_sites = 'somalier/v0/sites.hg38.vcf.gz'
+# Somalier 1kg data for the "ancestry" command
+somalier_1kg_targz = 'somalier/v0/1kg.somalier.tar.gz'
+# Somalier list of 1kg samples for the "ancestry" command.
+somalier_1kg_labels = 'somalier/v0/ancestry-labels-1kg.tsv'
+# LofTee reference tarball for VEP.
+vep_loftee = 'vep/loftee_GRCh38.tar'
+# Reference tarball for VEP.
+vep = 'vep/homo_sapiens_vep_105_GRCh38.tar'
+# Contains uncompressed VEP tarballs for mounting with cloudfuse.
+vep_mount = 'vep/GRCh38'
+# To cache intervals.
+intervals_prefix = 'intervals'
+
+## The Broad references
+[references.broad]
+# Path to a copy of the Broad reference bucket
+# gs://gcp-public-data--broad-references/hg38/v0
+prefix = 'hg38/v0'
+
+# Path to DRAGMAP index (relative to braod_ref)
+dragmap_prefix = 'dragen_reference'
+ref_fasta = 'dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+# For DRAGMAP, also the following files are expected to exist in `dragen_reference`:
+#  ['hash_table.cfg.bin', 'hash_table.cmp', 'reference.bin']
+# For BWA, files with the following indices added to ref_fasta expected:
+# are expected to exist: ['sa', 'amb', 'bwt', 'ann', 'pac', 'alt']
+# Similarly, for bwamem2: ['0123', 'amb', 'bwt.2bit.64', 'ann', 'pac', 'alt']
+
+# Primary contigs BED file (relative to broad_ref)
+noalt_bed = 'sv-resources/resources/v1/primary_contigs_plus_mito.bed.gz'
+
+# Exome calling regions (relative to broad_ref)
+exome_bed = 'Homo_sapiens_assembly38.contam.exome_calling_regions.v1.bed'
+
+# Calling intervals lists (relative to broad_ref)
+genome_calling_interval_lists = 'wgs_calling_regions.hg38.interval_list'
+exome_calling_interval_lists = 'exome_calling_regions.v1.interval_list'
+genome_evaluation_interval_lists = 'wgs_evaluation_regions.hg38.interval_list'
+exome_evaluation_interval_lists = 'exome_evaluation_regions.v1.interval_list'
+genome_coverage_interval_list = 'wgs_coverage_regions.hg38.interval_list'
+unpadded_intervals = 'hg38.even.handcurated.20k.intervals'
+
+# VQSR (relative to broad_ref)
+dbsnp_vcf = 'Homo_sapiens_assembly38.dbsnp138.vcf'
+dbsnp_vcf_index = 'Homo_sapiens_assembly38.dbsnp138.vcf.idx'
+hapmap_vcf = 'hapmap_3.3.hg38.vcf.gz'
+hapmap_vcf_index = 'hapmap_3.3.hg38.vcf.gz.tbi'
+omni_vcf = '1000G_omni2.5.hg38.vcf.gz'
+omni_vcf_index = '1000G_omni2.5.hg38.vcf.gz.tbi'
+one_thousand_genomes_vcf = '1000G_phase1.snps.high_confidence.hg38.vcf.gz'
+one_thousand_genomes_vcf_index = '1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi'
+mills_vcf = 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
+mills_vcf_index = 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi'
+axiom_poly_vcf = 'Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz'
+axiom_poly_vcf_index = 'Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi'
+
+# Contamination check (relative to boad_ref):
+contam_ud =  'contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD'
+contam_bed = 'contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed'
+contam_mu =  'contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu'
+
+## GnomAD resources for Hail Query
+[references.gnomad]
+prefix = 'gnomad/v0'
+# All paths below relative to prefix.
+tel_and_cent_ht = 'telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht'
+lcr_intervals_ht = 'lcr_intervals/LCRFromHengHg38.ht'
+seg_dup_intervals_ht = 'seg_dup_intervals/GRCh38_segdups.ht'
+clinvar_ht = 'clinvar/clinvar_20190923.ht'
+hapmap_ht = 'hapmap/hapmap_3.3.hg38.ht'
+kgp_omni_ht = 'kgp/1000G_omni2.5.hg38.ht'
+kgp_hc_ht = 'kgp/1000G_phase1.snps.high_confidence.hg38.ht'
+mills_ht = 'mills/Mills_and_1000G_gold_standard.indels.hg38.ht'
+
+[references.seqr]
+prefix = 'seqr/v0-1'
+combined_reference = 'combined_reference_data_grch38-2.0.4.ht'
+clinvar = 'clinvar.GRCh38.ht'

--- a/test/input/cpg_runtime_config.toml
+++ b/test/input/cpg_runtime_config.toml
@@ -2,6 +2,7 @@
 # Access level (test, standard, full). Translates into the storage and inputs
 # namespace (test or main):
 access_level = 'standard'
+output_prefix = 'test'
 
 # Input provider type ('csv' or 'smdb' for the CPG sample-metadata database)
 input_provider = 'smdb'

--- a/test/input/cpg_runtime_config.toml
+++ b/test/input/cpg_runtime_config.toml
@@ -2,6 +2,8 @@
 # Access level (test, standard, full). Translates into the storage and inputs
 # namespace (test or main):
 access_level = 'standard'
+dataset = 'testy_McTestFace'
+dataset_path = 'testy_McTestFace'
 output_prefix = 'test'
 
 # Input provider type ('csv' or 'smdb' for the CPG sample-metadata database)


### PR DESCRIPTION
# Fixes

  - N/A

## Benefits

After @lgruen 's feature presentation, I re-implemented checkpoints in the hail query script, to segregate & resolve blocks of filter queries [details on slack](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1656035482419579?thread_ts=1656031499.504459&cid=C018KFBCR1C). Runtime of the exact same operation was improved by ~40%.

## Proposed Changes

  - implements checkpointing in the Hail process:
    1. Checkpoint after a batch of independent filters
    2. Never run `count_rows()` prior to checkpoint
    3. flip-flop the checkpoint write-path, so we can use multiple checkpoints without trying to write to the current read-path. Method used rotates the temp path extension `.mt` <-> `.mt2`
    4. follow checkpoints with re-partitions (no way to auto-repartition AFAIK, despite checkpoint implementing a read & write)
  - alteration so that instead of separating the checkpoint, repartition, and logging, all those 3 operations are in a single method. Huge reduction in the number of times `count_rows()` is called
  - also fixes one bug on main, where unaffected samples are having variants confirmed in the report
    - for all MOI tests, only process samples as 'primary' where they are affected 
  - pre-commit removed from `setup.py` - I meant to include this in #60 but I smurfed it up

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
