### PR TITLE
translate sample ID even if not using seqr

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -283,10 +283,9 @@ class HTMLBuilder:
                     family=self.seqr[sample],
                     sample=self.external_map[sample],
                 )
-            elif sample in self.external_map:
-                sample_string = self.external_map[sample]
             else:
-                sample_string = sample
+                sample_string = self.external_map.get(sample, sample)
+
             html_lines.append(fr'<h3>Sample: {sample_string}</h3>')
             html_lines.append(table)
         html_lines.append('\n</body>')

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -283,6 +283,8 @@ class HTMLBuilder:
                     family=self.seqr[sample],
                     sample=self.external_map[sample],
                 )
+            elif sample in self.external_map:
+                sample_string = self.external_map[sample]
             else:
                 sample_string = sample
             html_lines.append(fr'<h3>Sample: {sample_string}</h3>')


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

  - The script should allow for the internal:external ID mapping to be provided & used independently of the Seqr content
  - Previous line either used both, or defaulted to showing only CPG### ID
