### PR TITLE
Field audit + tweaks

### DIFF
--- a/reanalysis/annotation.py
+++ b/reanalysis/annotation.py
@@ -14,6 +14,21 @@ import hail as hl
 logger = logging.getLogger(__file__)
 
 
+def add_call_stats(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """
+    If the GT stats were missing, add now
+    potentially less powerful than running on X-cohort joint-call
+    """
+    mt = mt.annotate_rows(gt_stats=hl.agg.call_stats(mt.GT, mt.alleles))
+    return mt.annotate_rows(
+        info=mt.info.annotate(
+            AC=mt.gt_stats.AC,
+            AF=mt.gt_stats.AF,
+            AN=mt.gt_stats.AN,
+        )
+    )
+
+
 def apply_annotations(
     vcf_path: str,
     vep_ht_path: str,
@@ -99,6 +114,9 @@ def apply_annotations(
 
     ref_ht = hl.read_table(str(ref_ht_path))
     clinvar_ht = hl.read_table(str(clinvar_ht_path))
+
+    if not all(field in mt.info for field in ['AC', 'AF', 'AN']):
+        mt = add_call_stats(mt)
 
     logger.info('Annotating with seqr-loader fields: round 1')
     mt = mt.annotate_rows(

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -485,8 +485,7 @@ def main(
         **{'vcf.bgz': HAIL_VCF_OUT, 'vcf.bgz.tbi': HAIL_VCF_OUT + '.tbi'}
     )
 
-    # for dev purposes - always run as default (family)
-    # if singleton VCF supplied, also run as singletons w/separate outputs
+    # if singleton PED supplied, also run as singletons w/separate outputs
     analysis_rounds = [(pedigree_in_batch, 'default')]
     if singletons and AnyPath(singletons).exists():
         pedigree_singletons = batch.read_input(singletons)
@@ -502,7 +501,6 @@ def main(
             output_dict=output_dict[analysis_index],
             prior_job=prior_job,
         )
-    batch.run(wait=False)
 
     # save the json file into the batch output, with latest run details
     with AnyPath(output_path('latest_config.json')).open('w') as handle:
@@ -515,6 +513,8 @@ def main(
     if singletons:
         with AnyPath(output_path('latest_singletons.fam')).open('w') as handle:
             handle.writelines(AnyPath(singletons).open().readlines())
+
+    batch.run(wait=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Fixes

  - closes #58

## Proposed Changes

This PR contains a collection of fixes across a couple of different categories
  - In lots of places there is a non-functional change of `matrix` -> `mt`, to harmonise with the canonical use of mt as a variable name in the hail code base
  - The step MT -> VCF prior to annotation takes AGES, and most of the variants will be filtered out downstream. To reduce overall time and expense for the end2end workflow, sites are removed from the MT where a QC failure filter is shown, and sites are removed if no present samples have alt alleles (possible hangover when extracting the cohort group from a X-cohort joint call). This can be altered to behave differently if required, but for AIP-specific use the filter failures are removed anyway; not doing this removal up front just creates bigger VCF files and longer running annotation jobs.
  - During the annotation phase, the GT stats fields AC/AN/AF are added if they were missing in the VCF (encountered during 1000G processing) (@vladsavelyev could you please check this? In the 1000G dataset example the fields were not populated into the VCF already, so the annotation stage failed [here](https://github.com/populationgenomics/automated-interpretation-pipeline/blob/main/reanalysis/annotation.py#L105-L107) - I would expect the same point of failure if a non-GATK/Hail generated VCF was supplied as input, and we'd like to be flexible enough to handle non-CPG data)
  - Prior to running the category labelling logic in Hail, an 'audit' is carried out, ensuring that all required fields are present in the correct part of the hierarchy, and are of the correct data type

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
