### PR TITLE
adds script to copy csiro data to release bucket

### DIFF
--- a/release_scripts/csiro_release.sh
+++ b/release_scripts/csiro_release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# https://github.com/populationgenomics/seqr-private/issues/11
+
+# copy single files
+gsutil -m -u acute-care-321904 cp \
+    gs://cpg-acute-care-test/csiro_copy/callset.vcf.bgz \
+    gs://cpg-acute-care-test/csiro_copy/hpo_terms.json \
+    gs://cpg-acute-care-test/csiro_copy/hpo_terms.tsv \
+    gs://cpg-acute-care-test/csiro_copy/pedigree.fam \
+    gs://cpg-acute-care-release/csiro


### PR DESCRIPTION
# Fixes

  - https://github.com/populationgenomics/seqr-private/issues/11

## Proposed Changes

  - adds a bash script to copy relevant CSIRO data to a release bucket