### PR TITLE
check the AC/AF/AN attributes at the top level, instead of in info

### DIFF
--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -323,7 +323,7 @@ def test_ac_threshold(
     :return:
     """
     config = {'min_samples_to_ac_filter': 0, 'ac_threshold': 0.1}
-    anno_mt = hail_matrix.annotate_rows(info=hail_matrix.info.annotate(AC=ac, AN=an))
+    anno_mt = hail_matrix.annotate_rows(AC=ac, AN=an)
     assert run_ac_check(anno_mt, config) == results
 
 

--- a/test/test_hail_broad_filters.py
+++ b/test/test_hail_broad_filters.py
@@ -30,7 +30,7 @@ def test_ac_filter_no_filt(ac: int, an: int, threshold: float, rows: int, hail_m
     """
     run tests on the ac filtering method
     """
-    matrix = hail_matrix.annotate_rows(info=hail_matrix.info.annotate(AC=ac, AN=an))
+    matrix = hail_matrix.annotate_rows(AC=ac, AN=an)
     assert filter_matrix_by_ac(matrix, threshold).count_rows() == rows
 
 


### PR DESCRIPTION
# Fixes

  - closes #123 

## Proposed Changes

  - Shifts logic to using the AC, AF, AN in `mt.X` instead of `mt.info.X`

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
