### PR TITLE
Remove filtering of de novo by binned quality from main process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # hail logs
 hail*.log
+inputs
 
 # local run files
 reanalysis/input

--- a/cohort_prep.sh
+++ b/cohort_prep.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+COHORT=$1
+SUBSAMPLE=${2:-"80"}
+TODAY=$(date +%F)
+
+# generate the folder
+mkdir -p "inputs/$COHORT"
+
+# generate the pedigree
+python helpers/pedigree_from_sample_metadata.py \
+    --project "${COHORT}" \
+    --output "inputs/${COHORT}/${COHORT}_${TODAY}_${SUBSAMPLE}_percent" \
+    --plink --hash_threshold \
+    "${SUBSAMPLE}"

--- a/helpers/pedigree_from_sample_metadata.py
+++ b/helpers/pedigree_from_sample_metadata.py
@@ -245,11 +245,6 @@ def main(
     logging.info('pulling internal-external sample mapping')
     sample_to_cpg_dict = ext_to_int_sample_map(project=project)
 
-    # store a way of reversing this lookup in future
-    reverse_lookup = generate_reverse_lookup(sample_to_cpg_dict)
-    with open(f'{output}_reversed.json', 'w', encoding='utf-8') as handle:
-        json.dump(reverse_lookup, handle, indent=4)
-
     logging.info('updating pedigree sample IDs to internal')
     ped_with_permutations = get_ped_with_permutations(
         pedigree_dicts=pedigree_dicts,
@@ -257,6 +252,11 @@ def main(
         make_singletons=singletons,
         plink_format=plink,
     )
+
+    # store a way of reversing this lookup in future
+    reverse_lookup = generate_reverse_lookup(sample_to_cpg_dict)
+    with open(f'{output}_reversed.json', 'w', encoding='utf-8') as handle:
+        json.dump(reverse_lookup, handle, indent=4)
 
     pedigree_output_path = f'{output}_pedigree.{"fam" if plink else "ped"}'
     logging.info('writing new PED file to "%s"', pedigree_output_path)

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -291,7 +291,10 @@ def annotate_category_4(
     dn_table = hl.de_novo(
         de_novo_matrix, pedigree, pop_frequency_prior=de_novo_matrix.info.gnomad_af
     )
-    dn_table = dn_table.filter(dn_table.confidence == 'HIGH')
+
+    # removing filter here as we are currently happy with the quality of the
+    # variant calling and subsequent call-set filtering
+    # dn_table = dn_table.filter(dn_table.confidence == 'HIGH')
 
     # re-key the table by locus,alleles, removing the sampleID from the compound key
     dn_table = dn_table.key_by(dn_table.locus, dn_table.alleles)


### PR DESCRIPTION
# Fixes

  - fixes #59 

## Proposed Changes

  - based on initial testing, AIP is frequently missing de novo variants
  - running in a notebook has shown that at least 4 clear de novo calls are being flagged as 'Low Confidence' by the in-built Hail implementation of https://github.com/ksamocha/de_novo_scripts
  - Fix for now is to do no post-filtering of these calls
  - Consider feeding this back to the Hail team...

## Bundled

Includes a new script to handle the generation of cohort pedigrees. This is just a convenience script, happy to remove it

When the pedigree generation script runs, I've shuffled the method ordering. This is so that the script outputs nothing unless all data requirements are satisfied (currently able to export the lookup JSON even if the pedigree generation fails)

## Checklist

- [x] Related Issue created
- [x] Linting checks pass
