### PR TITLE
remove middle index from report json (and extend same to tests)

### DIFF
--- a/comparison/comparison.py
+++ b/comparison/comparison.py
@@ -166,7 +166,7 @@ def common_format_from_results(results_dict: dict[str, Any]) -> CommonDict:
     # collect all per-sample results into a separate index
     for sample, variants in results_dict.items():
 
-        for var in variants.values():
+        for var in variants:
             coords = var['var_data']['coords']
             sample_dict[sample].append(
                 CommonFormatResult(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.0.4
 cloudpathlib[all]==0.9.0
-cpg-utils==4.4.0
+cpg-utils==4.4.4
 cyvcf2==0.30.15
 dill==0.3.4
 hail==0.2.96
@@ -8,5 +8,5 @@ Jinja2==3.0.3
 pandas==1.3.5
 peddy==0.4.8
 requests==2.25.1
-sample-metadata==4.10.0
+sample-metadata==4.14.0
 seqr-loader==1.2.5

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,14 @@ setup(
         'full': [
             'click==8.0.4',
             'cloudpathlib[all]==0.9.0',
-            'cpg-utils==4.4.3',
+            'cpg-utils==4.4.4',
             'dill==0.3.5.1',
             'hail==0.2.96',
             'Jinja2==3.0.3',
             'pandas==1.4.3',
             'peddy==0.4.8',
             'requests==2.25.1',
-            'sample-metadata==4.13.0',
+            'sample-metadata==4.14.0',
             'seqr-loader==1.2.5',
         ],
         'test': [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,7 @@ def fixture_hail_matrix():
     loads the single variant as a matrix table
     :return:
     """
-    mt = hl.import_vcf(HAIL_VCF, reference_genome='GRCh38')
-    return mt.key_rows_by(mt.locus)
+    return hl.import_vcf(HAIL_VCF, reference_genome='GRCh38')
 
 
 @pytest.fixture(name='single_variant_vcf_path')

--- a/test/input/aip_output_example.json
+++ b/test/input/aip_output_example.json
@@ -1,6 +1,6 @@
 {
-    "SAMPLE_1": {
-        "7-93105286-T-A__ENSG00000205413__Unsupported": {
+    "SAMPLE_1": [
+        {
             "sample": "SAMPLE_1",
             "gene": "ENSG00000205413",
             "var_data": {
@@ -63,7 +63,8 @@
                 "Autosomal Dominant"
             ],
             "supported": false,
-            "support_vars": null
+            "support_vars": null,
+            "flags": []
         }
-    }
+    ]
 }

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -371,7 +371,7 @@ def test_variant_is_normalised(
     :param hail_matrix:
     :return:
     """
-    anno_mt = hail_matrix.annotate_rows(alleles=alleles)
+    anno_mt = hail_matrix.key_rows_by(hail_matrix.locus).annotate_rows(alleles=alleles)
     assert check_variant_was_normalised(anno_mt) == results
 
 


### PR DESCRIPTION
# Fixes

  - closes #86 

## Proposed Changes

  - middle-index was already removed by an earlier commit
  - this changes the corresponding test fixtures and comparison process to adapt to that

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
