### PR TITLE
add incidentalome query and tests

### DIFF
--- a/design_docs/PanelApp_interaction.md
+++ b/design_docs/PanelApp_interaction.md
@@ -17,6 +17,12 @@ During an analysis run, the [Query Script](../reanalysis/query_panelapp.py) is u
 for the Mendeliome panel (gene ENSG, symbol, and Mode of Inheritance). This is saved as a dictionary indexed on
 GRCh38/Ensembl 90 ENSG.
 
+## Incidentalome Flag
+
+If the `--cpg_incidentalome` flag is used, the Mendeliome data is supplemented with Incidentalome genes, currently
+restricted to those flagged as being 'cardiac' in PanelApp. This Mendeliome + Incidentalome data becomes the 'default'
+gene list applied to all participants.
+
 ## Additional Panels
 
 If additional gene panel IDs are requested, the following steps are followed:

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -189,6 +189,7 @@ def handle_panelapp_job(
     extra_panels: list[str] | None = None,
     participant_panels: str | None = None,
     prior_job: hb.batch.job.Job | None = None,
+    use_incidentalome: bool = True,
 ) -> hb.batch.job.Job:
     """
 
@@ -196,6 +197,7 @@ def handle_panelapp_job(
     :param extra_panels:
     :param participant_panels:
     :param prior_job:
+    :param use_incidentalome:
     """
     panelapp_job = batch.new_job(name='query panelapp')
     set_job_resources(panelapp_job, auth=True, git=True, prior_job=prior_job)
@@ -207,6 +209,9 @@ def handle_panelapp_job(
 
     if participant_panels:
         panelapp_command += f'--panel_file {participant_panels} '
+
+    if use_incidentalome:
+        panelapp_command += '--cpg_incidentalome'
 
     if prior_job is not None:
         panelapp_job.depends_on(prior_job)

--- a/test/input/incidentalome.json
+++ b/test/input/incidentalome.json
@@ -19,6 +19,22 @@
       "entity_name": "ABCD",
       "confidence_level": "3",
       "mode_of_inheritance": "REALLY_BIG"
+    },
+    {
+      "gene_data": {
+        "ensembl_genes": {
+          "GRch38": {
+            "90": {
+              "ensembl_id": "ENSG00WXYZ"
+            }
+          }
+        }
+      },
+      "entity_type": "gene",
+      "entity_name": "WXYZ",
+      "confidence_level": "3",
+      "mode_of_inheritance": "MONOALLELIC",
+      "tags": ["cardiac"]
     }
   ]
 }

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -11,9 +11,10 @@ from reanalysis.query_panelapp import (
     get_json_response,
     get_panel_green,
     parse_gene_list,
-    combine_mendeliome_with_other_panels,
+    combine_panels,
     grab_genes_only,
     get_list_from_participants,
+    INCIDENTALOME,
 )
 
 
@@ -21,11 +22,9 @@ PWD = os.path.dirname(__file__)
 INPUT = os.path.join(PWD, 'input')
 PANELAPP_LATEST = os.path.join(INPUT, 'panelapp_current_137.json')
 PANELAPP_INCIDENTALOME = os.path.join(INPUT, 'incidentalome.json')
-PANELAPP_OLDER = os.path.join(INPUT, 'panelapp_older_137.json')
 LATEST_EXPECTED = os.path.join(INPUT, 'panel_green_latest_expected.json')
 CHANGES_EXPECTED = os.path.join(INPUT, 'panel_changes_expected.json')
 FAKE_GENE_LIST = os.path.join(INPUT, 'fake_gene_list.json')
-OLD_VERSION = 'old'
 
 
 @pytest.fixture(name='fake_panelapp')
@@ -47,13 +46,6 @@ def fixture_fake_panelapp(requests_mock):
             'https://panelapp.agha.umccr.org/api/v1/panels/126',
             json=json.load(handle),
         )
-    with open(PANELAPP_OLDER, 'r', encoding='utf-8') as handle:
-        requests_mock.register_uri(
-            'GET',
-            f'https://panelapp.agha.umccr.org/api/v1/panels/137?version={OLD_VERSION}',
-            complete_qs=True,
-            json=json.load(handle),
-        )
 
 
 def test_panel_query(fake_panelapp):  # pylint: disable=unused-argument
@@ -62,7 +54,7 @@ def test_panel_query(fake_panelapp):  # pylint: disable=unused-argument
     :param fake_panelapp:
     :return:
     """
-    result = get_panel_green(panel_id='137')
+    result = get_panel_green()
     with open(LATEST_EXPECTED, 'r', encoding='utf-8') as handle:
         expected = json.load(handle)
 
@@ -94,6 +86,18 @@ def test_get_json_response(fake_panelapp):  # pylint: disable=unused-argument
         assert result == json.load(handle)
 
 
+def test_tagged_incidentalome(fake_panelapp):  # pylint: disable=unused-argument
+    """
+    only grab the cardiac flagged variants
+    :param fake_panelapp:
+    :return:
+    """
+    results = get_panel_green(panel_id=INCIDENTALOME, keep_tags=['cardiac'])
+    key_set = set(list(results.keys()))
+    assert len(key_set) == 2
+    assert key_set == {'metadata', 'ENSG00WXYZ'}
+
+
 def test_parse_local_gene_list():
     """
     test parsing of a local file
@@ -107,11 +111,11 @@ def test_second_panel_update(fake_panelapp):  # pylint: disable=unused-argument
     """
     check that the combination method works
     """
-    main = get_panel_green('137')
+    main = get_panel_green()
     early_keys = set(main.keys())
     additional = get_panel_green('126')
-    combine_mendeliome_with_other_panels(main, additional)
-    assert set(main.keys()) == early_keys
+    combine_panels(main, additional)
+    assert set(main.keys()) == early_keys.union({'ENSG00WXYZ'})
     assert main['ENSG00ABCD'].get('flags') == ['Incidentalome']
 
 
@@ -128,7 +132,7 @@ def test_second_panel_update_moi():
         'metadata': [{'name': 'NAME', 'version': '1.0', 'id': '123'}],
         'ensg1': {'entity_name': '1', 'moi': 'REALLY_BIG'},
     }
-    combine_mendeliome_with_other_panels(main, additional)
+    combine_panels(main, additional)
     assert main['ensg1'].get('flags') == ['NAME']
     assert main['ensg1'].get('moi') == 'REALLY_BIG'
     assert len(main['metadata']) == 2
@@ -149,7 +153,7 @@ def test_second_panel_no_overlap():
         'metadata': [{'name': 'ADD', 'version': '1.1', 'id': '2'}],
         'ensg2': {'entity_name': '2', 'moi': 'REALLY_BIG'},
     }
-    combine_mendeliome_with_other_panels(main, additional)
+    combine_panels(main, additional)
     assert main['ensg1'].get('flags') == []
     assert main['ensg1'].get('moi') is None
     assert main['ensg2'].get('flags') == ['ADD']


### PR DESCRIPTION
# Fixes

  - Closes #116 

## Proposed Changes

  - adds a non-default flag option to query for the panelapp stage
  - if used, this flag means that the core panel data becomes Mendeliome + Cardiac Incidentalome instead of just the Mendeliome
  - 'cardiac' Incidentalome is determined using flags
  - The Flag-matching mechanic is available for any other potential flags

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
