### PR TITLE
Remove two tiny files, hard-code content

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -17,7 +17,6 @@ import json
 import logging
 import os
 import sys
-from typing import Any
 
 import click
 from cloudpathlib import AnyPath, CloudPath
@@ -99,12 +98,11 @@ def set_job_resources(
         )
 
 
-def mt_to_vcf(batch: hb.Batch, input_file: str, config: dict[str, Any]):
+def mt_to_vcf(batch: hb.Batch, input_file: str):
     """
     takes a MT and converts to VCF
     :param batch:
     :param input_file:
-    :param config:
     :return:
     """
     mt_to_vcf_job = batch.new_job(name='Convert MT to VCF')
@@ -115,11 +113,6 @@ def mt_to_vcf(batch: hb.Batch, input_file: str, config: dict[str, Any]):
         f'--input {input_file} '
         f'--output {INPUT_AS_VCF}'
     )
-
-    # if the config has an additional header file, add argument
-    vqsr_file = config.get('vqsr_header_file')
-    if vqsr_file:
-        job_cmd += f' --additional_header {vqsr_file}'
 
     logging.info(f'Command used to convert MT: {job_cmd}')
     copy_common_env(mt_to_vcf_job)
@@ -422,9 +415,7 @@ def main(
             ANNOTATED_MT = input_path
 
         else:
-            prior_job = mt_to_vcf(
-                batch=batch, input_file=input_path, config=config_dict
-            )
+            prior_job = mt_to_vcf(batch=batch, input_file=input_path)
             config_dict.update({'vcf_created': INPUT_AS_VCF})
             # overwrite input path with file we just created
             input_path = INPUT_AS_VCF

--- a/reanalysis/reanalysis_conf.json
+++ b/reanalysis/reanalysis_conf.json
@@ -44,7 +44,6 @@
     },
     "filter": {
         "description": "variables for the hail operations, including CSQ sets and filter thresholds",
-        "csq_header_file": "gs://cpg-acute-care-test/reanalysis/csq_header_line.txt",
         "af_semi_rare": 0.01,
         "ac_threshold": 0.01,
         "ref_genome": "GRCh38",
@@ -77,7 +76,6 @@
         "seqr_instance": "https://seqr.populationgenomics.org.au",
         "seqr_project": "R0011_acute_care"
     },
-    "vqsr_header_file": "gs://cpg-acute-care-test/reanalysis/vqsr_header_line.txt",
     "web_suffix": "web",
     "tmp_suffix": "tmp"
 }


### PR DESCRIPTION
# Fixes

  - Closes #113 

## Proposed Changes

  - instead of having 2 one-line files complicating setup of new datasets, hard-code the contents and write at runtime
  - CSQ being hard-coded makes more sense anyway, as the CSQ content/ordering is defined in-code

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
