### PR TITLE
Remove ab filter, replace with flagging

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -76,6 +76,14 @@ def filter_to_well_normalised(matrix: hl.MatrixTable) -> hl.MatrixTable:
 def filter_by_ab_ratio(matrix: hl.MatrixTable) -> hl.MatrixTable:
     """
     filters HomRef, Het, and HomAlt by appropriate AB ratio bins
+
+    NOTE: This is a broken implementation, as it will replace the
+    true genotype calls with missing values. This has implications for
+    MOI testing downstream, as the corresponding genotypes in family
+    members can be absent, despite being called in the VCF
+
+    This can also cause rows in the final report to be filled with
+    only WT/missing calls, removing all actual variant calls
     :param matrix:
     """
     ab = matrix.AD[1] / hl.sum(matrix.AD)
@@ -787,7 +795,9 @@ def main(mt: str, panelapp: str, config_path: str, plink: str):
     # running global quality filter steps
     matrix = filter_matrix_by_ac(matrix=matrix)
     matrix = filter_to_well_normalised(matrix)
-    matrix = filter_by_ab_ratio(matrix)
+
+    # see method docstring, currently disabled
+    # matrix = filter_by_ab_ratio(matrix)
 
     matrix = checkpoint_and_repartition(
         matrix,

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -82,7 +82,7 @@ def filter_by_ab_ratio(matrix: hl.MatrixTable) -> hl.MatrixTable:
     MOI testing downstream, as the corresponding genotypes in family
     members can be absent, despite being called in the VCF
 
-    This can also cause rows in the final report to be filled with
+    This can also cause rows in the resulting VCF to be
     only WT/missing calls, removing all actual variant calls
     :param matrix:
     """

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -323,6 +323,9 @@ class HTMLBuilder:
                         'variant': self.make_seqr_link(
                             var_string=var_string, sample=sample
                         ),
+                        'flags': ','.join(variant['flags'])
+                        if variant['flags'] is not None
+                        else '',
                         'categories': ', '.join(
                             list(
                                 map(

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -251,7 +251,8 @@ class BaseMoi:
         sample_ped_entry = self.pedigree[sample_id]
         for parent in [sample_ped_entry.mom, sample_ped_entry.dad]:
             if (
-                parent.sample_id in variant_1.het_samples and variant_2.het_samples
+                (parent.sample_id in variant_1.het_samples)
+                and (parent.sample_id in variant_2.het_samples)
             ) or parent.affected == PEDDY_AFFECTED:
                 return False
 

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -17,6 +17,7 @@ from typing import Any
 from peddy.peddy import Ped, PHENOTYPE
 
 from reanalysis.utils import (
+    check_ab_ratio,
     AbstractVariant,
     CompHetDict,
     ReportedVariant,
@@ -340,6 +341,7 @@ class DominantAutosomal(BaseMoi):
                     var_data=principal_var,
                     reasons={self.applied_moi},
                     supported=False,
+                    flags=check_ab_ratio(principal_var, sample_id),
                 )
             )
 
@@ -420,6 +422,7 @@ class RecessiveAutosomal(BaseMoi):
                     var_data=principal_var,
                     reasons={f'{self.applied_moi} Homozygous'},
                     supported=False,
+                    flags=check_ab_ratio(principal_var, sample_id),
                 )
             )
 
@@ -452,6 +455,7 @@ class RecessiveAutosomal(BaseMoi):
                 ):
                     continue
 
+                # multiple AB tests - flag if either is relevant
                 classifications.append(
                     ReportedVariant(
                         sample=sample_id,
@@ -460,6 +464,10 @@ class RecessiveAutosomal(BaseMoi):
                         reasons={f'{self.applied_moi} Compound-Het'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
+                        flags=(
+                            check_ab_ratio(principal_var, sample_id)
+                            or check_ab_ratio(partner_variant, sample_id)
+                        ),
                     )
                 )
 
@@ -566,6 +574,7 @@ class XDominant(BaseMoi):
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
                     supported=False,
+                    flags=check_ab_ratio(principal_var, sample_id),
                 )
             )
         return classifications
@@ -682,6 +691,10 @@ class XRecessive(BaseMoi):
                         reasons={f'{self.applied_moi} Compound-Het Female'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
+                        flags=(
+                            check_ab_ratio(principal_var, sample_id)
+                            or check_ab_ratio(partner_variant, sample_id)
+                        ),
                     )
                 )
 
@@ -732,6 +745,7 @@ class XRecessive(BaseMoi):
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
                     supported=False,
+                    flags=check_ab_ratio(principal_var, sample_id),
                 )
             )
         return classifications
@@ -818,6 +832,7 @@ class YHemi(BaseMoi):
                     var_data=principal_var,
                     reasons={self.applied_moi},
                     supported=False,
+                    flags=check_ab_ratio(principal_var, sample_id),
                 )
             )
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -324,7 +324,7 @@ def check_ab_ratio(variant: AbstractVariant, sample: str) -> list[str] | None:
     variant_ab = variant.ab_ratios.get(sample, 0.0)
     if (
         (variant_ab <= 0.15)
-        or (het and (0.25 <= variant_ab <= 0.75))
+        or (het and not 0.25 <= variant_ab <= 0.75)
         or (hom and variant_ab <= 0.85)
     ):
         return ['AB Ratio']

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -173,6 +173,8 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
             if phase != PHASE_SET_DEFAULT:
                 self.phased[sample][phase] = gt
 
+        self.ab_ratios = dict(zip(samples, map(float, var.gt_alt_freqs)))
+
     def __str__(self):
         return repr(self)
 
@@ -292,6 +294,7 @@ class ReportedVariant:
     the initial variant
     the MOI passed
     the support (if any)
+    allows for the presence of flags e.g. Borderline AB ratio
     """
 
     sample: str
@@ -300,6 +303,32 @@ class ReportedVariant:
     reasons: set[str]
     supported: bool
     support_vars: list[str] | None = None
+    flags: list[str] | None = None
+
+
+def check_ab_ratio(variant: AbstractVariant, sample: str) -> list[str] | None:
+    """
+    AB ratio test for this sample's variant call. Prior ratios:
+
+    ab = matrix.AD[1] / hl.sum(matrix.AD)
+    return matrix.filter_entries(
+        (matrix.GT.is_hom_ref() & (ab <= 0.15))
+        | (matrix.GT.is_het() & (ab >= 0.25) & (ab <= 0.75))
+        | (matrix.GT.is_hom_var() & (ab >= 0.85))
+    )
+    :param variant: the variant being processed
+    :param sample: this affected individual
+    """
+    het = sample in variant.het_samples
+    hom = sample in variant.hom_samples
+    variant_ab = variant.ab_ratios.get(sample, 0.0)
+    if (
+        (variant_ab <= 0.15)
+        or (het and (0.25 <= variant_ab <= 0.75))
+        or (hom and variant_ab <= 0.85)
+    ):
+        return ['AB Ratio']
+    return None
 
 
 def canonical_contigs_from_vcf(reader) -> set[str]:


### PR DESCRIPTION
# Fixes

  - closes #77 

## Proposed Changes

  - removes the filtering out of variant ratio (AB) test failures
  - instead these variants are flagged, with the flag presenting on the final report
  - makes a spot in the ReportedVariant model for other flags we might want to add (e.g. partial penetrance, incidentalome)

## Unrelated

Slight logical tweak to fix the comp-het test (was removing all C-H variants)

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
