### PR TITLE
Update report meta

### DIFF
--- a/helpers/cohort_prep.sh
+++ b/helpers/cohort_prep.sh
@@ -13,5 +13,6 @@ mkdir -p "inputs/$COHORT"
 python helpers/pedigree_from_sample_metadata.py \
     --project "${COHORT}" \
     --output "inputs/${COHORT}/${TODAY}_${SUBSAMPLE}_percent" \
-    --plink --hash_threshold \
-    "${SUBSAMPLE}"
+    --plink \
+    --hash_threshold "${SUBSAMPLE}" \
+    --copy

--- a/helpers/file_prep.sh
+++ b/helpers/file_prep.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+# 'canonical' files
+CANONICAL_FILES="gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt gs://cpg-acute-care-test/reanalysis/csq_header_line.txt"
+COHORT_LIST=("acute-care")
+
+for cohort in ${COHORT_LIST[@]}; do
+    gsutil -m cp ${CANONICAL_FILES} "gs://cpg-${cohort}-test/reanalysis"
+done

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -742,7 +742,7 @@ def green_and_new_from_panelapp(
     """
 
     # take all the green genes, remove the metadata
-    green_genes = set(panel_data.keys()) - {'panel_metadata'}
+    green_genes = set(panel_data.keys()) - {'metadata'}
     logging.info(f'Extracted {len(green_genes)} green genes')
     green_gene_set_expression = hl.literal(green_genes)
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -299,13 +299,12 @@ class HTMLBuilder:
         uses the results to create the HTML tables
         writes all content to the output path
         """
-        meta_tables = self.read_metadata()
         summary_table, zero_categorised_samples = self.get_summary_stats()
         html_tables = self.create_html_tables()
 
         html_lines = ['<head></head>\n<body>\n']
 
-        for title, meta_table in meta_tables.items():
+        for title, meta_table in self.read_metadata().items():
             html_lines.append(f'<h3>{title}</h3>')
             html_lines.append(meta_table)
             html_lines.append('<br/>')

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -196,11 +196,12 @@ class HTMLBuilder:
         takes the results from the analysis and purges forbidden-gene variants
         """
         clean_results = defaultdict(list[dict[str, Any]])
-        for sample, variants in variant_dictionary.items():
+        for sample, content in variant_dictionary.items():
             if sample == 'metadata':
+                clean_results['metadata'] = content
                 continue
             sample_vars = []
-            for variant in variants:
+            for variant in content:
                 skip_variant = False
                 for gene_id in variant['gene'].split(','):
                     if gene_id in self.forbidden_genes.keys():

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -282,14 +282,14 @@ class HTMLBuilder:
                 index=False, escape=False
             ),
             'Meta': pd.DataFrame(
-                {key.capitalize(): self.config['metadata'][key]}
+                {key.capitalize(): self.results['metadata'][key]}
                 for key in ['cohort', 'run_datetime', 'input_file']
             ).to_html(index=False, escape=False),
             'Families': pd.DataFrame(
                 [
                     {'family_size': fam_type, 'tally': fam_count}
                     for fam_type, fam_count in sorted(
-                        self.config['metadata']['family_breakdown'].items()
+                        self.results['metadata']['family_breakdown'].items()
                     )
                 ]
             ).to_html(index=False, escape=False),

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -286,7 +286,7 @@ class HTMLBuilder:
                 index=False, escape=False
             ),
             'Meta': pd.DataFrame(
-                {key.capitalize(): self.results['metadata'][key]}
+                {'Data': key.capitalize(), 'Value': self.results['metadata'][key]}
                 for key in ['cohort', 'run_datetime', 'input_file']
             ).to_html(index=False, escape=False),
             'Families': pd.DataFrame(

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -371,6 +371,10 @@ class HTMLBuilder:
         sample_tables = {}
 
         for sample, variants in self.results.items():
+
+            if sample == 'metadata':
+                continue
+
             for variant in variants:
 
                 # pull out the string representation

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -278,7 +278,7 @@ class HTMLBuilder:
         parses into a general table and a panel table
         """
         tables = {
-            'Panels': pd.DataFrame(self.config['metadata']['panels']).to_html(
+            'Panels': pd.DataFrame(self.panelapp['metadata']).to_html(
                 index=False, escape=False
             ),
             'Meta': pd.DataFrame(

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -230,6 +230,9 @@ class HTMLBuilder:
 
         for sample, variants in self.results.items():
 
+            if sample == 'metadata':
+                continue
+
             if len(variants) == 0:
                 samples_with_no_variants.append(self.external_map.get(sample, sample))
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -197,6 +197,8 @@ class HTMLBuilder:
         """
         clean_results = defaultdict(list[dict[str, Any]])
         for sample, variants in variant_dictionary.items():
+            if sample == 'metadata':
+                continue
             sample_vars = []
             for variant in variants:
                 skip_variant = False

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -278,7 +278,7 @@ class HTMLBuilder:
         parses into a general table and a panel table
         """
         tables = {
-            'Panels': pd.DataFrame(self.panelapp['metadata']).to_html(
+            'Panels': pd.DataFrame(self.results['metadata']['panels']).to_html(
                 index=False, escape=False
             ),
             'Meta': pd.DataFrame(

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -500,7 +500,7 @@ def main(
 
     # save the json file into the batch output, with latest run details
     with AnyPath(output_path('latest_config.json')).open('w') as handle:
-        json.dump(config_dict, handle)
+        json.dump(config_dict, handle, indent=True)
 
     # write pedigree content to the output folder
     with AnyPath(output_path('latest_pedigree.fam')).open('w') as handle:

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -356,6 +356,7 @@ def main(
             'latest_run': f'{datetime.now():%Y-%m-%d %H:%M:%S%z}',
             'input_file': input_path,
             'panelapp_file': PANELAPP_JSON_OUT,
+            'cohort': get_config()['workflow']['dataset'],
         }
     )
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -485,11 +485,12 @@ def main(
         pedigree_singletons = batch.read_input(singletons)
         analysis_rounds.append((pedigree_singletons, 'singletons'))
 
+    # pointing this analysis at the updated config file, including input metadata
     for relationships, analysis_index in analysis_rounds:
         logging.info(f'running analysis in {analysis_index} mode')
         _results_job = handle_results_job(
             batch=batch,
-            config=config_json,
+            config=output_path('latest_config.json'),
             labelled_vcf=labelled_vcf_in_batch,
             pedigree=relationships,
             output_dict=output_dict[analysis_index],

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -84,9 +84,9 @@ def get_panel_green(panel_id: str) -> dict[str, dict[str, Union[str, bool]]]:
 
     gene_dict = {
         'metadata': {
-            'current_version': panel_version,
             'panel_name': panel_name,
             'panel_version': panel_version,
+            'panel_id': panel_id,
             'additional_panels': [],
         }
     }
@@ -173,9 +173,12 @@ def combine_mendeliome_with_other_panels(panel_dict: PanelData, additional: Pane
     """
 
     additional_name = additional['metadata']['panel_name']
-    additional_version = additional['metadata']['panel_version']
-    panel_dict['additional_panels'].append(
-        {'panel_name': additional_name, 'panel_version': additional_version}
+    panel_dict['metadata']['additional_panels'].append(
+        {
+            'panel_name': additional_name,
+            'panel_version': additional['metadata']['panel_version'],
+            'panel_id': additional['metadata']['panel_id'],
+        }
     )
     panel_keys = panel_dict.keys()
     for ensg in additional.keys():

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -173,7 +173,7 @@ def combine_mendeliome_with_other_panels(panel_dict: PanelData, additional: Pane
     :param additional:
     """
 
-    additional_name = [0]
+    additional_name = additional['metadata'][0]['name']
     panel_dict['metadata'].append(
         {
             'name': additional['metadata'][0]['name'],

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -31,7 +31,7 @@ from cloudpathlib import AnyPath
 
 MENDELIOME = '137'
 PANELAPP_BASE = 'https://panelapp.agha.umccr.org/api/v1/panels/'
-PanelData = dict[str, dict]
+PanelData = dict[str, dict | list[dict]]
 
 
 def parse_gene_list(path_to_list: str) -> set[str]:
@@ -83,12 +83,13 @@ def get_panel_green(panel_id: str) -> dict[str, dict[str, Union[str, bool]]]:
     )
 
     gene_dict = {
-        'metadata': {
-            'panel_name': panel_name,
-            'panel_version': panel_version,
-            'panel_id': panel_id,
-            'additional_panels': [],
-        }
+        'metadata': [
+            {
+                'name': panel_name,
+                'version': panel_version,
+                'id': panel_id,
+            }
+        ]
     }
 
     for gene in panel_json['genes']:
@@ -172,12 +173,12 @@ def combine_mendeliome_with_other_panels(panel_dict: PanelData, additional: Pane
     :param additional:
     """
 
-    additional_name = additional['metadata']['panel_name']
-    panel_dict['metadata']['additional_panels'].append(
+    additional_name = [0]
+    panel_dict['metadata'].append(
         {
-            'panel_name': additional_name,
-            'panel_version': additional['metadata']['panel_version'],
-            'panel_id': additional['metadata']['panel_id'],
+            'name': additional['metadata'][0]['name'],
+            'version': additional['metadata'][0]['version'],
+            'id': additional['metadata'][0]['id'],
         }
     )
     panel_keys = panel_dict.keys()

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -219,8 +219,9 @@ def update_result_meta(
         family_counter[str(len(pedigree.families[family].samples))] += 1
 
     results['metadata'] = {
-        'run_datetime': config['latest_run'],
+        'cohort': config['cohort'],
         'input_file': config['input_file'],
+        'run_datetime': config['latest_run'],
         'family_breakdown': dict(family_counter),
         'panels': panelapp['metadata'],
     }

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -218,20 +218,11 @@ def update_result_meta(
             family_counter['quads'] += quads
         family_counter[str(len(pedigree.families[family].samples))] += 1
 
-    panels = panelapp['metadata']['additional_panels']
-    panels.append(
-        {
-            'panel_name': panelapp['metadata']['panel_name'],
-            'panel_version': panelapp['metadata']['panel_version'],
-            'panel_id': panelapp['metadata']['panel_id'],
-        }
-    )
-
     results['metadata'] = {
         'run_datetime': config['latest_run'],
         'input_file': config['input_file'],
         'family_breakdown': dict(family_counter),
-        'panels': panels,
+        'panels': panelapp['metadata'],
     }
 
     return results

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -224,6 +224,7 @@ def update_result_meta(
         {
             'panel_name': panelapp['metadata']['panel_name'],
             'panel_version': panelapp['metadata']['panel_version'],
+            'panel_id': panelapp['metadata']['panel_id'],
         }
     )
 

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -199,7 +199,7 @@ def clean_initial_results(
 
 
 def update_result_meta(
-    results: dict, config: dict, pedigree: Ped, panelapp: dict
+    results: dict, config: dict, pedigree: Ped, panelapp: dict, samples: list[str]
 ) -> dict:
     """
     takes the 'cleaned' results, and adds in a metadata key
@@ -208,6 +208,10 @@ def update_result_meta(
     """
     family_counter = defaultdict(int)
     for family in pedigree.families:
+        # don't count families who don't appear in this pedigree subset
+        if not any(sam.sample_id in samples for sam in pedigree.families[family]):
+            continue
+
         affected, sex, trios, quads = pedigree.families[family].summary()
         family_counter['affected'] += affected[True]
         family_counter['male'] += sex['male']
@@ -312,7 +316,11 @@ def main(
 
     # add metadata into the results
     meta_results = update_result_meta(
-        cleaned_results, config_dict, pedigree=pedigree_digest, panelapp=panelapp_data
+        cleaned_results,
+        config_dict,
+        pedigree=pedigree_digest,
+        panelapp=panelapp_data,
+        samples=vcf_opened.samples,
     )
 
     # dump results using the custom-encoder to transform sets & DataClasses

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -71,8 +71,7 @@ def set_up_inheritance_filters(
     # iterate over all genes
     for key, gene_data in panelapp_data.items():
 
-        # skip over the stored metadata
-        if '_version' in key:
+        if key == 'metadata':
             continue
 
         # extract the per-gene MOI, and SIMPLIFY

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -213,9 +213,11 @@ def update_result_meta(
         family_counter['affected'] += affected[True]
         family_counter['male'] += sex['male']
         family_counter['female'] += sex['female']
-        family_counter['trios'] += trios
-        family_counter['quads'] += quads
-        family_counter[len(pedigree.families[family].samples)] += 1
+        if trios != 0:
+            family_counter['trios'] += trios
+        if quads != 0:
+            family_counter['quads'] += quads
+        family_counter[str(len(pedigree.families[family].samples))] += 1
 
     panels = panelapp['metadata']['additional_panels']
     panels.append(
@@ -228,7 +230,7 @@ def update_result_meta(
     results['metadata'] = {
         'run_datetime': config['latest_run'],
         'input_file': config['input_file'],
-        'family_breakdown': family_counter,
+        'family_breakdown': dict(family_counter),
         'panels': panels,
     }
 

--- a/test/input/panel_changes_expected.json
+++ b/test/input/panel_changes_expected.json
@@ -1,6 +1,6 @@
 {
- "panel_metadata": {
-  "current_version": "0.11088"
+ "metadata": {
+  "version": "0.11088"
  },
  "ENSG00ABCD": {
   "symbol": "ABCD",

--- a/test/input/panel_green_latest_expected.json
+++ b/test/input/panel_green_latest_expected.json
@@ -1,7 +1,9 @@
 {
- "panel_metadata": {
-  "current_version": "0.11088",
-  "panel_name": "Mendeliome"
+ "metadata": {
+  "panel_version": "0.11088",
+  "panel_name": "Mendeliome",
+  "panel_id": "137",
+  "additional_panels": []
  },
  "ENSG00ABCD": {
   "symbol": "ABCD",

--- a/test/input/panel_green_latest_expected.json
+++ b/test/input/panel_green_latest_expected.json
@@ -1,10 +1,11 @@
 {
- "metadata": {
-  "panel_version": "0.11088",
-  "panel_name": "Mendeliome",
-  "panel_id": "137",
-  "additional_panels": []
- },
+ "metadata": [
+  {
+   "version": "0.11088",
+   "name": "Mendeliome",
+   "id": "137"
+  }
+ ],
  "ENSG00ABCD": {
   "symbol": "ABCD",
   "moi": "BIALLELIC",

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -119,23 +119,19 @@ def test_second_panel_update_moi():
     - expect overwriting of MOI
     """
     main = {
-        'metadata': {'panel_name': 'NAME', 'additional_panels': []},
+        'metadata': [{'name': 'NAME', 'id': 'fish'}],
         'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
     }
     additional = {
-        'metadata': {
-            'panel_name': 'NAME',
-            'panel_version': '1.0',
-            'panel_id': '123',
-            'additional_panels': [],
-        },
+        'metadata': [{'name': 'NAME', 'version': '1.0', 'id': '123'}],
         'ensg1': {'entity_name': '1', 'moi': 'REALLY_BIG'},
     }
     combine_mendeliome_with_other_panels(main, additional)
     assert main['ensg1'].get('flags') == ['NAME']
     assert main['ensg1'].get('moi') == 'REALLY_BIG'
-    assert len(main['metadata']['additional_panels']) == 1
-    assert main['metadata']['additional_panels'][0]['panel_id'] == '123'
+    assert len(main['metadata']) == 2
+    assert main['metadata'][0]['id'] == 'fish'
+    assert main['metadata'][1]['id'] == '123'
 
 
 def test_second_panel_no_overlap():
@@ -144,21 +140,11 @@ def test_second_panel_no_overlap():
     - expect both results
     """
     main = {
-        'metadata': {
-            'panel_name': 'NAME',
-            'panel_version': '1.0',
-            'panel_id': '1',
-            'additional_panels': [],
-        },
+        'metadata': [{'name': 'NAME', 'version': '1.0', 'id': '1'}],
         'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
     }
     additional = {
-        'metadata': {
-            'panel_name': 'ADD',
-            'panel_version': '1.1',
-            'panel_id': '2',
-            'additional_panels': [],
-        },
+        'metadata': [{'name': 'ADD', 'version': '1.1', 'id': '2'}],
         'ensg2': {'entity_name': '2', 'moi': 'REALLY_BIG'},
     }
     combine_mendeliome_with_other_panels(main, additional)
@@ -166,5 +152,6 @@ def test_second_panel_no_overlap():
     assert main['ensg1'].get('moi') is None
     assert main['ensg2'].get('flags') == ['ADD']
     assert main['ensg2'].get('moi') == 'REALLY_BIG'
-    assert len(main['metadata']['additional_panels']) == 1
-    assert main['metadata']['additional_panels'][0]['panel_version'] == '1.1'
+    assert len(main['metadata']) == 2
+    assert main['metadata'][0]['version'] == '1.0'
+    assert main['metadata'][1]['version'] == '1.1'

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -119,16 +119,23 @@ def test_second_panel_update_moi():
     - expect overwriting of MOI
     """
     main = {
-        'panel_metadata': {'panel_name': 'NAME'},
+        'metadata': {'panel_name': 'NAME', 'additional_panels': []},
         'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
     }
     additional = {
-        'panel_metadata': {'panel_name': 'NAME'},
+        'metadata': {
+            'panel_name': 'NAME',
+            'panel_version': '1.0',
+            'panel_id': '123',
+            'additional_panels': [],
+        },
         'ensg1': {'entity_name': '1', 'moi': 'REALLY_BIG'},
     }
     combine_mendeliome_with_other_panels(main, additional)
     assert main['ensg1'].get('flags') == ['NAME']
     assert main['ensg1'].get('moi') == 'REALLY_BIG'
+    assert len(main['metadata']['additional_panels']) == 1
+    assert main['metadata']['additional_panels'][0]['panel_id'] == '123'
 
 
 def test_second_panel_no_overlap():
@@ -137,15 +144,27 @@ def test_second_panel_no_overlap():
     - expect both results
     """
     main = {
-        'panel_metadata': {'panel_name': 'NAME'},
+        'metadata': {
+            'panel_name': 'NAME',
+            'panel_version': '1.0',
+            'panel_id': '1',
+            'additional_panels': [],
+        },
         'ensg1': {'entity_name': '1', 'moi': None, 'flags': []},
     }
     additional = {
-        'panel_metadata': {'panel_name': 'NAME'},
+        'metadata': {
+            'panel_name': 'ADD',
+            'panel_version': '1.1',
+            'panel_id': '2',
+            'additional_panels': [],
+        },
         'ensg2': {'entity_name': '2', 'moi': 'REALLY_BIG'},
     }
     combine_mendeliome_with_other_panels(main, additional)
     assert main['ensg1'].get('flags') == []
     assert main['ensg1'].get('moi') is None
-    assert main['ensg2'].get('flags') == ['NAME']
+    assert main['ensg2'].get('flags') == ['ADD']
     assert main['ensg2'].get('moi') == 'REALLY_BIG'
+    assert len(main['metadata']['additional_panels']) == 1
+    assert main['metadata']['additional_panels'][0]['panel_version'] == '1.1'

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -27,9 +27,14 @@ def test_update_results_meta(peddy_ped):
             ],
         }
     }
+    ped_samples = ['male', 'female', 'mother_1', 'father_1', 'mother_2', 'father_2']
 
     big_results = update_result_meta(
-        results=results, config=config, pedigree=peddy_ped, panelapp=panelapp
+        results=results,
+        config=config,
+        pedigree=peddy_ped,
+        panelapp=panelapp,
+        samples=ped_samples,
     )
     assert big_results == {
         'metadata': {

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -1,0 +1,45 @@
+"""
+script testing methods within reanalysis/validate_categories.py
+"""
+
+
+from reanalysis.validate_categories import update_result_meta
+
+
+def test_update_results_meta(peddy_ped):
+    """
+    testing the dict update
+    """
+
+    results = {}
+    config = {'input_file': 'foo', 'latest_run': 'bar'}
+    panelapp = {
+        'metadata': {
+            'panel_name': 'biff',
+            'panel_version': 'pow',
+            'additional_panels': [
+                {'panel_name': 'extra_panel', 'panel_version': 'extra_version'},
+            ],
+        }
+    }
+
+    big_results = update_result_meta(
+        results=results, config=config, pedigree=peddy_ped, panelapp=panelapp
+    )
+    assert big_results == {
+        'metadata': {
+            'run_datetime': 'bar',
+            'input_file': 'foo',
+            'family_breakdown': {
+                'affected': 2,
+                'male': 3,
+                'female': 3,
+                'trios': 2,
+                '3': 2,
+            },
+            'panels': [
+                {'panel_name': 'extra_panel', 'panel_version': 'extra_version'},
+                {'panel_name': 'biff', 'panel_version': 'pow'},
+            ],
+        }
+    }

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -17,8 +17,13 @@ def test_update_results_meta(peddy_ped):
         'metadata': {
             'panel_name': 'biff',
             'panel_version': 'pow',
+            'panel_id': 'wallop',
             'additional_panels': [
-                {'panel_name': 'extra_panel', 'panel_version': 'extra_version'},
+                {
+                    'panel_name': 'extra_panel',
+                    'panel_version': 'extra_version',
+                    'panel_id': 2,
+                },
             ],
         }
     }
@@ -38,8 +43,12 @@ def test_update_results_meta(peddy_ped):
                 '3': 2,
             },
             'panels': [
-                {'panel_name': 'extra_panel', 'panel_version': 'extra_version'},
-                {'panel_name': 'biff', 'panel_version': 'pow'},
+                {
+                    'panel_name': 'extra_panel',
+                    'panel_version': 'extra_version',
+                    'panel_id': 2,
+                },
+                {'panel_name': 'biff', 'panel_version': 'pow', 'panel_id': 'wallop'},
             ],
         }
     }

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -12,7 +12,7 @@ def test_update_results_meta(peddy_ped):
     """
 
     results = {}
-    config = {'input_file': 'foo', 'latest_run': 'bar'}
+    config = {'input_file': 'foo', 'latest_run': 'bar', 'cohort': 'cohort'}
     panelapp = {
         'metadata': {
             'panel_name': 'biff',
@@ -40,6 +40,7 @@ def test_update_results_meta(peddy_ped):
         'metadata': {
             'run_datetime': 'bar',
             'input_file': 'foo',
+            'cohort': 'cohort',
             'family_breakdown': {
                 'affected': 2,
                 'male': 3,

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -14,19 +14,12 @@ def test_update_results_meta(peddy_ped):
     results = {}
     config = {'input_file': 'foo', 'latest_run': 'bar', 'cohort': 'cohort'}
     panelapp = {
-        'metadata': {
-            'panel_name': 'biff',
-            'panel_version': 'pow',
-            'panel_id': 'wallop',
-            'additional_panels': [
-                {
-                    'panel_name': 'extra_panel',
-                    'panel_version': 'extra_version',
-                    'panel_id': 2,
-                },
-            ],
-        }
+        'metadata': [
+            {'name': 'biff', 'version': 'pow', 'id': 'wallop'},
+            {'name': 'extra_panel', 'version': 'extra_version', 'id': 2},
+        ]
     }
+
     ped_samples = ['male', 'female', 'mother_1', 'father_1', 'mother_2', 'father_2']
 
     big_results = update_result_meta(
@@ -49,12 +42,8 @@ def test_update_results_meta(peddy_ped):
                 '3': 2,
             },
             'panels': [
-                {
-                    'panel_name': 'extra_panel',
-                    'panel_version': 'extra_version',
-                    'panel_id': 2,
-                },
-                {'panel_name': 'biff', 'panel_version': 'pow', 'panel_id': 'wallop'},
+                {'name': 'biff', 'version': 'pow', 'id': 'wallop'},
+                {'name': 'extra_panel', 'version': 'extra_version', 'id': 2},
             ],
         }
     }


### PR DESCRIPTION
# Fixes

  - closes #105

## Non-issue changes

A couple of QoL changes to helper scripts, useful when setting up new cohorts to run through AIP

- copies all the 'boilerplate' files from the acute-care bucket to the target bucket (CSQ string header line, VQSR header line, pre-panelapp mendeliome gene list)
- when parsing the pedigree and internal:external ID mapping from metamist, includes a `--copy` argument to additionally push those files directly from local to GCP (saves 2 manual copying operations, will fail if local user doesn't have write permission/is not auth'd)

## Proposed Changes

  - does a better job of logging the names and versions of all panels parsed as part of the analysis (name/version/id) in the panelapp output
  - counts all family structures common between the VCF and pedigree, and writes into the results metadata
  - counts male/female/affected and writes into HTML as a table
  - stores top-level metadata in the output config JSON which is copied into the run output folder
  - use the 'this run' config when running downstream stages
  - adds a trio of tables to the output HTML:
  
1. Panels: The name, ID, and version number of all panels used in the analysis
2. Meta: cohort, run time, and input file used
3. Families: count of number of families of each size, male/female, affected participants 

## Further improvements

1. instead of `don't run step X if the output exists`, find a better way - e.g. incorporate the hash of all extra panel IDs in the panelapp data, or always run a panelapp query and hash the content to decide whether to re-run the hail phase (e.g. check if green genes have changed) - this would require running the panelapp task before the batch is set off (currently they are both dependent jobs, and the hail stage can't be skipped in response to the panelapp result)
2. incorporate the cohort name into the html/json output name? 

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
