### PR TITLE
Compound het check

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -24,7 +24,7 @@ from peddy import Ped
 from cloudpathlib import AnyPath
 from cpg_utils.hail_batch import init_batch, output_path
 
-from reanalysis.utils import check_good_value, read_json_from_path
+from reanalysis.utils import read_json_from_path
 
 
 # set some Hail constants
@@ -750,9 +750,7 @@ def main(mt: str, panelapp: str, config_path: str, plink: str):
     config_dict = read_json_from_path(config_path)
 
     # get temp suffix from the config (can be None or missing)
-    checkpoint_root = output_path(
-        'hail_matrix.mt', check_good_value('tmp_suffix', config_dict)
-    )
+    checkpoint_root = output_path('hail_matrix.mt', config_dict.get('tmp_suffix'))
 
     # find the config area specific to hail operations
     hail_config = config_dict.get('filter')

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -750,7 +750,9 @@ def main(mt: str, panelapp: str, config_path: str, plink: str):
     config_dict = read_json_from_path(config_path)
 
     # get temp suffix from the config (can be None or missing)
-    checkpoint_root = output_path('hail_matrix.mt', config_dict.get('tmp_suffix'))
+    checkpoint_root = output_path(
+        'hail_matrix.mt', config_dict.get('tmp_suffix') or None
+    )
 
     # find the config area specific to hail operations
     hail_config = config_dict.get('filter')

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -10,7 +10,7 @@ from cloudpathlib import AnyPath
 import pandas as pd
 from peddy.peddy import Ped
 
-from reanalysis.utils import read_json_from_path, check_good_value
+from reanalysis.utils import read_json_from_path
 
 
 GNOMAD_TEMPLATE = (
@@ -143,11 +143,11 @@ class HTMLBuilder:
         self.config = read_json_from_path(config)['output']
 
         # map of internal:external IDs for translation in results (optional)
-        ext_lookup = check_good_value('external_lookup', self.config)
+        ext_lookup = self.config.get('external_lookup')
         self.external_map = read_json_from_path(ext_lookup) if ext_lookup else {}
 
         # use config to find CPG-to-Seqr ID JSON; allow to fail
-        seqr_path = check_good_value('seqr_lookup', self.config)
+        seqr_path = self.config.get('seqr_lookup')
         self.seqr = {}
 
         if seqr_path is not None:
@@ -155,8 +155,8 @@ class HTMLBuilder:
 
             # force user to correct config file if seqr URL/project are missing
             for seqr_key in ['seqr_instance', 'seqr_project']:
-                assert check_good_value(
-                    seqr_key, self.config
+                assert self.config.get(
+                    seqr_key
                 ), f'Seqr-related key required but not present: {seqr_key}'
 
         self.panelapp = read_json_from_path(panelapp_data)

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -150,7 +150,7 @@ class HTMLBuilder:
         seqr_path = self.config.get('seqr_lookup')
         self.seqr = {}
 
-        if seqr_path is not None:
+        if seqr_path:
             self.seqr = read_json_from_path(seqr_path)
 
             # force user to correct config file if seqr URL/project are missing

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -356,20 +356,22 @@ def main(
     config_dict = read_json_from_path(config_json)
 
     # create output paths with optional suffixes
-    vep_stage_tmp = output_path('vep_temp', config_dict.get('tmp_suffix'))
-    vep_ht_tmp = output_path('vep_annotations.ht', config_dict.get('tmp_suffix'))
+    vep_stage_tmp = output_path('vep_temp', config_dict.get('tmp_suffix') or None)
+    vep_ht_tmp = output_path(
+        'vep_annotations.ht', config_dict.get('tmp_suffix') or None
+    )
 
     # separate paths for familial and singleton analysis
     output_dict = {
         'default': {
             'web_html': output_path(
-                'summary_output.html', config_dict.get('web_suffix')
+                'summary_output.html', config_dict.get('web_suffix') or None
             ),
             'results': output_path('summary_results.json'),
         },
         'singletons': {
             'web_html': output_path(
-                'singleton_output.html', config_dict.get('web_suffix')
+                'singleton_output.html', config_dict.get('web_suffix') or None
             ),
             'results': output_path('singleton_results.json'),
         },

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -39,7 +39,7 @@ from cpg_utils.hail_batch import (
 )
 
 import annotation
-from utils import check_good_value, read_json_from_path, FileTypes, identify_file_type
+from utils import read_json_from_path, FileTypes, identify_file_type
 from vep.jobs import vep_jobs, SequencingType
 
 
@@ -356,21 +356,20 @@ def main(
     config_dict = read_json_from_path(config_json)
 
     # create output paths with optional suffixes
-    vep_stage_tmp = output_path('vep_temp', check_good_value('tmp_suffix', config_dict))
-    vep_ht_tmp = output_path(
-        'vep_annotations.ht', check_good_value('tmp_suffix', config_dict)
-    )
+    vep_stage_tmp = output_path('vep_temp', config_dict.get('tmp_suffix'))
+    vep_ht_tmp = output_path('vep_annotations.ht', config_dict.get('tmp_suffix'))
+
     # separate paths for familial and singleton analysis
     output_dict = {
         'default': {
             'web_html': output_path(
-                'summary_output.html', check_good_value('web_suffix', config_dict)
+                'summary_output.html', config_dict.get('web_suffix')
             ),
             'results': output_path('summary_results.json'),
         },
         'singletons': {
             'web_html': output_path(
-                'singleton_output.html', check_good_value('web_suffix', config_dict)
+                'singleton_output.html', config_dict.get('web_suffix')
             ),
             'results': output_path('singleton_results.json'),
         },

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -229,53 +229,29 @@ class BaseMoi:
         return True
 
     def check_familial_comp_het(
-        self,
-        sample_id: str,
-        called_variants_1: set[str],
-        called_variants_2: set[str],
-        partial_penetrance: bool = False,
+        self, sample_id: str, variant_1: AbstractVariant, variant_2: AbstractVariant
     ) -> bool:
         """
-        compound_het check, requires 2 pools of variant calls
-        called_variants_1 & called_variants_2 are the relevant variant calls from
-        2 different variants. We evaluate the sample as 'having this variant pair'
-        if the sample ID appears in both call groups
+        use parents to accept or dismiss the comp-het
+        If the 'comp-het' pair are inherited from a single parent, they are in cis
+        rather than trans, and reporting as a comp-het would be misleading.
 
-        - find the family ID from this sample
-        - iterate through all family members, and check that MOI holds for all
-        - this MOI test requires the participant to have both variant calls in order
-          to 'have this variant'
-
-        At each stage, append the sample ID of all checked samples so we don't repeat
-        One broken check will fail the variant for the whole family
-
-        Return False if a participant fails tests, True if all members pass
+        compound het is inherently not inherited from a single parent, so rule out
+        when either parent has both, or either parent is affected
 
         :param sample_id:
-        :param called_variants_1: called samples for variant 1
-        :param called_variants_2: called samples for variant 2
-        :param partial_penetrance: if True, allow unaffected has variant call
+        :param variant_1:
+        :param variant_2:
         :return:
         """
 
-        # iterate through family members, no interest in relationship directionality
-        for member in self.pedigree.families[self.pedigree[sample_id].family_id]:
-
-            # one value to store the check that this sample has _this_ comp-het
-            sample_comp_het = (
-                member.sample_id in called_variants_1
-                and member.sample_id in called_variants_2
-            )
-
-            # complete & incomplete penetrance - affected samples must have the variant
-            # complete pen. requires participants to be affected if they have the var
-            # if any of these combinations occur, fail the family
-            if (member.affected == PEDDY_AFFECTED and not sample_comp_het) or (
-                sample_comp_het
-                and not partial_penetrance
-                and not member.affected == PEDDY_AFFECTED
-            ):
-                # fail
+        # if both vars are present in a single parent: not a compound het
+        # or if the parent is affected: not causative
+        sample_ped_entry = self.pedigree[sample_id]
+        for parent in [sample_ped_entry.mom, sample_ped_entry.dad]:
+            if (
+                parent.sample_id in variant_1.het_samples and variant_2.het_samples
+            ) or parent.affected == PEDDY_AFFECTED:
                 return False
 
         return True
@@ -471,9 +447,8 @@ class RecessiveAutosomal(BaseMoi):
                 # check if this is a candidate for comp-het inheritance
                 if not self.check_familial_comp_het(
                     sample_id=sample_id,
-                    called_variants_1=principal_var.het_samples,
-                    called_variants_2=partner_variant.het_samples,
-                    partial_penetrance=partial_penetrance,
+                    variant_1=principal_var,
+                    variant_2=partner_variant,
                 ):
                     continue
 
@@ -692,18 +667,10 @@ class XRecessive(BaseMoi):
                 if not partner_variant.sample_specific_category_check(sample_id):
                     continue
 
-                # check if this is a candidate for comp-het inheritance
-                # get all female het calls on the paired variant
-                het_females_partner = {
-                    sam
-                    for sam in partner_variant.het_samples
-                    if self.pedigree[sample_id].sex == 'female'
-                }
                 if not self.check_familial_comp_het(
                     sample_id=sample_id,
-                    called_variants_1=principal_var.het_samples,
-                    called_variants_2=het_females_partner,
-                    partial_penetrance=partial_penetrance,
+                    variant_1=principal_var,
+                    variant_2=partner_variant,
                 ):
                     continue
 

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -4,20 +4,9 @@ One class (MoiRunner) to run all the appropriate MOIs on a variant
 
 Reduce the PanelApp plain text MOI description into a few categories
 We then run a permissive MOI match for the variant,
-e.g. if the MOI is Dominant, we may also be interested in Recessive (?)
-e.g. if the MOI is X-linked Dom, we also search X-linked Recessive (?)
-    - relevant for females, if the pedigree is loaded
-    - also depends on the accuracy of a male hemi call
-
-This will come down to clinician preference, some may exclusively
-prefer dominant model = monogenic search
 
 This model does not apply anything to MT, I expect those to default
 to a Monogenic MOI
-
-
-DOES NOT CURRENTLY CHECK PARENT GENOTYPES - MVP holds that everyone is
-a singleton
 """
 
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -609,21 +609,3 @@ def find_comp_hets(var_list: list[AbstractVariant], pedigree) -> CompHetDict:
                 ).append(var_1)
 
     return comp_het_results
-
-
-def good_string(in_string: str) -> bool:
-    """quick string check"""
-    if isinstance(in_string, str) and len(in_string) > 0:
-        return True
-    return False
-
-
-def check_good_value(key: str, conf: dict[str, Any]) -> str | None:
-    """
-    check if a key from the dictionary is a good string
-    return it or None
-    """
-    conf_value = conf.get(key)
-    if good_string(conf_value):
-        return conf_value
-    return None

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -279,12 +279,7 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
         return self.category_1_2_3_5 or self.sample_de_novo(sample_id)
 
 
-# CompHetDict structure:
-# {
-#     sample: {
-#         variant_string: [variant, ...]
-#     }
-# }
+# CompHetDict structure: {sample: {variant_string: [variant, ...]}}
 # sample: string, e,g, CGP12345
 CompHetDict = dict[str, dict[str, list[AbstractVariant]]]
 GeneDict = dict[str, list[AbstractVariant]]
@@ -404,7 +399,7 @@ def read_json_from_path(bucket_path: str) -> dict[str, Any]:
     take a path to a JSON file, read into an object
     :param bucket_path:
     """
-    with open(AnyPath(bucket_path), encoding='utf-8') as handle:
+    with AnyPath(bucket_path).open() as handle:
         return json.load(handle)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 click==8.0.4
 cloudpathlib[all]==0.9.0
 cpg-utils==4.4.0
-cyvcf2==0.30.14
+cyvcf2==0.30.15
 dill==0.3.4
-hail==0.2.93
+hail==0.2.96
 Jinja2==3.0.3
 pandas==1.3.5
 peddy==0.4.8


### PR DESCRIPTION
# Fixes

  - closes #76

## Proposed Changes

  - Compound hets just aren't heritable from one parent, so alter the logic
  - The Comp-Het test now only checks parents and rules out as plausibly causative if either parent is affected, or if one parent has both variants

## Unrelated

I was using a couple of methods to check that values exist in the config file... `dictionary.get(key)` works well enough that those methods are useless, so I've cut them out

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
