### PR TITLE
Comparison update

### DIFF
--- a/comparison/README.md
+++ b/comparison/README.md
@@ -60,12 +60,12 @@ results = {
 }
 ```
 
-In addition, we require a number of other input files from the AIP run being analysed:
+The majority of the input files (AIP outputs, AIP labelled VCF, PanelApp data, config file, pedigree) are located
+relative to the root run folder, so running via the wrapper is simple. The 3 arguments when using the wrapper are:
 
-- PanelApp Data
-- VCF produced by the labelling process
-- MT used to derive labelled variants from
-- Configuration used
+- Seqr Tags CSV
+- MT used as input for AIP run
+- AIP analysis folder
 
 ---
 
@@ -78,6 +78,7 @@ of the Category 1 filter criteria was failed`.
 
 1. Parse both AIP and external results into a common format
 2. Compare AIP + Ext. data, find `True Positives` and discrepancies
+   - At this point the top-line results are logged to GCP in JSON format
 3. For each Discrepancy:
 
 ![ComparisonTree](../design_docs/images/comparison_decision_tree.png)
@@ -96,7 +97,6 @@ reasons = [
    'Cat. 1: Clinvar Stars: 1',
    'Cat. 2: Gene not new in PanelApp',
    'Cat. 3: No VEP HIGH CSQ',
-   'Cat. 4: Not implemented',
    'Cat. Support: not Missense'
 ]
 ```
@@ -148,7 +148,7 @@ multiple affecteds in the same family). The MT-portion of the algorithm should b
 2. find which of those discrepant variants weren't present in the VCF (un-classified in the Hail stage)
 3. for each of those discrepant variants, find all corresponding reasons
 
-Change to:
+### Change to
 
 1. retain steps 1 & 2
 2. Pool all unique variants across all samples

--- a/comparison/comparison.py
+++ b/comparison/comparison.py
@@ -778,12 +778,13 @@ def check_mt(
     return not_in_mt, untiered
 
 
-def main(results_folder: str, seqr: str, vcf: str, mt: str, output: str):
+def main(results_folder: str, pedigree: str, seqr: str, vcf: str, mt: str, output: str):
     """
     runs a full match-seeking analysis of this AIP run against the
     expected variants (based on seqr training flags)
 
     :param results_folder:
+    :param pedigree:
     :param seqr:
     :param vcf:
     :param mt:
@@ -799,9 +800,7 @@ def main(results_folder: str, seqr: str, vcf: str, mt: str, output: str):
     )
 
     # Search for all affected sample IDs in the Peddy Pedigree
-    affected = find_affected_samples(
-        Ped(os.path.join(results_folder, 'latest_pedigree.fam'))
-    )
+    affected = find_affected_samples(Ped(pedigree))
 
     # parse the Seqr results table, specifically targeting variants in probands
     seqr_results = common_format_seqr(seqr=seqr, affected=affected)
@@ -876,6 +875,7 @@ if __name__ == '__main__':
     )
     parser = ArgumentParser()
     parser.add_argument('--results_folder')
+    parser.add_argument('--pedigree')
     parser.add_argument('--seqr')
     parser.add_argument('--vcf')
     parser.add_argument('--mt')
@@ -883,6 +883,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     main(
         results_folder=args.results_folder,
+        pedigree=args.pedigree,
         seqr=args.seqr,
         vcf=args.vcf,
         mt=args.mt,

--- a/comparison/comparison.py
+++ b/comparison/comparison.py
@@ -131,7 +131,7 @@ class CommonFormatResult:
 
     def __repr__(self):
         return (
-            f'{self.chr}:{self.pos}_{self.ref}>{self.alt} - '
+            f'{self.chr}:{self.pos}_{self.ref}>{self.alt} '
             f'- {", ".join(map(str, sorted(self.confidence)))}'
         )
 
@@ -259,7 +259,7 @@ def find_seqr_flags(aip_results: CommonDict, seqr_results: CommonDict):
         if sample not in aip_results:
             for v in variants:
                 for conf in v.confidence:
-                    flag_matches[conf]['unmatched'].append(f'{sample}::{repr(v)}')
+                    flag_matches[conf.name]['unmatched'].append(f'{sample}::{repr(v)}')
                 total_seqr_variants += 1
             continue
 
@@ -268,7 +268,7 @@ def find_seqr_flags(aip_results: CommonDict, seqr_results: CommonDict):
             total_seqr_variants += 1
             match = 'matched' if v in aip_variants else 'unmatched'
             for conf in v.confidence:
-                flag_matches[conf][match].append(f'{sample}::{repr(v)}')
+                flag_matches[conf.name][match].append(f'{sample}::{repr(v)}')
 
     # print a summary into logging
     logging.info(f'Total Seqr Variants: {total_seqr_variants}')

--- a/comparison/comparison.py
+++ b/comparison/comparison.py
@@ -166,7 +166,7 @@ def common_format_from_results(results_dict: dict[str, Any]) -> CommonDict:
     # collect all per-sample results into a separate index
     for sample, variants in results_dict.items():
 
-        for var in variants.values():
+        for var in variants:
             coords = var['var_data']['coords']
             sample_dict[sample].append(
                 CommonFormatResult(

--- a/comparison/comparison.py
+++ b/comparison/comparison.py
@@ -251,7 +251,7 @@ def find_seqr_flags(aip_results: CommonDict, seqr_results: CommonDict):
 
     flag_matches = {
         key: {'matched': [], 'unmatched': []}
-        for key in [Confidence.EXPECTED, Confidence.UNLIKELY, Confidence.POSSIBLE]
+        for key in ['EXPECTED', 'UNLIKELY', 'POSSIBLE']
     }
     total_seqr_variants = 0
 

--- a/comparison/comparison_wrapper.py
+++ b/comparison/comparison_wrapper.py
@@ -24,6 +24,7 @@ from cpg_utils.hail_batch import (
     authenticate_cloud_credentials_in_job,
     copy_common_env,
     remote_tmpdir,
+    output_path,
 )
 from cpg_utils.config import get_config
 
@@ -40,17 +41,7 @@ COMPARISON_SCRIPT = os.path.join(os.path.dirname(__file__), 'comparison.py')
 @click.option('--mt', help='matrix table of annotated variants')
 @click.option('--config', help='configuration used in AIP')
 @click.option('--panel', help='PanelApp data used in AIP')
-@click.option('--output', help='where to write results to')
-def main(
-    results: str,
-    seqr: str,
-    ped: str,
-    vcf: str,
-    mt: str,
-    config: str,
-    panel: str,
-    output: str,
-):
+def main(results: str, seqr: str, ped: str, vcf: str, mt: str, config: str, panel: str):
     """
     main method, which runs the AIP comparison
     :param results:
@@ -60,7 +51,6 @@ def main(
     :param mt:
     :param config:
     :param panel:
-    :param output:
     :return:
     """
 
@@ -113,7 +103,7 @@ def main(
         f'--mt {mt} '
         f'--config {config} '
         f'--panel {panel} '
-        f'--output {output} '
+        f'--output {output_path("comparison_result")} '
     )
     logging.info(f'Results command: {results_command}')
     comp_job.command(results_command)

--- a/comparison/comparison_wrapper.py
+++ b/comparison/comparison_wrapper.py
@@ -79,11 +79,13 @@ def main(results_folder: str, seqr: str, mt: str):
     vcf_in_batch = batch.read_input_group(
         **{'vcf.bgz': run_vcf, 'vcf.bgz.tbi': run_vcf + '.tbi'}
     )
+    ped_in_batch = batch.read_input(os.path.join(results_folder, 'latest_pedigree.fam'))
 
     results_command = (
         'pip install . && '
         f'python3 {COMPARISON_SCRIPT} '
         f'--results_folder {results_folder} '
+        f'--pedigree {ped_in_batch} '
         f'--seqr {seqr} '
         f'--vcf {vcf_in_batch["vcf.bgz"]} '
         f'--mt {mt} '

--- a/comparison/comparison_wrapper.py
+++ b/comparison/comparison_wrapper.py
@@ -3,7 +3,6 @@
 
 """
 Entrypoint for the comparison process
-initially just print results
 """
 
 
@@ -34,23 +33,15 @@ COMPARISON_SCRIPT = os.path.join(os.path.dirname(__file__), 'comparison.py')
 
 
 @click.command()
-@click.option('--results', help='AIP result JSON')
+@click.option('--results_folder', help='folder containing the results')
 @click.option('--seqr', help='Seqr flagged variants export')
-@click.option('--ped', help='plink file for the cohort')
-@click.option('--vcf', help='labelled VCF')
 @click.option('--mt', help='matrix table of annotated variants')
-@click.option('--config', help='configuration used in AIP')
-@click.option('--panel', help='PanelApp data used in AIP')
-def main(results: str, seqr: str, ped: str, vcf: str, mt: str, config: str, panel: str):
+def main(results_folder: str, seqr: str, mt: str):
     """
     main method, which runs the AIP comparison
-    :param results:
+    :param results_folder:
     :param seqr:
-    :param ped:
-    :param vcf:
     :param mt:
-    :param config:
-    :param panel:
     :return:
     """
 
@@ -59,20 +50,15 @@ def main(results: str, seqr: str, ped: str, vcf: str, mt: str, config: str, pane
         billing_project=get_config()['hail']['billing_project'],
         remote_tmpdir=remote_tmpdir(),
     )
-    batch = hb.Batch(
-        name='run AIP comparison',
-        backend=service_backend,
-        cancel_after_n_failures=1,
-        default_timeout=1000,
-    )
+    batch = hb.Batch(name='run AIP comparison', backend=service_backend)
 
     # create a new job
     comp_job = batch.new_job(name='Run Comparison')
 
-    image_default = get_config()['workflow']['driver_image']
-
     # set reasonable job resources
-    comp_job.cpu(2).image(image_default).memory('standard').storage('50G')
+    comp_job.cpu(4).image(get_config()['workflow']['driver_image']).memory(
+        'standard'
+    ).storage('50G')
 
     # run gcloud authentication
     authenticate_cloud_credentials_in_job(comp_job)
@@ -89,20 +75,18 @@ def main(results: str, seqr: str, ped: str, vcf: str, mt: str, config: str, pane
     )
 
     # need to localise the VCF + index
+    run_vcf = os.path.join(results_folder, 'hail_categorised.vcf.bgz')
     vcf_in_batch = batch.read_input_group(
-        **{'vcf.bgz': vcf, 'vcf.bgz.tbi': vcf + '.tbi'}
+        **{'vcf.bgz': run_vcf, 'vcf.bgz.tbi': run_vcf + '.tbi'}
     )
 
     results_command = (
         'pip install . && '
         f'python3 {COMPARISON_SCRIPT} '
-        f'--results {results} '
+        f'--results_folder {results_folder} '
         f'--seqr {seqr} '
-        f'--ped {ped} '
         f'--vcf {vcf_in_batch["vcf.bgz"]} '
         f'--mt {mt} '
-        f'--config {config} '
-        f'--panel {panel} '
         f'--output {output_path("comparison_result")} '
     )
     logging.info(f'Results command: {results_command}')

--- a/comparison/run_comparison.sh
+++ b/comparison/run_comparison.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# set the date, or provide a default
+PAP_DATE=${1:-$(date +%F)}
+
+# run
+analysis-runner \
+  --dataset acute-care \
+  --description "Run Comparison" \
+  -o "reanalysis/comparison/${PAP_DATE}" \
+  --access-level test \
+  comparison/comparison_wrapper.py \
+    --results_folder gs://cpg-acute-care-test/reanalysis/2022-08-19 \
+    --seqr gs://cpg-acute-care-test/reanalysis/comparison/seqr_acute_care_tags.tsv \
+    --mt gs://cpg-acute-care-main/mt/986d792a448c66a8a5cfba65434e7d1ce9b1ff_1051-acute-care.mt

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -447,8 +447,11 @@ class RecessiveAutosomal(BaseMoi):
                 sample=sample_id,
             ):
 
-                # categorised for this specific
-                if not partner_variant.sample_specific_category_check(sample_id):
+                # categorised for this specific sample, allow support in partner
+                if not (
+                    partner_variant.sample_specific_category_check(sample_id)
+                    or partner_variant.has_support
+                ):
                     continue
 
                 # check if this is a candidate for comp-het inheritance
@@ -673,7 +676,10 @@ class XRecessive(BaseMoi):
             ):
 
                 # allow for de novo check
-                if not partner_variant.sample_specific_category_check(sample_id):
+                if not (
+                    partner_variant.sample_specific_category_check(sample_id)
+                    or partner_variant.has_support
+                ):
                     continue
 
                 if not self.check_familial_comp_het(

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -122,7 +122,7 @@ def apply_moi_to_variants(
             continue
 
         simple_moi = get_simple_moi(panel_gene_data.get('moi'))
-        additional_panels = panel_gene_data.get('flags')
+        additional_panels = panel_gene_data.get('flags', [])
 
         for variant in variants:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==8.0.4
 cloudpathlib[all]==0.9.0
-cpg-utils==4.4.0
+cpg-utils==4.4.4
 cyvcf2==0.30.15
 dill==0.3.4
 hail==0.2.96
@@ -8,5 +8,5 @@ Jinja2==3.0.3
 pandas==1.3.5
 peddy==0.4.8
 requests==2.25.1
-sample-metadata==4.10.0
+sample-metadata==4.14.0
 seqr-loader==1.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ Jinja2==3.0.3
 pandas==1.3.5
 peddy==0.4.8
 requests==2.25.1
-sample-metadata==4.14.0
+sample-metadata==4.15.0
 seqr-loader==1.2.5

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,14 @@ setup(
         'full': [
             'click==8.0.4',
             'cloudpathlib[all]==0.9.0',
-            'cpg-utils==4.4.3',
+            'cpg-utils==4.4.4',
             'dill==0.3.5.1',
             'hail==0.2.96',
             'Jinja2==3.0.3',
             'pandas==1.4.3',
             'peddy==0.4.8',
             'requests==2.25.1',
-            'sample-metadata==4.13.0',
+            'sample-metadata==4.14.0',
             'seqr-loader==1.2.5',
         ],
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             'pandas==1.4.3',
             'peddy==0.4.8',
             'requests==2.25.1',
-            'sample-metadata==4.14.0',
+            'sample-metadata==4.15.0',
             'seqr-loader==1.2.5',
         ],
         'test': [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,7 @@ def fixture_hail_matrix():
     loads the single variant as a matrix table
     :return:
     """
-    mt = hl.import_vcf(HAIL_VCF, reference_genome='GRCh38')
-    return mt.key_rows_by(mt.locus)
+    return hl.import_vcf(HAIL_VCF, reference_genome='GRCh38')
 
 
 @pytest.fixture(name='single_variant_vcf_path')

--- a/test/input/aip_output_example.json
+++ b/test/input/aip_output_example.json
@@ -1,6 +1,6 @@
 {
-    "SAMPLE_1": {
-        "7-93105286-T-A__ENSG00000205413__Unsupported": {
+    "SAMPLE_1": [
+        {
             "sample": "SAMPLE_1",
             "gene": "ENSG00000205413",
             "var_data": {
@@ -63,7 +63,8 @@
                 "Autosomal Dominant"
             ],
             "supported": false,
-            "support_vars": null
+            "support_vars": null,
+            "flags": []
         }
-    }
+    ]
 }

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -371,7 +371,7 @@ def test_variant_is_normalised(
     :param hail_matrix:
     :return:
     """
-    anno_mt = hail_matrix.annotate_rows(alleles=alleles)
+    anno_mt = hail_matrix.key_rows_by(hail_matrix.locus).annotate_rows(alleles=alleles)
     assert check_variant_was_normalised(anno_mt) == results
 
 

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -14,8 +14,8 @@ from comparison.comparison import (
     check_gene_is_green,
     check_variant_was_normalised,
     check_in_vcf,
-    common_format_from_results,
-    common_format_from_seqr,
+    common_format_aip,
+    common_format_seqr,
     find_affected_samples,
     filter_sample_by_ab,
     find_missing,
@@ -34,7 +34,7 @@ def test_parse_aip(output_json):
     :return:
     """
 
-    parsed_result = common_format_from_results(output_json)
+    parsed_result = common_format_aip(output_json)
     assert list(parsed_result.keys()) == ['SAMPLE_1']
 
     parsed_variants = parsed_result['SAMPLE_1']
@@ -99,7 +99,7 @@ def test_seqr_parser(seqr_csv_output):
     :return:
     """
 
-    seqr_results = common_format_from_seqr(seqr_csv_output, affected=['PROBAND'])
+    seqr_results = common_format_seqr(seqr_csv_output, affected=['PROBAND'])
 
     # only results for one sample
     assert len(list(seqr_results.keys())) == 1


### PR DESCRIPTION
# Fixes

  - closes #71

## Proposed Changes

  - results are saved into output files, rather than only printing to the Hail logs
  - requires fewer defined inputs - works input paths out by using the run folder root location
  - produces comparison stats for the # of matched and missed Seqr Training Flags

## Example

[This Hail Run](https://batch.hail.populationgenomics.org.au/batches/140982/jobs/1)

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
