### PR TITLE
correction to syntax

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -108,7 +108,7 @@ def fields_audit(mt: hl.MatrixTable) -> bool:
     problems = []
     # iterate over top-level attributes
     for annotation, datatype in BASE_FIELDS_REQUIRED:
-        if annotation in mt:
+        if annotation in mt.row_value or annotation in mt.row_key:
             if not isinstance(mt[annotation], datatype):
                 problems.append(f'{annotation}: {datatype}/{type(mt[annotation])}')
         else:


### PR DESCRIPTION
# Fixes

  - relevant to #123

## Proposed Changes

  - I left some incorrect syntax in the previous PR
  - for top level attributes, you need to check either `row_key` or `row_value` when checking if an annotation exists
  - for any further nested level it's fine to check `if X in mt.info`

## Checklist

- [x] Related Issue created
-  [x] Linting checks pass
