### PR TITLE
allow for multiple panels in query

### DIFF
--- a/design_docs/Annotation.md
+++ b/design_docs/Annotation.md
@@ -24,7 +24,7 @@ Annotation is currently built around the resource bundle structure defined in [h
 This allows us to leverage the Broad's resource packaging tools, whilst allowing us the flexibility to update and alter
 data sources as & when we see fit.
 
-The annotation resource structure is currently set rigidly, using the following structure:
+The annotation resources use the following structure:
 
 ```text
 reference_location/

--- a/design_docs/MOI_Checks.md
+++ b/design_docs/MOI_Checks.md
@@ -1,19 +1,12 @@
 # MOI Checks
 
-Following the labelling and VCF re-headering, we have a heavily filtered VCF file containing all the required
-labels and annotations. Combining this information with the pedigree, we can iterate through each of the variants, and
-check if the evidence supports the PanelApp suggested Mode Of Inheritance for the corresponding gene.
-
-For each participant, we compile a list of variants where the inheritance model matches the PanelApp MOI, e.g.
+Following the category labelling stage, we have a heavily filtered VCF. Combining this information with the pedigree, we
+iterate through each variant and check if the gene's PanelApp MOI fits for any samples. For each participant, we compile
+a list of variants where the inheritance model matches the PanelApp MOI, e.g.
 
 - Variants in Monoallelic genes must pass additional population frequency filters
 - Biallelic variants must be Homozygous or supported by a 'second-hit'
 - X-Hemizygous variants must be monoallelic in males, and biallelic in females
-
-## Extensions post MVP
-
-1. Enable partially penetrant disease/affection-status
-2. Familial inheritance checks using a supplied pedigree file
 
 ---
 
@@ -207,3 +200,12 @@ which will generate a reported variant structure for the sample(s) which passed 
 
 *Note*: if multiple samples have variants at a locus, Cat. 4 is only confirmed where the sample IDs are within that Cat.
 4 list, showing that they were subject to all tests relevant to _de novo_ status.
+
+## Flags
+
+When a reportable event is found, a JSON blob representing the variant and sample is created. If the relevant gene was
+in one or more of the additional panels requested (see [additional panels](PanelApp_interaction.md#additional-panels)),
+the names/IDs of those panels are appended to the list of any variant-specific panels.
+
+This leaves us the flexibility to mark individual samples/families as having disease-relevant panels, which can then be
+cross-referenced against these flags for visual emphasis in the final report.

--- a/design_docs/PanelApp_interaction.md
+++ b/design_docs/PanelApp_interaction.md
@@ -10,17 +10,27 @@ a traffic light system:
 * Green (strong evidence linking gene to theme)
 
 For this project, we will focus analysis on a specific list of genes associated strongly with mendelian
-disease. The Gene list we will use is the [Mendeliome Gene Panel](https://panelapp.agha.umccr.org/panels/137/).
+disease, with an option to supplement this gene list with any number of additional PanelApp entries.
+The Gene list we will use as the spine of the analysis is the [Mendeliome](https://panelapp.agha.umccr.org/panels/137/).
 
 During an analysis run, the [Query Script](../reanalysis/query_panelapp.py) is used to pull down the latest data
-for the mendeliome panel (gene ENSG, symbol, and Mode of Inheritance). This is saved as a dictionary indexed on
-the ENSG
+for the Mendeliome panel (gene ENSG, symbol, and Mode of Inheritance). This is saved as a dictionary indexed on
+GRCh38/Ensembl 90 ENSG.
 
-One key use case for this application is to chart the differences in gene list(s) over time. This script provides
-two key ways to do this:
+## Additional Panels
 
-1. Provide a prior version as a command line argument. If this is done, the script will parse the Mendeliome's
-content at the indicated version. Using this as comparison data, the 'latest' data is annotated with whether the
-gene is newly green, or if the MOI has changed (new and previous both present).
-2. Provide a path to a gene list file. This will be a JSON file containing a single list of Strings. the 'latest'
-data will be annotated with `new=True` if the PanelApp gene doesn't appear in the provided gene list
+If additional gene panel IDs are requested, the following steps are followed:
+
+* the new panel's content is retrieved from PanelApp
+* the Mendeliome (base) data is updated per-gene with new content
+  * if a gene was on the mendeliome, add a `flag` with the additional panel ID/name
+  * if a gene was on the mendeliome with no MOI, and the subsequent panel contains an MOI, update the MOI
+  * if a gene was not on the mendeliome, add a new gene entry with the panel ID as a flag
+* if multiple additional panels are added, this is repeated for each (extending `flags` for each panel a gene overlaps with)
+
+## New Genes
+
+Once all required panels are merged in, the final [optional] step is to check for 'new' genes. This can be done by
+providing a gene list; a JSON file containing a single list of Strings. Each gene's entry will be annotated with
+`new=True` if the PanelApp gene doesn't appear in the provided gene list, otherwise `new` remains at the default value
+which is False.

--- a/helpers/get_untagged_incidental_genes.py
+++ b/helpers/get_untagged_incidental_genes.py
@@ -2,20 +2,15 @@
 
 
 """
-PanelApp Parser for Reanalysis project
+PanelApp Forbidden gene parser
+Targets the Incidentalome, and finds all genes
+- green
+- not tagged as cardiac
 
- Takes a panel ID
-Pulls latest 'green' content; Symbol, ENSG, and MOI
-
-Optionally user can provide a panel version number in the past
-Pull all details from the earlier version
-Annotate all discrepancies between earlier and current
-
-Optionally user can provide path to a JSON gene list
-Annotate all genes in current panel and not the gene list
-
-Write all output to a JSON dictionary
+Makes them into a JSON list of forbidden content
+(to be scrubbed out of any report)
 """
+
 import json
 import sys
 

--- a/reanalysis/get_untagged_incidental_genes.py
+++ b/reanalysis/get_untagged_incidental_genes.py
@@ -29,14 +29,15 @@ if __name__ == '__main__':
 
     problem_genes = []
     for gene in panel_json['genes']:
+        if gene['confidence_level'] != '3' or gene['entity_type'] != 'gene':
+            continue
         if gene['tags'] != ['cardiac']:
             for build, content in gene['gene_data']['ensembl_genes'].items():
                 if build.lower() == 'grch38':
                     # the ensembl version may alter over time, but will be singular
                     ensg = content[list(content.keys())[0]]['ensembl_id']
                     if not ensg:
-                        print('FAIL!')
-                        print(gene)
+                        print(f'FAIL! {gene}')
                         sys.exit(1)
                     problem_genes.append(ensg)
 

--- a/reanalysis/get_untagged_incidental_genes.py
+++ b/reanalysis/get_untagged_incidental_genes.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+
+"""
+PanelApp Parser for Reanalysis project
+
+ Takes a panel ID
+Pulls latest 'green' content; Symbol, ENSG, and MOI
+
+Optionally user can provide a panel version number in the past
+Pull all details from the earlier version
+Annotate all discrepancies between earlier and current
+
+Optionally user can provide path to a JSON gene list
+Annotate all genes in current panel and not the gene list
+
+Write all output to a JSON dictionary
+"""
+import json
+import sys
+
+import requests
+
+
+if __name__ == '__main__':
+    inci = requests.get('https://panelapp.agha.umccr.org/api/v1/panels/126')
+    inci.raise_for_status()
+    panel_json = inci.json()
+
+    problem_genes = []
+    for gene in panel_json['genes']:
+        if gene['tags'] != ['cardiac']:
+            for build, content in gene['gene_data']['ensembl_genes'].items():
+                if build.lower() == 'grch38':
+                    # the ensembl version may alter over time, but will be singular
+                    ensg = content[list(content.keys())[0]]['ensembl_id']
+                    if not ensg:
+                        print('FAIL!')
+                        print(gene)
+                        sys.exit(1)
+                    problem_genes.append(ensg)
+
+    with open('problem_genes.json', 'w', encoding='utf-8') as handle:
+        json.dump(sorted(problem_genes), handle, indent=True)

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -291,7 +291,7 @@ def annotate_category_4(
     dn_table = hl.de_novo(
         de_novo_matrix,
         pedigree,
-        pop_frequency_prior=mt.info.gnomad_af,
+        pop_frequency_prior=de_novo_matrix.info.gnomad_af,
         ignore_in_sample_allele_frequency=True,
     )
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -253,10 +253,6 @@ class HTMLBuilder:
             for key, key_list in category_count.items():
                 key_list.append(len(sample_variants[key]))
 
-        print(sample_variants)
-        print(unique_variants)
-        print(category_count)
-
         summary_dicts = [
             {
                 'Category': key,

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -195,8 +195,9 @@ class HTMLBuilder:
             sample_vars = []
             for variant in variants:
 
-                if variant['gene'] in self.forbidden_genes:
-                    continue
+                for gene_id in variant['gene'].split(','):
+                    if gene_id in self.forbidden_genes:
+                        continue
 
                 sample_vars.append(variant)
 
@@ -285,8 +286,14 @@ class HTMLBuilder:
 
         html_lines = ['<head>\n</head>\n<body>\n']
 
+        if self.forbidden_genes:
+            html_lines.append('<h3>Forbidden Gene IDs:</h3>')
+            html_lines.append(f'<h4>{", ".join(self.forbidden_genes)}</h4>')
+        else:
+            html_lines.append('<h3>No Forbidden Genes</h3>')
+
         if len(zero_categorised_samples) > 0:
-            html_lines.append(f'<h5>{", ".join(zero_categorised_samples)}</h3>')
+            html_lines.append(f'<h4>{", ".join(zero_categorised_samples)}</h3>')
         html_lines.append('<br/>')
 
         html_lines.append('<h3>Per-Category summary</h3>')

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -1,7 +1,7 @@
 """
 Methods for taking the final output and generating static report content
 """
-
+import logging
 from collections import defaultdict
 from argparse import ArgumentParser
 from typing import Any
@@ -160,6 +160,9 @@ class HTMLBuilder:
             if self.config.get('forbidden') is not None
             else set()
         )
+        print(self.forbidden_genes)
+
+        logging.warning(f'There are {len(self.forbidden_genes)} forbidden genes')
 
         # pre-filter the results to remove forbidden genes
         self.results = self.remove_forbidden_genes(read_json_from_path(results_dict))
@@ -194,8 +197,8 @@ class HTMLBuilder:
         for sample, variants in variant_dictionary.items():
             sample_vars = []
             for variant in variants:
-
                 for gene_id in variant['gene'].split(','):
+                    print(gene_id)
                     if gene_id in self.forbidden_genes:
                         continue
 
@@ -291,8 +294,10 @@ class HTMLBuilder:
             html_lines.append(f'<h4>{", ".join(self.forbidden_genes)}</h4>')
         else:
             html_lines.append('<h3>No Forbidden Genes</h3>')
+        html_lines.append('<br/>')
 
         if len(zero_categorised_samples) > 0:
+            html_lines.append('<h3>Samples with no Reportable Variants</h3>')
             html_lines.append(f'<h4>{", ".join(zero_categorised_samples)}</h3>')
         html_lines.append('<br/>')
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -251,23 +251,9 @@ class HTMLBuilder:
         """
 
         summary_table, zero_categorised_samples = self.get_summary_stats()
-        html_tables, category_2_genes = self.create_html_tables()
-        category_2_table = self.category_2_table(category_2_genes)
+        html_tables = self.create_html_tables()
 
         html_lines = ['<head>\n</head>\n<body>\n']
-
-        if category_2_table:
-            html_lines.extend(
-                [
-                    '<h3>MOI changes used for Cat.2</h3>',
-                    category_2_table,
-                    '<br/>',
-                    f'<h3>Samples without Categorised Variants '
-                    f'({len(zero_categorised_samples)})</h3>',
-                ]
-            )
-        else:
-            html_lines.append('<h3>No Cat.2 variants found</h3>')
 
         if len(zero_categorised_samples) > 0:
             html_lines.append(f'<h5>{", ".join(zero_categorised_samples)}</h3>')
@@ -311,8 +297,6 @@ class HTMLBuilder:
         candidate_dictionaries = {}
         sample_tables = {}
 
-        category_2_genes = set()
-
         for sample, variants in self.results.items():
             for variant in variants:
 
@@ -323,9 +307,6 @@ class HTMLBuilder:
                 variant_categories = category_strings(
                     variant['var_data'], sample=sample
                 )
-
-                if '2' in variant_categories:
-                    category_2_genes.update(set(variant['gene'].split(',')))
 
                 csq_string, mane_string = get_csq_details(variant)
                 candidate_dictionaries.setdefault(variant['sample'], []).append(
@@ -387,38 +368,7 @@ class HTMLBuilder:
                 index=False, render_links=True, escape=False
             )
 
-        return sample_tables, category_2_genes
-
-    def category_2_table(self, category_2_variants: set[str]) -> str:
-        """
-        takes all Cat. 2 variants, and documents relevant genes
-        cat. 2 is now 'new genes', not 'new, or altered MOI'
-        table altered to account for this changed purpose
-
-        :param category_2_variants:
-        :return:
-        """
-
-        if len(category_2_variants) == 0:
-            return ''
-
-        current_key = (
-            f'MOI in v{self.panelapp["panel_metadata"].get("current_version")}'
-        )
-
-        gene_dicts = []
-        for gene in category_2_variants:
-            gene_data = self.panelapp.get(gene)
-            gene_dicts.append(
-                {
-                    'gene': gene,
-                    'symbol': PANELAPP_TEMPLATE.format(symbol=gene_data.get('symbol')),
-                    current_key: gene_data.get('moi'),
-                }
-            )
-        return pd.DataFrame(gene_dicts).to_html(
-            index=False, render_links=True, escape=False
-        )
+        return sample_tables
 
     def make_seqr_link(self, var_string: str, sample: str) -> str:
         """

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -206,7 +206,6 @@ class HTMLBuilder:
             # iterate over the list of variants
             for variant in variants:
                 var_string = make_coord_string(variant['var_data']['coords'])
-                category_count['any'].add(var_string)
 
                 # find all categories associated with this variant
                 # for each category, add to corresponding list and set

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -48,7 +48,7 @@ def make_coord_string(var_coord: dict[str, str]) -> str:
     make a quick string representation from vardata
     """
     return (
-        f'{var_coord["chrom"]}:{var_coord["pos"]} {var_coord["ref"]}>{var_coord["alt"]}'
+        f'{var_coord["chrom"]}-{var_coord["pos"]}-{var_coord["ref"]}-{var_coord["alt"]}'
     )
 
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -184,7 +184,6 @@ class HTMLBuilder:
         """
 
         category_count = {key: [] for key in CATEGORY_ORDERING}
-        category_count['any'] = set()
 
         unique_variants = defaultdict(set)
 
@@ -197,10 +196,7 @@ class HTMLBuilder:
 
                 # update all indices; 0 variants for this sample
                 for category_list in category_count.values():
-                    if isinstance(category_list, list):
-                        category_list.append(0)
-                    else:
-                        category_list.add(0)
+                    category_list.append(0)
 
                 continue
 
@@ -224,6 +220,8 @@ class HTMLBuilder:
 
                 # update the set of all unique variants
                 unique_variants['any'].add(var_string)
+
+            category_count['any'].append(len(unique_variants['any']))
 
             # update the global lists with per-sample counts
             for key, key_list in category_count.items():

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -197,7 +197,11 @@ class HTMLBuilder:
 
                 # update all indices; 0 variants for this sample
                 for category_list in category_count.values():
-                    category_list.append(0)
+                    if isinstance(category_list, list):
+                        category_list.append(0)
+                    else:
+                        category_list.add(0)
+
                 continue
 
             # create a per-sample object to track variants for each category

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -194,16 +194,10 @@ class HTMLBuilder:
         for sample, variants in variant_dictionary.items():
             sample_vars = []
             for variant in variants:
-                # purge any variants where a forbidden gene consequence is seen
-                if any(
-                    {
-                        tx_con['symbol'] in self.forbidden_genes
-                        for tx_con in variant['var_data']['info'][
-                            'transcript_consequences'
-                        ]
-                    }
-                ):
+
+                if variant['gene'] in self.forbidden_genes:
                     continue
+
                 sample_vars.append(variant)
 
             # add any retained variants to the new per-sample list

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -505,7 +505,7 @@ def main(
     batch.run(wait=False)
 
     # save the json file into the batch output, with latest run details
-    with AnyPath(output_path('latest_config.json')).open() as handle:
+    with AnyPath(output_path('latest_config.json')).open('w') as handle:
         json.dump(config_dict, handle)
 
     # write pedigree content to the output folder

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -215,7 +215,7 @@ def handle_panelapp_job(
     if gene_list is not None:
         panelapp_command += f'--gene_list {gene_list} '
     if extra_panel is not None and len(extra_panel) != 0:
-        panelapp_command += f'--panel_id {" ".join(extra_panel)} '
+        panelapp_command += f'-p {" ".join(extra_panel)} '
 
     if prior_job is not None:
         panelapp_job.depends_on(prior_job)

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -4,9 +4,7 @@
 """
 PanelApp Parser for Reanalysis project
 
-runs an optional click interface
-
-Takes a panel ID
+ Takes a panel ID
 Pulls latest 'green' content; Symbol, ENSG, and MOI
 
 Optionally user can provide a panel version number in the past
@@ -31,7 +29,9 @@ import requests
 from cloudpathlib import AnyPath
 
 
-PanelData = dict[str, dict[str, Union[str, bool]]]
+MENDELIOME = '137'
+PANELAPP_BASE = 'https://panelapp.agha.umccr.org/api/v1/panels/'
+PanelData = dict[str, dict[str, Union[str, bool, list[str]]]]
 
 
 def parse_gene_list(path_to_list: str) -> set[str]:
@@ -60,36 +60,31 @@ def get_json_response(url: str) -> dict[str, Any]:
     return response.json()
 
 
-def get_panel_green(
-    panel_id: str = '137',
-    version: str | None = None,
-) -> dict[str, dict[str, Union[str, bool]]]:
+def get_panel_green(panel_id: str) -> dict[str, dict[str, Union[str, bool]]]:
     """
     Takes a panel number, and pulls all GRCh38 gene details from PanelApp
     For each gene, keep the MOI, symbol, ENSG (where present)
 
     :param panel_id: defaults to the PanelAppAU Mendeliome
-    :param version: optional, where specified the version is added to the query
     """
 
     # prepare the query URL
-    panel_app_genes_url = f'https://panelapp.agha.umccr.org/api/v1/panels/{panel_id}'
-    if version is not None:
-        panel_app_genes_url += f'?version={version}'
-
+    panel_app_genes_url = f'{PANELAPP_BASE}{panel_id}'
     panel_response = requests.get(panel_app_genes_url)
     panel_response.raise_for_status()
     panel_json = panel_response.json()
 
     panel_version = panel_json.get('version')
+    panel_name = panel_json.get('name')
 
     # pop the version in logging if not manually defined
-    if version is None:
-        logging.info(
-            f'Current panel version: {panel_version}',
-        )
+    logging.info(
+        f'Current {panel_name} panel version: {panel_version}',
+    )
 
-    gene_dict = {'panel_metadata': {'current_version': panel_version}}
+    gene_dict = {
+        'panel_metadata': {'current_version': panel_version, 'panel_name': panel_name}
+    }
 
     for gene in panel_json['genes']:
 
@@ -122,50 +117,10 @@ def get_panel_green(
             'new': False,
             'changed': False,
             'old_moi': None,
+            'flags': [],
         }
 
     return gene_dict
-
-
-def get_panel_changes(
-    previous_version: str,
-    panel_id: str,
-    latest_content: PanelData,
-):
-    """
-    take the latest panel content, and compare with a previous version
-    update content in original dict where appropriate
-    https://panelapp.agha.umccr.org/api/v1/panels/137/?version=0.10952
-
-    :param previous_version:
-    :param panel_id:
-    :param latest_content:
-    :return: None, updates object in place
-    """
-
-    # get the full content for the specified panel version
-    previous_content = get_panel_green(panel_id=panel_id, version=previous_version)
-
-    # iterate over the latest content,skipping over the metadata keys
-    for gene_ensg in [
-        ensg for ensg in latest_content.keys() if ensg != 'panel_metadata'
-    ]:
-
-        value = latest_content[gene_ensg]
-
-        # if the gene wasn't present before, take it in full
-        if gene_ensg not in previous_content:
-            latest_content[gene_ensg]['new'] = True
-
-        # otherwise check if the MOI has changed
-        else:
-            prev_moi = previous_content.get(gene_ensg).get('moi')
-            latest_moi = value.get('moi')
-
-            # if so, store the old and new MOI
-            if prev_moi != latest_moi:
-                latest_content[gene_ensg]['changed'] = True
-                latest_content[gene_ensg]['old_moi'] = prev_moi
 
 
 def gene_list_differences(latest_content: PanelData, previous_genes: set[str]):
@@ -206,22 +161,50 @@ def write_output_json(output_path: str, object_to_write: Any):
         json.dump(object_to_write, fh, indent=4, default=str)
 
 
-def main(
-    panel_id: str,
-    out_path: str,
-    previous_version: str | None,
-    gene_list: str | None,
-):
+def combine_mendeliome_with_other_panels(panel_dict: PanelData, additional: PanelData):
     """
-    takes a panel ID
-    finds all latest panel data from the API
+    takes the main panel data and an additional panel dict
+
+    :param panel_dict:
+    :param additional:
+    """
+
+    additional_name = additional['panel_metadata']['panel_name']
+    panel_keys = panel_dict.keys()
+    for ensg in additional.keys():
+        if ensg == 'panel_metadata':
+            continue
+
+        if ensg in panel_keys:
+            # update MOI if None
+            if panel_dict[ensg]['moi'] is None:
+                panel_dict[ensg]['moi'] = additional[ensg].get('moi', None)
+
+            panel_dict[ensg]['flags'].append(additional_name)
+        else:
+            panel_dict[ensg] = {
+                'symbol': additional[ensg].get('entity_name'),
+                'moi': additional[ensg].get('moi', None),
+                'new': False,
+                'changed': False,
+                'old_moi': None,
+                'flags': [additional_name],
+            }
+
+
+def main(additional_panels: list[str], out_path: str, gene_list: str | None):
+    """
+    Base assumption here is that we are always using the Mendeliome
+    Optionally, additional panel IDs can be specified to expand the gene list
+
+    Finds all latest panel data from the API
     optionally take a prior version argument, records all panel differences
         - new genes
         - altered MOI
     optionally take a reference to a JSON gene list, records all genes:
         - green in current panelapp
         - absent in provided gene list
-    :param panel_id:
+    :param additional_panels: op
     :param out_path: path to write a JSON object out to
     :param previous_version: prior panel version to compare to
     :param gene_list: alternative to prior data, give a strict gene list file
@@ -229,29 +212,22 @@ def main(
     """
 
     logging.info('Starting PanelApp Query Stage')
-    if gene_list is not None and previous_version is not None:
-        raise ValueError('Only one of [Date/GeneList] can be specified per run')
 
-    # get latest panel data
-    panel_dict = get_panel_green(panel_id=panel_id)
+    # get latest Mendeliome data
+    panel_dict = get_panel_green(panel_id=MENDELIOME)
+
+    if additional_panels:
+        for additional_panel_id in additional_panels:
+            ad_panel = get_panel_green(panel_id=additional_panel_id)
+            combine_mendeliome_with_other_panels(
+                panel_dict=panel_dict, additional=ad_panel
+            )
 
     if gene_list is not None:
         logging.info(f'A Gene_List was selected: {gene_list}')
         gene_list_contents = parse_gene_list(gene_list)
         logging.info(f'Length of gene list: {len(gene_list_contents)}')
         gene_list_differences(panel_dict, gene_list_contents)
-
-    # migrate more of this into a method to test
-    if previous_version is not None:
-        # only continue if the versions are different
-        if previous_version != panel_dict['panel_metadata'].get('current_version'):
-            logging.info(f'Previous panel version: {previous_version}')
-            panel_dict['panel_metadata']['previous_version'] = previous_version
-            get_panel_changes(
-                previous_version=previous_version,
-                panel_id=panel_id,
-                latest_content=panel_dict,
-            )
 
     write_output_json(output_path=out_path, object_to_write=panel_dict)
 
@@ -266,20 +242,14 @@ if __name__ == '__main__':
 
     parser = ArgumentParser()
     parser.add_argument(
-        '--panel_id',
-        default='137',
+        '-p',
+        '--additional_panels',
+        nargs='+',
         required=False,
-        type=str,
-        help='The Mendeliome panel number to use',
+        help='Panelapp IDs of any additional panels to query for',
     )
     parser.add_argument(
         '--out_path', type=str, required=True, help='Path to write output JSON to'
-    )
-    parser.add_argument(
-        '--previous_version',
-        type=str,
-        required=False,
-        help='If a prior Mendeliome panel version is being used as a comparison point',
     )
     parser.add_argument(
         '--gene_list',
@@ -289,8 +259,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
     main(
-        panel_id=args.panel_id,
+        additional_panels=args.additional_panels,
         out_path=args.out_path,
-        previous_version=args.previous_version,
         gene_list=args.gene_list,
     )

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -206,7 +206,6 @@ def main(additional_panels: list[str], out_path: str, gene_list: str | None):
         - absent in provided gene list
     :param additional_panels: op
     :param out_path: path to write a JSON object out to
-    :param previous_version: prior panel version to compare to
     :param gene_list: alternative to prior data, give a strict gene list file
     :return:
     """
@@ -243,7 +242,6 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument(
         '-p',
-        '--additional_panels',
         nargs='+',
         required=False,
         help='Panelapp IDs of any additional panels to query for',
@@ -259,7 +257,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
     main(
-        additional_panels=args.additional_panels,
+        additional_panels=args.p,
         out_path=args.out_path,
         gene_list=args.gene_list,
     )

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -148,7 +148,7 @@ def write_output_json(output_path: str, object_to_write: Any):
     AnyPath provides platform abstraction
 
     :param output_path:
-    :param object_to_write:=
+    :param object_to_write:
     """
 
     logging.info(f'Writing output JSON file to {output_path}')

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -179,11 +179,11 @@ def combine_mendeliome_with_other_panels(panel_dict: PanelData, additional: Pane
             # update MOI if None
             if panel_dict[ensg]['moi'] is None:
                 panel_dict[ensg]['moi'] = additional[ensg].get('moi', None)
-
             panel_dict[ensg]['flags'].append(additional_name)
+
         else:
             panel_dict[ensg] = {
-                'symbol': additional[ensg].get('entity_name'),
+                'symbol': additional[ensg].get('symbol'),
                 'moi': additional[ensg].get('moi', None),
                 'new': False,
                 'changed': False,

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -468,7 +468,7 @@ def gather_gene_dict_from_contig(
                 continue
 
             if not gene_data.get('new', False):
-                variant.info['categoryboolean2'] = False
+                abs_var.info['categoryboolean2'] = False
 
         # if unclassified, skip the whole variant
         if not abs_var.is_classified:

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -378,7 +378,7 @@ class ReportedVariant:
 
     def __eq__(self, other):
         """
-        makes reported variants comparable?
+        makes reported variants comparable
         """
         self_supvar = set() if self.support_vars is None else set(self.support_vars)
         other_supvar = set() if other.support_vars is None else set(other.support_vars)
@@ -388,6 +388,9 @@ class ReportedVariant:
             and self.supported == other.supported
             and self_supvar == other_supvar
         )
+
+    def __lt__(self, other):
+        return self.var_data.coords < other.var_data.coords
 
 
 def canonical_contigs_from_vcf(reader) -> set[str]:

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -29,6 +29,13 @@ HOMALT: int = 3
 BAD_GENOTYPES: set[int] = {HOMREF, UNKNOWN}
 
 PHASE_SET_DEFAULT = -2147483648
+CHROM_ORDER = list(map(str, range(1, 23))) + [
+    'X',
+    'Y',
+    'MT',
+    'M',
+]
+
 X_CHROMOSOME = {'X'}
 NON_HOM_CHROM = {'Y', 'MT', 'M'}
 
@@ -90,6 +97,29 @@ class Coordinates:
         chr-pos-ref-alt
         """
         return f'{self.chrom}-{self.pos}-{self.ref}-{self.alt}'
+
+    def __lt__(self, other):
+        """
+        positional sorting
+        """
+        # this will return False for same chrom and position
+        if self.chrom == other.chrom:
+            return self.pos < other.pos
+        # otherwise take the relative index from sorted chromosomes list
+        if self.chrom in CHROM_ORDER and other.chrom in CHROM_ORDER:
+            return CHROM_ORDER.index(self.chrom) < CHROM_ORDER.index(other.chrom)
+        # if self is on a canonical chromosome, sort before HLA/Decoy etc.
+        if self.chrom in CHROM_ORDER:
+            return True
+        return False
+
+    def __eq__(self, other):
+        return (
+            self.chrom == other.chrom
+            and self.pos == other.pos
+            and self.ref == other.ref
+            and self.alt == other.alt
+        )
 
 
 def get_phase_data(samples, var) -> dict[str, dict[int, str]]:
@@ -199,6 +229,12 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
 
     def __str__(self):
         return repr(self)
+
+    def __lt__(self, other):
+        return self.coords < other.coords
+
+    def __eq__(self, other):
+        return self.coords == other.coords
 
     @property
     def has_boolean_categories(self) -> bool:
@@ -344,10 +380,13 @@ class ReportedVariant:
         """
         makes reported variants comparable?
         """
+        self_supvar = set() if self.support_vars is None else set(self.support_vars)
+        other_supvar = set() if other.support_vars is None else set(other.support_vars)
         return (
-            self.var_data.coords.string_format == other.var_data.coords.string_format
+            self.sample == other.sample
+            and self.var_data.coords == other.var_data.coords
             and self.supported == other.supported
-            and self.support_vars == other.support_vars
+            and self_supvar == other_supvar
         )
 
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -340,6 +340,16 @@ class ReportedVariant:
     support_vars: list[str] | None = None
     flags: list[str] | None = None
 
+    def __eq__(self, other):
+        """
+        makes reported variants comparable?
+        """
+        return (
+            self.var_data.coords.string_format == other.var_data.coords.string_format
+            and self.supported == other.supported
+            and self.support_vars == other.support_vars
+        )
+
 
 def canonical_contigs_from_vcf(reader) -> set[str]:
     """

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -178,6 +178,10 @@ def clean_initial_results(
             prev_event.flags.extend(each_event.flags)
             prev_event.flags = list(set(prev_event.flags))
 
+    # organise the variants by chromosomal location
+    for sample in clean_results:
+        clean_results[sample].sort()
+
     # Empty list for 0 variant samples with affected status
     # explicitly record samples checked in this analysis
     # the PED could have more samples than a joint call, due to sub-setting or QC.

--- a/test/input/incidentalome.json
+++ b/test/input/incidentalome.json
@@ -1,0 +1,24 @@
+{
+  "id": 126,
+  "name": "Incidentalome",
+  "status": "public",
+  "version": "0.12345",
+  "version_created": "2022-03-01T20:33:56.901400Z",
+  "genes": [
+    {
+      "gene_data": {
+        "ensembl_genes": {
+          "GRch38": {
+            "90": {
+              "ensembl_id": "ENSG00ABCD"
+            }
+          }
+        }
+      },
+      "entity_type": "gene",
+      "entity_name": "ABCD",
+      "confidence_level": "3",
+      "mode_of_inheritance": "REALLY_BIG"
+    }
+  ]
+}

--- a/test/input/panel_changes_expected.json
+++ b/test/input/panel_changes_expected.json
@@ -7,20 +7,23 @@
   "moi": "BIALLELIC",
   "new": false,
   "changed": true,
-  "old_moi": "MONOALLELIC"
+  "old_moi": "MONOALLELIC",
+  "flags": []
  },
  "ENSG00EFGH": {
   "symbol": "EFGH",
   "moi": "MONOALLELIC",
   "new": true,
   "changed": false,
-  "old_moi": null
+  "old_moi": null,
+  "flags": []
  },
  "ENSG00IJKL": {
   "symbol": "IJKL",
   "moi": "BOTH",
   "new": false,
   "changed": false,
-  "old_moi": null
+  "old_moi": null,
+  "flags": []
  }
 }

--- a/test/input/panel_green_latest_expected.json
+++ b/test/input/panel_green_latest_expected.json
@@ -1,26 +1,30 @@
 {
  "panel_metadata": {
-  "current_version": "0.11088"
+  "current_version": "0.11088",
+  "panel_name": "Mendeliome"
  },
  "ENSG00ABCD": {
   "symbol": "ABCD",
   "moi": "BIALLELIC",
   "new": false,
   "changed": false,
-  "old_moi": null
+  "old_moi": null,
+  "flags": []
  },
  "ENSG00EFGH": {
   "symbol": "EFGH",
   "moi": "MONOALLELIC",
   "new": false,
   "changed": false,
-  "old_moi": null
+  "old_moi": null,
+  "flags": []
  },
  "ENSG00IJKL": {
   "symbol": "IJKL",
   "moi": "BOTH",
   "new": false,
   "changed": false,
-  "old_moi": null
+  "old_moi": null,
+  "flags": []
  }
 }

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -128,7 +128,7 @@ def test_second_panel_update_moi():
     }
     combine_mendeliome_with_other_panels(main, additional)
     assert main['ensg1'].get('flags') == ['NAME']
-    assert main['ensg1'].get('moi') == ['REALLY_BIG']
+    assert main['ensg1'].get('moi') == 'REALLY_BIG'
 
 
 def test_second_panel_no_overlap():

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -4,20 +4,21 @@ tests for the PanelApp parser
 
 import json
 import os
-
 import pytest
 
 from reanalysis.query_panelapp import (
     gene_list_differences,
     get_json_response,
     get_panel_green,
-    get_panel_changes,
     parse_gene_list,
+    combine_mendeliome_with_other_panels,
 )
+
 
 PWD = os.path.dirname(__file__)
 INPUT = os.path.join(PWD, 'input')
 PANELAPP_LATEST = os.path.join(INPUT, 'panelapp_current_137.json')
+PANELAPP_INCIDENTALOME = os.path.join(INPUT, 'incidentalome.json')
 PANELAPP_OLDER = os.path.join(INPUT, 'panelapp_older_137.json')
 LATEST_EXPECTED = os.path.join(INPUT, 'panel_green_latest_expected.json')
 CHANGES_EXPECTED = os.path.join(INPUT, 'panel_changes_expected.json')
@@ -36,6 +37,12 @@ def fixture_fake_panelapp(requests_mock):
         requests_mock.register_uri(
             'GET',
             'https://panelapp.agha.umccr.org/api/v1/panels/137',
+            json=json.load(handle),
+        )
+    with open(PANELAPP_INCIDENTALOME, 'r', encoding='utf-8') as handle:
+        requests_mock.register_uri(
+            'GET',
+            'https://panelapp.agha.umccr.org/api/v1/panels/126',
             json=json.load(handle),
         )
     with open(PANELAPP_OLDER, 'r', encoding='utf-8') as handle:
@@ -74,22 +81,6 @@ def test_gene_list_changes():
     assert latest['ENSG00IJKL']['new']
 
 
-def test_get_panel_changes(fake_panelapp):  # pylint: disable=unused-argument
-    """
-
-    :param fake_panelapp:
-    :return:
-    """
-    with open(LATEST_EXPECTED, 'r', encoding='utf-8') as handle:
-        latest = json.load(handle)
-
-    get_panel_changes(
-        previous_version=OLD_VERSION, panel_id='137', latest_content=latest
-    )
-    with open(CHANGES_EXPECTED, 'r', encoding='utf-8') as handle2:
-        assert latest == json.load(handle2)
-
-
 def test_get_json_response(fake_panelapp):  # pylint: disable=unused-argument
     """
     read the json content via an API call
@@ -108,3 +99,53 @@ def test_parse_local_gene_list():
     """
     found_genes = parse_gene_list(FAKE_GENE_LIST)
     assert found_genes == {'foo bar', 'foo', 'bar'}
+
+
+def test_second_panel_update(fake_panelapp):  # pylint: disable=unused-argument
+    """
+    check that the combination method works
+    """
+    main = get_panel_green('137')
+    early_keys = set(main.keys())
+    additional = get_panel_green('126')
+    combine_mendeliome_with_other_panels(main, additional)
+    assert set(main.keys()) == early_keys
+    assert main['ENSG00ABCD'].get('flags') == ['Incidentalome']
+
+
+def test_second_panel_update_moi():
+    """
+    panels overlap with MOI in second panel
+    - expect overwriting of MOI
+    """
+    main = {
+        'panel_metadata': {'panel_name': 'NAME'},
+        'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
+    }
+    additional = {
+        'panel_metadata': {'panel_name': 'NAME'},
+        'ensg1': {'entity_name': '1', 'moi': 'REALLY_BIG'},
+    }
+    combine_mendeliome_with_other_panels(main, additional)
+    assert main['ensg1'].get('flags') == ['NAME']
+    assert main['ensg1'].get('moi') == ['REALLY_BIG']
+
+
+def test_second_panel_no_overlap():
+    """
+    two panels don't overlap
+    - expect both results
+    """
+    main = {
+        'panel_metadata': {'panel_name': 'NAME'},
+        'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
+    }
+    additional = {
+        'panel_metadata': {'panel_name': 'NAME'},
+        'ensg2': {'entity_name': '2', 'moi': 'REALLY_BIG'},
+    }
+    combine_mendeliome_with_other_panels(main, additional)
+    assert main['ensg1'].get('flags') == []
+    assert main['ensg1'].get('moi') is None
+    assert main['ensg2'].get('flags') == ['NAME']
+    assert main['ensg2'].get('moi') == 'REALLY_BIG'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 """
 test class for the utils collection
 """
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import List
 import pytest
@@ -53,14 +54,14 @@ def test_reported_variant_ordering(trio_abs_variant):
     report_1 = ReportedVariant(
         sample='1',
         gene='2',
-        var_data=trio_abs_variant,
+        var_data=deepcopy(trio_abs_variant),
         reasons={'test'},
         supported=False,
     )
     report_2 = ReportedVariant(
         sample='1',
         gene='2',
-        var_data=trio_abs_variant,
+        var_data=deepcopy(trio_abs_variant),
         reasons={'test'},
         supported=False,
     )
@@ -73,6 +74,10 @@ def test_reported_variant_ordering(trio_abs_variant):
     # alter sample ID, expected mismatch
     report_1.sample = '2'
     assert report_1 != report_2
+    report_2.sample = '2'
+    report_1.var_data.coords.chrom = '1'
+    report_2.var_data.coords.chrom = '11'
+    assert report_1 < report_2
 
 
 def test_file_types():


### PR DESCRIPTION
# Fixes

  - closes #46
  - closes #93

## Proposed Changes

  - when the analysis is triggered some runtime details are recorded in a JSON file and written to the output folder (file used as input, whether it was a MT converted to VCF, whether annotation was re-run, panelapp file used...). Pedigree file(s) are also copied to the output directory
  - A lot of work around making the custom objects comparable (__eq__ and __lt__ methods) so that we can sort coordinates, AbstractVariants and Report objects
  - Removes a layer of indexing in the output dict which is no longer required (due to variants being directly comparable)
  - additional argument(s) are forwarded to the panelapp query to combine more other panels with the standard mendeliome data (relevant docs to be updated)
    - if the additional panel contains a non-mendeliome gene it is added to the panel data
    - if the mendeliome and additional panel overlap:
      - if MOI is present only on the non-mendeliome panel the MOI is updated
      - the gene entry's `flags` is updated to contain the extra panel's name
  - all logic to determine `new genes` from two versions of the panel are discarded - now the only way of determining new is against a gene list (logic can be retrieved from git history)
  - if a gene is on one of the supplemental supplied panels, there is a `flag` added to the panelapp data with the name of non-mendeliome panel(s)
  - when reportable variants are found, the pre-existing `flags` field is updated to show the name of any additional panels it's in (as well as any applicable QC flags, like AB ratio)
  - Report now includes a list of Forbidden genes which were scrubbed back out of the report

## Note: 

The relevant documentation for all of this needs to be updated to reflect changed functionality (once the design is settled)

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
