### PR TITLE
Corrected MT sample set check

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -712,7 +712,7 @@ def subselect_mt_to_pedigree(matrix: hl.MatrixTable, pedigree: str) -> hl.Matrix
     logging.info(f'Common Samples: {len(common_samples)}')
 
     # full overlap = no filtering
-    if common_samples == ped_samples:
+    if common_samples == matrix_samples:
         return matrix
 
     # reduce to those common samples


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

  - When subsetting the samples within the MatrixTable, I pick out the samples from the pedigree (which can be a subset of the overall cohort, see #62), pick out samples from the MT, then run a set intersection.
  - Prior to subsetting the MT, I check if the MT already contains only the subset, in which case no operation is required
  - The test as implemented was checking the wrong two objects, so the subsetting was not performed