### PR TITLE
Write human results in analysis

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -500,8 +500,10 @@ def main(
 
     # write pedigree content to the output folder
     to_path(pedigree).copy(
-        output_path(f'pedigree_{EXECUTION_TIME}.fam'),
-        get_config()['buckets'].get('analysis_suffix'),
+        output_path(
+            f'pedigree_{EXECUTION_TIME}.fam',
+            get_config()['buckets'].get('analysis_suffix'),
+        )
     )
     # endregion
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -54,7 +54,9 @@ INPUT_AS_VCF = output_path('prior_to_annotation.vcf.bgz')
 ANNOTATED_MT = output_path('annotated_variants.mt')
 
 # panelapp query results
-PANELAPP_JSON_OUT = output_path('panelapp_data')
+PANELAPP_JSON_OUT = output_path(
+    'panelapp_data', get_config()['buckets'].get('analysis_suffix')
+)
 
 # output of labelling task in Hail
 HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
@@ -346,13 +348,17 @@ def main(
             'web_html': output_path(
                 'summary_output.html', get_config()['buckets'].get('web_suffix')
             ),
-            'results': output_path('summary_results'),
+            'results': output_path(
+                'summary_results', get_config()['buckets'].get('analysis_suffix')
+            ),
         },
         'singletons': {
             'web_html': output_path(
                 'singleton_output.html', get_config()['buckets'].get('web_suffix')
             ),
-            'results': output_path('singleton_results'),
+            'results': output_path(
+                'singleton_results', get_config()['buckets'].get('analysis_suffix')
+            ),
         },
     }
     # endregion
@@ -456,7 +462,12 @@ def main(
     # if singleton PED supplied, also run as singletons w/separate outputs
     analysis_rounds = [(pedigree_in_batch, 'default')]
     if singletons and to_path(singletons).exists():
-        to_path(singletons).copy(output_path(f'singletons_{EXECUTION_TIME}.fam'))
+        to_path(singletons).copy(
+            output_path(
+                f'singletons_{EXECUTION_TIME}.fam',
+                get_config()['buckets'].get('analysis_suffix'),
+            )
+        )
         pedigree_singletons = batch.read_input(singletons)
         analysis_rounds.append((pedigree_singletons, 'singletons'))
     # endregion
@@ -481,11 +492,17 @@ def main(
     # include datetime to differentiate output files and prevent clashes
     if participant_panels:
         to_path(participant_panels).copy(
-            output_path(f'pid_to_panels_{EXECUTION_TIME}.json')
+            output_path(
+                f'pid_to_panels_{EXECUTION_TIME}.json',
+                get_config()['buckets'].get('analysis_suffix'),
+            )
         )
 
     # write pedigree content to the output folder
-    to_path(pedigree).copy(output_path(f'pedigree_{EXECUTION_TIME}.fam'))
+    to_path(pedigree).copy(
+        output_path(f'pedigree_{EXECUTION_TIME}.fam'),
+        get_config()['buckets'].get('analysis_suffix'),
+    )
     # endregion
 
     batch.run(wait=False)

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -1,6 +1,7 @@
 [buckets]
 web_suffix = "web"
 tmp_suffix = "tmp"
+analysis_suffix = "analysis"
 
 [moi_tests]
 description = "thresholds for different filters during the MOI checks"


### PR DESCRIPTION
# Fixes

  - closes #137 

## Proposed Changes

  - Writes human-useful files to the `-analysis` subset bucket instead of directly in main
  - This fragments the output across more folders, but makes it user-accessible as/when required, e.g. debugging
  - Summary JSON, Pedigree(s), and PanelApp data
  - Takes the analysis suffix from config, where it can be missing/None (i.e. if the deployment doesn't have a separate analysis bucket, results will be written to the regular location)

## Checklist

- [x] Related Issue created
- [x] Linting checks pass
