### PR TITLE
Remove second de novo

### DIFF
--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -278,17 +278,6 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
             sample_id in self.info[sam_cat] for sam_cat in self.sample_categories
         )
 
-    def confident_sample_de_novo(self, sample_id: str) -> bool:
-        """
-        return True if the sample is present in all sample lists
-
-        :param sample_id:
-        :return:
-        """
-        return all(
-            sample_id in self.info[sam_cat] for sam_cat in self.sample_categories
-        )
-
     def sample_specific_category_check(self, sample_id: str) -> bool:
         """
 
@@ -301,15 +290,7 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
         """
         gets all report flags for this sample
         """
-        return self.check_ab_ratio(sample) + self.check_dodgy_de_novo(sample)
-
-    def check_dodgy_de_novo(self, sample: str) -> list[str]:
-        """
-        flag if a de novo is only called by the lenient method
-        """
-        if self.sample_de_novo(sample) and not self.confident_sample_de_novo(sample):
-            return ['Dodgy de novo']
-        return []
+        return self.check_ab_ratio(sample)
 
     def check_ab_ratio(self, sample: str) -> list[str]:
         """

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -89,7 +89,7 @@ def test_class_1_assignment(values, classified, hail_matrix):
     )
 
     anno_matrix = annotate_category_1(anno_matrix)
-    assert anno_matrix.info.CategoryBoolean1.collect() == [classified]
+    assert anno_matrix.info.categoryboolean1.collect() == [classified]
 
 
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ def test_class_2_assignment(values, classified, hail_matrix):
     anno_matrix = annotate_category_2(
         anno_matrix, config=category_conf, new_genes=hl.set(['GREEN'])
     )
-    assert anno_matrix.info.CategoryBoolean2.collect() == [classified]
+    assert anno_matrix.info.categoryboolean2.collect() == [classified]
 
 
 @pytest.mark.parametrize(
@@ -184,7 +184,7 @@ def test_class_3_assignment(values, classified, hail_matrix):
     )
 
     anno_matrix = annotate_category_3(anno_matrix, config=category_conf)
-    assert anno_matrix.info.CategoryBoolean3.collect() == [classified]
+    assert anno_matrix.info.categoryboolean3.collect() == [classified]
 
 
 @pytest.mark.parametrize(
@@ -202,7 +202,7 @@ def test_category_5_assignment(spliceai_score: float, flag: int, hail_matrix):
     )
     conf = {'spliceai_full': 0.5}
     matrix = annotate_category_5(matrix, conf)
-    assert matrix.info.CategoryBoolean5.collect() == [flag]
+    assert matrix.info.categoryboolean5.collect() == [flag]
 
 
 @pytest.mark.parametrize(
@@ -255,7 +255,7 @@ def test_support_assignment(values, classified, hail_matrix):
     )
 
     anno_matrix = annotate_category_support(anno_matrix, config=category_conf)
-    assert anno_matrix.info.CategorySupport.collect() == [classified]
+    assert anno_matrix.info.categorysupport.collect() == [classified]
 
 
 def test_green_and_new_from_panelapp(panel_changes):
@@ -384,12 +384,12 @@ def test_filter_to_classified(
     """
     anno_matrix = hail_matrix.annotate_rows(
         info=hail_matrix.info.annotate(
-            CategoryBoolean1=one,
-            CategoryBoolean2=two,
-            CategoryBoolean3=three,
-            CategorySample4=four,
-            CategoryBoolean5=five,
-            CategorySupport=support,
+            categoryboolean1=one,
+            categoryboolean2=two,
+            categoryboolean3=three,
+            categorysample4=four,
+            categoryboolean5=five,
+            categorysupport=support,
         )
     )
     matrix = filter_to_categorised(anno_matrix)

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -364,21 +364,20 @@ def test_filter_to_green_genes_and_split__consequence(hail_matrix):
 
 
 @pytest.mark.parametrize(
-    'one,two,three,four,four_b,five,support,length',
+    'one,two,three,four,five,support,length',
     [
-        (0, 0, 0, 'missing', 'missing', 0, 0, 0),
-        (0, 1, 0, 'missing', 'missing', 0, 0, 1),
-        (0, 0, 1, 'missing', 'missing', 0, 0, 1),
-        (0, 0, 0, 'missing', 'missing', 0, 1, 1),
-        (0, 0, 0, 'missing', 'not_blank', 0, 0, 1),
-        (0, 0, 0, 'not_blank', 'missing', 0, 0, 1),
-        (0, 0, 0, 'missing', 'missing', 1, 0, 1),
-        (0, 1, 1, 'missing', 'missing', 0, 1, 1),
-        (1, 0, 0, 'missing', 'missing', 0, 1, 1),
+        (0, 0, 0, 'missing', 0, 0, 0),
+        (0, 1, 0, 'missing', 0, 0, 1),
+        (0, 0, 1, 'missing', 0, 0, 1),
+        (0, 0, 0, 'missing', 0, 1, 1),
+        (0, 0, 0, 'not_blank', 0, 0, 1),
+        (0, 0, 0, 'missing', 1, 0, 1),
+        (0, 1, 1, 'missing', 0, 1, 1),
+        (1, 0, 0, 'missing', 0, 1, 1),
     ],
 )
 def test_filter_to_classified(
-    one, two, three, four, four_b, five, support, length, hail_matrix
+    one, two, three, four, five, support, length, hail_matrix
 ):
     """
     :param hail_matrix:
@@ -389,7 +388,6 @@ def test_filter_to_classified(
             CategoryBoolean2=two,
             CategoryBoolean3=three,
             CategorySample4=four,
-            CategorySample4b=four_b,
             CategoryBoolean5=five,
             CategorySupport=support,
         )

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -50,7 +50,6 @@ class SimpleVariant:
     hom_samples: set[str] = field(default_factory=set)
     category_1: bool = True
     category_4: list[str] = field(default_factory=list)
-    category_4b: list[str] = field(default_factory=list)
     ab_ratios = {'nobody': 1.0}
 
     def sample_specific_category_check(self, sample):
@@ -59,9 +58,7 @@ class SimpleVariant:
         :param sample:
         :return:
         """
-        return (
-            self.category_1 or sample in self.category_4 or sample in self.category_4b
-        )
+        return self.category_1 or sample in self.category_4
 
     def get_sample_flags(self, *args, **kwargs):
         """
@@ -84,7 +81,6 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
     het_samples: set[str] = field(default_factory=set)
     hom_samples: set[str] = field(default_factory=set)
     category_4: list[str] = field(default_factory=list)
-    category_4b: list[str] = field(default_factory=list)
     # add category default
     category_1: bool = True
 
@@ -93,7 +89,7 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
         :param sample:
         :return:
         """
-        return sample in self.category_4 or sample in self.category_4b
+        return sample in self.category_4
 
     def sample_specific_category_check(self, sample):
         """
@@ -118,19 +114,11 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
             return ['AB Ratio']
         return []
 
-    def check_dodgy_de_novo(self, sample: str) -> list[str]:
-        """
-        flag if a de novo is only called by the lenient method
-        """
-        if self.sample_de_novo(sample) and sample not in self.category_4b:
-            return ['Dodgy de novo']
-        return []
-
     def get_sample_flags(self, sample: str):
         """
         gets all report flags for this sample
         """
-        return self.check_ab_ratio(sample) + self.check_dodgy_de_novo(sample)
+        return self.check_ab_ratio(sample)
 
 
 @pytest.mark.parametrize(
@@ -543,7 +531,6 @@ def test_het_de_novo_het_passes(peddy_ped):
         het_samples={'female'},
         coords=Coordinates('x', 1, 'A', 'C'),
         category_4=['female'],
-        category_4b=['female'],
         ab_ratios={'female': 0.5},
     )
     dom_a = DominantAutosomal(pedigree=peddy_ped, config=MOI_CONF)
@@ -569,7 +556,6 @@ def test_het_de_novo_het_passes_flagged(peddy_ped):
     results = dom_a.run(passing_variant)
     assert len(results) == 1
     assert results[0].reasons == {'Autosomal Dominant'}
-    assert results[0].flags == ['Dodgy de novo']
 
 
 def test_x_recessive_female_het_fails(peddy_ped):

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -48,8 +48,8 @@ class SimpleVariant:
     coords: Coordinates
     het_samples: set[str] = field(default_factory=set)
     hom_samples: set[str] = field(default_factory=set)
-    category_1: bool = True
-    category_4: list[str] = field(default_factory=list)
+    categoryboolean1: bool = True
+    categorysample4: list[str] = field(default_factory=list)
     ab_ratios = {'nobody': 1.0}
 
     def sample_specific_category_check(self, sample):
@@ -58,7 +58,7 @@ class SimpleVariant:
         :param sample:
         :return:
         """
-        return self.category_1 or sample in self.category_4
+        return self.categoryboolean1 or sample in self.categorysample4
 
     def get_sample_flags(self, *args, **kwargs):
         """
@@ -80,23 +80,23 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
     info: dict[str, Any] = field(default_factory=dict)
     het_samples: set[str] = field(default_factory=set)
     hom_samples: set[str] = field(default_factory=set)
-    category_4: list[str] = field(default_factory=list)
+    categorysample4: list[str] = field(default_factory=list)
     # add category default
-    category_1: bool = True
+    categoryboolean1: bool = True
 
     def sample_de_novo(self, sample):
         """
         :param sample:
         :return:
         """
-        return sample in self.category_4
+        return sample in self.categorysample4
 
     def sample_specific_category_check(self, sample):
         """
         :param sample:
         :return:
         """
-        return (sample in self.category_4) or self.category_1
+        return (sample in self.categorysample4) or self.categoryboolean1
 
     def check_ab_ratio(self, sample) -> list[str]:
         """
@@ -505,13 +505,13 @@ def test_x_recessive_female_het_passes(peddy_ped):
     passing_variant = RecessiveSimpleVariant(
         het_samples={'female'},
         coords=Coordinates('x', 1, 'A', 'C'),
-        category_4=['female'],
+        categorysample4=['female'],
         ab_ratios={'female': 0.5},
     )
     passing_variant_2 = RecessiveSimpleVariant(
         het_samples={'female'},
         coords=Coordinates('x', 2, 'A', 'C'),
-        category_4=['female'],
+        categorysample4=['female'],
         ab_ratios={'female': 0.5},
     )
     comp_hets = {'female': {'x-1-A-C': [passing_variant_2]}}
@@ -530,7 +530,7 @@ def test_het_de_novo_het_passes(peddy_ped):
     passing_variant = RecessiveSimpleVariant(
         het_samples={'female'},
         coords=Coordinates('x', 1, 'A', 'C'),
-        category_4=['female'],
+        categorysample4=['female'],
         ab_ratios={'female': 0.5},
     )
     dom_a = DominantAutosomal(pedigree=peddy_ped, config=MOI_CONF)
@@ -549,7 +549,7 @@ def test_het_de_novo_het_passes_flagged(peddy_ped):
     passing_variant = RecessiveSimpleVariant(
         het_samples={'female'},
         coords=Coordinates('x', 1, 'A', 'C'),
-        category_4=['female'],
+        categorysample4=['female'],
         ab_ratios={'female': 0.5},
     )
     dom_a = DominantAutosomal(pedigree=peddy_ped, config=MOI_CONF)
@@ -566,13 +566,13 @@ def test_x_recessive_female_het_fails(peddy_ped):
     passing_variant = RecessiveSimpleVariant(
         het_samples={'female'},
         coords=Coordinates('x', 1, 'A', 'C'),
-        category_4=['male'],
+        categorysample4=['male'],
         ab_ratios={'female': 0.5},
     )
     passing_variant_2 = RecessiveSimpleVariant(
         het_samples={'male'},
         coords=Coordinates('x', 2, 'A', 'C'),
-        category_4=['male'],
+        categorysample4=['male'],
         ab_ratios={'male': 0.5},
     )
     comp_hets = {'female': {'x-2-A-C': [passing_variant_2]}}


### PR DESCRIPTION
# Fixes

  - Closes #90 

## Proposed Changes

  - No longer calls the naive de novo logic when generating Category4 - this means there's no need for 4 and 4b
  - Investigation to follow on whether the need for this sub-category in the first place was the result of a fixable bug in Hail's implementation


## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
