### PR TITLE
Skip absent parents during comp-het

### DIFF
--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -249,6 +249,10 @@ class BaseMoi:
         # or if the parent is affected: not causative
         sample_ped_entry = self.pedigree[sample_id]
         for parent in [sample_ped_entry.mom, sample_ped_entry.dad]:
+            # skip to prevent crashing on !trios
+            if parent is None:
+                continue
+
             if (
                 (parent.sample_id in variant_1.het_samples)
                 and (parent.sample_id in variant_2.het_samples)


### PR DESCRIPTION
# Fixes

  - #84

## Proposed Changes

  - When running the comp-het check, don't assume that the mother/father of the current sample will be populated
  - Note: This branch was used to run the Mito cohort

## Checklist

- [x] Related Issue created
- [x] Tests covering new change (tested as [batch](https://batch.hail.populationgenomics.org.au/batches/83639))
- [x] Linting checks pass
