### PR TITLE
Platform independence changes

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -14,7 +14,6 @@ Categories applied here are treated as unconfirmed
 """
 
 from typing import Any
-import json
 import logging
 import sys
 from argparse import ArgumentParser
@@ -24,6 +23,8 @@ from peddy import Ped
 
 from cloudpathlib import AnyPath
 from cpg_utils.hail_batch import init_batch, output_path
+
+from reanalysis.utils import read_json_from_path
 
 
 # set some Hail constants
@@ -36,9 +37,6 @@ BENIGN = hl.str('benign')
 CONFLICTING = hl.str('conflicting')
 LOFTEE_HC = hl.str('HC')
 PATHOGENIC = hl.str('pathogenic')
-
-VCF_OUT = output_path('hail_categorised.vcf.bgz')
-TEMP_CHECKPOINT = output_path('hail_matrix.mt', 'tmp')
 
 
 def filter_matrix_by_ac(
@@ -639,7 +637,9 @@ def write_matrix_to_vcf(matrix: hl.MatrixTable, additional_header: str | None = 
     :param matrix:
     :param additional_header: file containing any other lines to add into header
     """
-    hl.export_vcf(matrix, VCF_OUT, append_to_header=additional_header, tabix=True)
+    vcf_out = output_path('hail_categorised.vcf.bgz')
+    logging.info(f'Writing categorised variants out to {vcf_out}')
+    hl.export_vcf(matrix, vcf_out, append_to_header=additional_header, tabix=True)
 
 
 def green_and_new_from_panelapp(
@@ -665,7 +665,10 @@ def green_and_new_from_panelapp(
 
 
 def checkpoint_and_repartition(
-    matrix: hl.MatrixTable, checkpoint_num: int, extra_logging: str | None = ''
+    matrix: hl.MatrixTable,
+    checkpoint_root: str,
+    checkpoint_num: int,
+    extra_logging: str | None = '',
 ) -> hl.MatrixTable:
     """
     uses an estimate of row size to inform the repartitioning of a MT
@@ -673,11 +676,12 @@ def checkpoint_and_repartition(
     Kat's thread:
     https://discuss.hail.is/t/best-way-to-repartition-heavily-filtered-matrix-tables/2140
     :param matrix:
+    :param checkpoint_root:
     :param checkpoint_num:
     :param extra_logging: any additional context
     :return: repartitioned, post-checkpoint matrix
     """
-    checkpoint_extended = f'{TEMP_CHECKPOINT}_{checkpoint_num}'
+    checkpoint_extended = f'{checkpoint_root}_{checkpoint_num}'
     logging.info(f'Checkpointing MT to {checkpoint_extended}')
     matrix = matrix.checkpoint(checkpoint_extended, overwrite=True)
 
@@ -745,16 +749,21 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
 
     # get the run configuration JSON
     logging.info(f'Reading config dict from "{config_path}"')
-    with open(AnyPath(config_path), encoding='utf-8') as handle:
-        config_dict = json.load(handle)
+    config_dict = read_json_from_path(config_path)
+
+    # get temp suffix from the config (can be None or missing)
+    tmp_suffix = config_dict.get('tmp_suffix')
+    if isinstance(tmp_suffix, str) and len(tmp_suffix) > 0:
+        checkpoint_root = output_path('hail_matrix.mt', tmp_suffix)
+    else:
+        checkpoint_root = output_path('hail_matrix.mt')
 
     # find the config area specific to hail operations
     hail_config = config_dict.get('filter')
 
     # read the parsed panelapp data
     logging.info(f'Reading PanelApp data from "{panelapp_path}"')
-    with AnyPath(panelapp_path).open() as handle:
-        panelapp = json.load(handle)
+    panelapp = read_json_from_path(panelapp_path)
 
     # pull green and new genes from the panelapp data
     green_expression, new_expression = green_and_new_from_panelapp(panelapp)
@@ -790,6 +799,7 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
 
     matrix = checkpoint_and_repartition(
         matrix,
+        checkpoint_root=checkpoint_root,
         checkpoint_num=checkpoint_number,
         extra_logging='after applying quality filters',
     )
@@ -804,6 +814,7 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
 
     matrix = checkpoint_and_repartition(
         matrix,
+        checkpoint_root=checkpoint_root,
         checkpoint_num=checkpoint_number,
         extra_logging='after applying Rare & Green-Gene filters',
     )
@@ -826,6 +837,7 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
     matrix = filter_to_categorised(matrix)
     matrix = checkpoint_and_repartition(
         matrix,
+        checkpoint_root=checkpoint_root,
         checkpoint_num=checkpoint_number,
         extra_logging='after filtering to categorised only',
     )
@@ -841,7 +853,6 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
         )
     )
 
-    logging.info(f'Write variants out to "{VCF_OUT}"')
     write_matrix_to_vcf(
         matrix=matrix, additional_header=hail_config.get('csq_header_file')
     )

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -24,7 +24,7 @@ from peddy import Ped
 from cloudpathlib import AnyPath
 from cpg_utils.hail_batch import init_batch, output_path
 
-from reanalysis.utils import read_json_from_path
+from reanalysis.utils import check_good_value, read_json_from_path
 
 
 # set some Hail constants
@@ -752,11 +752,9 @@ def main(mt_input: str, panelapp_path: str, config_path: str, plink_file: str):
     config_dict = read_json_from_path(config_path)
 
     # get temp suffix from the config (can be None or missing)
-    tmp_suffix = config_dict.get('tmp_suffix')
-    if isinstance(tmp_suffix, str) and len(tmp_suffix) > 0:
-        checkpoint_root = output_path('hail_matrix.mt', tmp_suffix)
-    else:
-        checkpoint_root = output_path('hail_matrix.mt')
+    checkpoint_root = output_path(
+        'hail_matrix.mt', check_good_value('tmp_suffix', config_dict)
+    )
 
     # find the config area specific to hail operations
     hail_config = config_dict.get('filter')

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -865,26 +865,10 @@ if __name__ == '__main__':
     )
 
     parser = ArgumentParser()
-    parser.add_argument(
-        '--mt_input',
-        required=True,
-        help='path to the matrix table to ingest',
-    )
-    parser.add_argument(
-        '--panelapp_path',
-        type=str,
-        required=True,
-        help='bucket path containing panelapp JSON',
-    )
-    parser.add_argument(
-        '--config_path',
-        type=str,
-        required=False,
-        help='If a gene list is being used as a comparison ',
-    )
-    parser.add_argument(
-        '--plink_file', type=str, required=True, help='Family Pedigree in PLINK format'
-    )
+    parser.add_argument('--mt', required=True, help='path to input MT')
+    parser.add_argument('--panelapp', type=str, required=True, help='panelapp JSON')
+    parser.add_argument('--config_path', type=str)
+    parser.add_argument('--plink', type=str, required=True, help='Cohort Pedigree')
     args = parser.parse_args()
     main(
         mt_input=args.mt_input,

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -259,7 +259,7 @@ def handle_hail_filtering(
         labelling_job, auth=True, git=True, prior_job=prior_job, memory='16Gi'
     )
     labelling_command = (
-        f'pip install peddy==0.4.8 && '
+        f'pip install . && '
         f'python3 {HAIL_FILTER} '
         f'--mt_input {ANNOTATED_MT} '
         f'--panelapp_path {PANELAPP_JSON_OUT} '

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -252,10 +252,10 @@ def handle_hail_filtering(
     labelling_command = (
         f'pip install . && '
         f'python3 {HAIL_FILTER} '
-        f'--mt_input {ANNOTATED_MT} '
-        f'--panelapp_path {PANELAPP_JSON_OUT} '
+        f'--mt {ANNOTATED_MT} '
+        f'--panelapp {PANELAPP_JSON_OUT} '
         f'--config_path {config} '
-        f'--plink_file {plink_file}'
+        f'--plink {plink_file}'
     )
 
     logging.info(f'Labelling Command: {labelling_command}')

--- a/reanalysis/reanalysis_conf.json
+++ b/reanalysis/reanalysis_conf.json
@@ -79,5 +79,7 @@
         "seqr_instance": "https://seqr.populationgenomics.org.au",
         "seqr_project": "R0011_acute_care"
     },
-    "vqsr_header_file": "gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt"
+    "vqsr_header_file": "gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt",
+    "web_suffix": "web",
+    "tmp_suffix": "tmp"
 }

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -616,3 +616,14 @@ def good_string(in_string: str) -> bool:
     if isinstance(in_string, str) and len(in_string) > 0:
         return True
     return False
+
+
+def check_good_value(key: str, conf: dict[str, Any]) -> str | None:
+    """
+    check if a key from the dictionary is a good string
+    return it or None
+    """
+    conf_value = conf.get(key)
+    if good_string(conf_value):
+        return conf_value
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.0.4
-cloudpathlib[azure,gs]==0.7.0
+cloudpathlib[all]==0.7.0
 cpg-utils==4.4.0
 cyvcf2==0.30.14
 dill==0.3.4

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'click==8.0.4',
-        'cloudpathlib[azure,gs]==0.7.0',
+        'cloudpathlib[all]==0.7.0',
         'cpg-utils==4.4.0',
         'cyvcf2==0.30.14',
         'dill==0.3.4',


### PR DESCRIPTION
# Fixes

  - partially resolves #72 

## Proposed Changes

Various changes to reduce hard-coded dependence on CPG infrastructure
  - we no longer assume the `bucket`, `bucket-tmp`, `bucket-web` structure. Instead, those suffixes are read from the config file and can be missing/empty strings, in which case the results will all be lumped into the same bucket
  - added the `web_suffix` and `tmp_suffix` keys to the config template
  - new method to read config and check for a 'good' (len > 0) string - if not returns None
  - no changes to the annotation component

## Incidental

Squashed some argparse/click descriptions to squash down the line count

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
