### PR TITLE
Reconcile clinvar submissions (1)

### DIFF
--- a/clinvar/clinvar.toml
+++ b/clinvar/clinvar.toml
@@ -1,0 +1,2 @@
+[references]
+genome_build='GRCh38'

--- a/clinvar/conflict_huntr.py
+++ b/clinvar/conflict_huntr.py
@@ -428,10 +428,10 @@ def main(
 
         all_decisions.append(
             {
-                'locus': hl.Locus(
-                    contig=allele_map[allele_id]['chrom'],
-                    position=allele_map[allele_id]['pos'],
-                ),
+                # 'locus': hl.Locus(
+                #     contig=allele_map[allele_id]['chrom'],
+                #     position=allele_map[allele_id]['pos'],
+                # ),
                 'alleles': [allele_map[allele_id]['ref'], allele_map[allele_id]['alt']],
                 'contig': allele_map[allele_id]['chrom'],
                 'position': allele_map[allele_id]['pos'],

--- a/clinvar/conflict_huntr.py
+++ b/clinvar/conflict_huntr.py
@@ -168,9 +168,16 @@ def lines_from_gzip(filename: str) -> str:
             yield line.rstrip().split('\t')
 
 
-def county_county(subs: list[Submission]) -> Consequence:
+def consequence_decision(subs: list[Submission]) -> Consequence:
     """
-    count different consequence assignments
+    determine overall consequence assignment based on
+    remaining submissions
+
+    Args:
+        subs (): a list of submission objects for this allele
+
+    Returns:
+        a single Consequence object
     """
     # pylint: disable=R0912
 
@@ -416,7 +423,7 @@ def main(
         submissions = acmg_filter_submissions(submissions)
 
         # obtain an aggregate rating
-        rating = county_county(submissions)
+        rating = consequence_decision(submissions)
 
         # assess stars in remaining entries
         stars = check_stars(submissions)

--- a/clinvar/conflict_huntr.py
+++ b/clinvar/conflict_huntr.py
@@ -19,6 +19,7 @@ variant_summary.txt
 
 
 import gzip
+import json
 import logging
 from argparse import ArgumentParser
 from collections import defaultdict
@@ -443,6 +444,9 @@ def main(
 
     # sort all collected decisions, trying to reduce overhead in HT later
     all_decisions = sort_decisions(all_decisions)
+
+    with to_path(output_path(out_path).replace('.mt', '.json')).open('w') as handle:
+        json.dump(all_decisions, handle)
 
     ht = dict_list_to_ht(all_decisions)
 

--- a/clinvar/conflict_huntr.py
+++ b/clinvar/conflict_huntr.py
@@ -1,0 +1,545 @@
+"""
+reads over the clinvar submissions
+identifies consensus and disagreements
+
+Requires two files from
+https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/
+
+submission_summary.txt
+ - all individual submissions to ClinVar
+relevant fields:
+1.  VariationID: the identifier assigned by ClinVar
+2.  ClinicalSignificance:
+7.  ReviewStatus: the level of review for this submission, namely
+10. Submitter
+
+variant_summary.txt
+ - links clinvar AlleleID, Variant ID, position and alleles
+"""
+
+
+import gzip
+import logging
+from argparse import ArgumentParser
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from itertools import chain, islice
+
+import hail as hl
+import pandas as pd
+
+from cpg_utils import to_path, CloudPath
+from cpg_utils.hail_batch import output_path, init_batch
+
+
+BENIGN_SIGS = {'Benign', 'Likely benign', 'Benign/Likely benign', 'protective'}
+CONFLICTING = 'conflicting data from submitters'
+PATH_SIGS = {
+    'Pathogenic',
+    'Likely pathogenic',
+    'Pathogenic, low penetrance',
+    'Likely pathogenic, low penetrance',
+    'Pathogenic/Likely pathogenic',
+}
+UNCERTAIN_SIGS = {'Uncertain significance', 'Uncertain risk allele'}
+USELESS_RATINGS = {'no assertion criteria provided'}
+MEGA_BLACKLIST = [
+    'victorian clinical genetics services,murdoch childrens research institute'
+]
+MAJORITY_RATIO = 0.6
+MINORITY_RATIO = 0.2
+STRONG_REVIEWS = ['practice guideline', 'reviewed by expert panel']
+
+# published Nov 2015, available pre-print since March 2015
+# assumed to be influential since 2016
+ACMG_THRESHOLD = datetime(year=2016, month=1, day=1)
+VERY_OLD = datetime(year=1970, month=1, day=1)
+LARGEST_COMPLEX_INDELS = 40
+
+
+class Consequence(Enum):
+    """
+    csq enumeration
+    """
+
+    BENIGN = 'Benign'
+    CONFLICTING = 'Conflicting'
+    PATHOGENIC = 'Pathogenic'
+    UNCERTAIN = 'VUS'
+    UNKNOWN = 'Unknown'
+
+
+# submitters which aren't trusted for a subset of consequences
+QUALIFIED_BLACKLIST = [(Consequence.BENIGN, {'Illumina Laboratory Services; Illumina'})]
+
+
+@dataclass
+class Submission:
+    """
+    POPO to store details on each Submission
+    """
+
+    date: datetime
+    submitter: str
+    classification: Consequence
+    review_status: str
+
+
+def chunks(iterable, chunk_size):
+    """
+    Yield successive n-sized chunks from an iterable
+
+    Args:
+        iterable (): any iterable - tuple, str, list, set
+        chunk_size (): size of intervals to return
+
+    Returns:
+        intervals of requested size across the collection
+    """
+
+    if isinstance(iterable, set):
+        iterable = list(iterable)
+
+    for i in range(0, len(iterable), chunk_size):
+        yield iterable[i : (i + chunk_size)]
+
+
+def generator_chunks(generator, size):
+    """
+    Iterates across a generator, returning specifically sized chunks
+
+    Args:
+        generator (): any generator or method implementing yield
+        size (): size of iterator to return
+
+    Returns:
+        a subset of the generator results
+    """
+    iterator = iter(generator)
+    for first in iterator:
+        yield list(chain([first], islice(iterator, size - 1)))
+
+
+def get_allele_locus_map(summary_file: str) -> tuple[dict, set]:
+    """
+    Process variant_summary.txt
+     - links the allele ID, Locus/Alleles, and variant ID
+    relevant fields:
+    0 #AlleleID
+    20 Chromosome
+    30 VariationID
+    31 Start
+    32 ReferenceAllele
+    33 AlternateAllele
+
+    Args:
+        summary_file (str): path to the gzipped text file
+
+    Returns:
+
+    """
+
+    allele_dict = {}
+    all_contigs = set()
+
+    for line in lines_from_gzip(summary_file):
+        if 'GRCh37' in line:
+            continue
+
+        # pull values from the line
+        allele_id = line[0]
+        chromosome = line[18] if 'chr' in line[18] else f'chr{line[18]}'
+        var_id = line[30]
+        pos = int(line[31])
+        ref = line[32]
+        alt = line[33]
+
+        # skip chromosomal deletions and insertions, mito, or massive indels
+        # this might break hail?
+        if (
+            ref == 'na'
+            or alt == 'na'
+            or 'm' in chromosome.lower()
+            or (len(ref) + len(alt)) > LARGEST_COMPLEX_INDELS
+        ):
+            continue
+
+        all_contigs.add(chromosome)
+
+        allele_dict[var_id] = {
+            'allele': allele_id,
+            'chrom': chromosome,
+            'pos': pos,
+            'ref': ref,
+            'alt': alt,
+        }
+
+    return allele_dict, all_contigs
+
+
+def lines_from_gzip(filename: str) -> str:
+    """
+    generator for gzip reading
+    copies file to local prior to reading
+
+    Args:
+        filename (): the gzipped input file
+
+    Returns:
+        generator - yields each line
+    """
+
+    if isinstance(to_path(filename), CloudPath):
+        tempfile = 'file.txt.gz'
+        to_path(filename).copy(tempfile)
+        filename = tempfile
+
+    with gzip.open(filename, 'rt') as handle:
+        for line in handle:
+            if line.startswith('#'):
+                continue
+            yield line.rstrip().split('\t')
+
+
+def county_county(subs: list[Submission]) -> Consequence:
+    """
+    count different consequence assignments
+    """
+    # pylint: disable=R0912
+
+    # start with a default consequence
+    decision = Consequence.UNCERTAIN
+
+    # establish counts
+    benign = 0
+    pathogenic = 0
+    uncertain = 0
+    total = 0
+
+    for each_sub in subs:
+
+        # for 3/4-star ratings, don't look any further
+        if each_sub.review_status in STRONG_REVIEWS:
+            return each_sub.classification
+
+        total += 1
+        if each_sub.classification == Consequence.PATHOGENIC:
+            pathogenic += 1
+        elif each_sub.classification == Consequence.BENIGN:
+            benign += 1
+        elif each_sub.classification == Consequence.UNCERTAIN:
+            uncertain += 1
+
+    # no entries - no decision
+    if total == 0:
+        return decision
+
+    if pathogenic and benign:
+        if pathogenic == benign:
+            decision = Consequence.CONFLICTING
+
+        elif (max(pathogenic, benign) >= (total * MAJORITY_RATIO)) and (
+            min(pathogenic, benign) <= (total * MINORITY_RATIO)
+        ):
+            decision = (
+                Consequence.BENIGN if benign > pathogenic else Consequence.PATHOGENIC
+            )
+        else:
+            decision = Consequence.CONFLICTING
+
+    elif uncertain >= total / 2:
+        decision = Consequence.UNCERTAIN
+
+    elif pathogenic:
+        decision = Consequence.PATHOGENIC
+
+    elif benign:
+        decision = Consequence.BENIGN
+
+    return decision
+
+
+def check_stars(subs: list[Submission]) -> int:
+    """
+    processes the submissions, and assigns a 'gold star' rating
+    Args:
+        subs (): list of all submissions at this allele
+
+    Returns:
+        integer, summarising the rating
+    """
+    minimum = 0
+    for sub in subs:
+        if sub.review_status == 'practice guideline':
+            return 4
+        if sub.review_status == 'reviewed by expert panel':
+            return 3
+        if 'criteria provided' in sub.review_status:
+            minimum = 1
+
+    return minimum
+
+
+def process_line(data: str) -> tuple[str, Submission]:
+    """
+    takes a line array and strips out useful content
+    :param data: the un-split TSV content
+    """
+    allele_id = data[0]
+    if data[1] in PATH_SIGS:
+        classification = Consequence.PATHOGENIC
+    elif data[1] in BENIGN_SIGS:
+        classification = Consequence.BENIGN
+    elif data[1] in UNCERTAIN_SIGS:
+        classification = Consequence.UNCERTAIN
+    else:
+        classification = Consequence.UNKNOWN
+    date = datetime.strptime(data[2], '%b %d, %Y') if data[2] != '-' else VERY_OLD
+    sub = data[9].lower()
+    rev_status = data[6].lower()
+
+    return allele_id, Submission(date, sub, classification, rev_status)
+
+
+def dict_list_to_ht(list_of_dicts: list) -> hl.Table:
+    """
+    takes the per-allele results and aggregates into a hl.Table
+
+    Args:
+        list_of_dicts ():
+
+    Returns:
+        Hail table of the same content, indexed on locus & alleles
+
+    """
+
+    # convert list of dictionaries to a DataFrame
+    pdf = pd.DataFrame(list_of_dicts)
+
+    # convert DataFrame to a Table, keyed on Locus & Alleles
+    return hl.Table.from_pandas(pdf, key=['locus', 'alleles'])
+
+
+def get_all_decisions(
+    submission_file: str, threshold_date: datetime, allele_ids: set
+) -> dict[str, list[Submission]]:
+    """
+    obtains all submissions per-allele which pass basic criteria
+        - not a blacklisted submitter
+        - not a csq-specific blacklisted submitter
+        - not after the user-specified date
+
+    Args:
+        submission_file ():
+        threshold_date ():
+        allele_ids ():
+
+    Returns:
+
+    """
+    submission_dict = defaultdict(list)
+
+    for line in lines_from_gzip(submission_file):
+
+        a_id, line_sub = process_line(line)
+
+        # skip any rows where the variantID isn't in this mapping
+        # this saves a little effort on haplotypes, CNVs, and SVs
+        if (
+            (a_id not in allele_ids)
+            or (line_sub.submitter in MEGA_BLACKLIST)
+            or (line_sub.date > threshold_date)
+            or (line_sub.review_status in USELESS_RATINGS)
+            or (line_sub.classification == Consequence.UNKNOWN)
+        ):
+            continue
+
+        # screen out some submitters per-consequence
+        for consequence, submitters in QUALIFIED_BLACKLIST:
+            if (
+                line_sub.classification == consequence
+                and line_sub.submitter in submitters
+            ):
+                continue
+
+        submission_dict[a_id].append(line_sub)
+
+    return submission_dict
+
+
+def acmg_filter_submissions(subs: list[Submission]) -> list[Submission]:
+    """
+    filter submissions by dates
+    if any submissions for this variant occur after the ACMG introduction
+        - only return those
+    if not
+        - return all submissions
+
+    Just to remove the possibility of removing expert curations, we won't
+    date filter any expert/manual entries this way
+
+    Args:
+        subs (): list of submissions
+
+    Returns:
+        either all submissions if none are after the ACMG cut-off
+        or, if newer entries exist, only those after cut-off
+    """
+
+    # apply the date threshold to all submissions
+    date_filt_subs = [
+        sub
+        for sub in subs
+        if sub.date >= ACMG_THRESHOLD or sub.review_status in STRONG_REVIEWS
+    ]
+
+    # if this contains results, return only those
+    if date_filt_subs:
+        return date_filt_subs
+
+    # default to returning everything
+    return subs
+
+
+def ht_from_contig(contig: str, all_decisions: list[dict]) -> hl.Table:
+    """
+    filters to this contig only, generates table
+    Args:
+        contig ():
+        all_decisions ():
+
+    Returns:
+        a Hail Table of the relevant decisions
+    """
+
+    logging.info(f'Generating a Hail Table from {contig}')
+
+    contig_decisions = [
+        each_dict for each_dict in all_decisions if each_dict['locus'].contig == contig
+    ]
+
+    return dict_list_to_ht(contig_decisions)
+
+
+def main(
+    submissions_file: str,
+    summary: str,
+    out_path: str,
+    threshold_date: datetime,
+):
+    """
+
+    Args:
+        submissions_file (): file path to all submissions (gzipped)
+        summary (): file path to variant summary (gzipped)
+        out_path (): path to write JSON out to
+        threshold_date (): date threshold to use for filtering submissions
+    """
+
+    logging.info('Getting all alleleID-VariantID-Loci from variant summary')
+    allele_map, all_contigs = get_allele_locus_map(summary)
+
+    # ordered list of all the loci actually identified
+    ordered_alleles = [
+        f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y'] if f'chr{x}' in all_contigs
+    ]
+
+    logging.info('Getting all decisions, indexed on clinvar AlleleID')
+    decision_dict = get_all_decisions(
+        submission_file=submissions_file,
+        threshold_date=threshold_date,
+        allele_ids=set(allele_map.keys()),
+    )
+
+    # placeholder to fill wth per-allele decisions
+    all_decisions = []
+
+    # now filter each set of decisions per allele
+    for allele_id, submissions in decision_dict.items():
+        # filter against ACMG date
+        submissions = acmg_filter_submissions(submissions)
+
+        # obtain an aggregate rating
+        rating = county_county(submissions)
+
+        # assess stars in remaining entries
+        stars = check_stars(submissions)
+
+        # for now, skip over variants which are not relevant to AIP
+        if rating in [Consequence.UNCERTAIN, Consequence.UNKNOWN]:
+            continue
+
+        all_decisions.append(
+            {
+                'id': allele_id,
+                'rating': rating.value,
+                'stars': stars,
+                'allele_id': allele_map[allele_id]['allele'],
+                'locus': hl.Locus(
+                    contig=allele_map[allele_id]['chrom'],
+                    position=allele_map[allele_id]['pos'],
+                ),
+                'alleles': [allele_map[allele_id]['ref'], allele_map[allele_id]['alt']],
+            }
+        )
+
+    # placeholder for hail table
+    base_table = None
+
+    # process each contig's entries into a Hail Table
+    # write to disk separately, and append to a master table
+    for contig in ordered_alleles:
+        logging.info(f'Processing Contig {contig}')
+        write_path = output_path(f'{contig}_{out_path}')
+        if to_path(write_path).exists():
+            logging.info(f'{write_path} already exists, reading')
+            ht = hl.read_table(write_path)
+
+        else:
+            # save a hail table of this contig to disk
+            ht = ht_from_contig(contig, all_decisions)
+            if ht.count() > 0:
+                ht.write(output=write_path, overwrite=True)
+            else:
+                logging.info(f'No entries on {contig}')
+                continue
+
+        # update the whole-genome table
+        if base_table is None:
+            base_table = ht
+        else:
+            base_table = base_table.union(ht)
+
+    # write out the aggregated table
+    base_table.write(output_path(out_path), overwrite=True)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    parser = ArgumentParser()
+    parser.add_argument('-s', help='submission_summary.txt.gz from NCBI', required=True)
+    parser.add_argument('-v', help='variant_summary.txt.gz from NCBI', required=True)
+    parser.add_argument(
+        '-d',
+        help='date, format DD-MM-YYYY - submissions after this date '
+        'will be removed. Un-dated submissions will pass this threshold',
+        default=datetime.now(),
+    )
+    parser.add_argument('-o', help='output filename', required=True)
+    args = parser.parse_args()
+
+    processed_date = (
+        datetime.strptime(args.d, '%d-%m-%Y') if isinstance(args.d, str) else args.d
+    )
+
+    init_batch()
+
+    main(
+        submissions_file=args.s,
+        summary=args.v,
+        threshold_date=processed_date,
+        out_path=args.o,
+    )

--- a/clinvar/conflict_huntr.py
+++ b/clinvar/conflict_huntr.py
@@ -469,7 +469,7 @@ if __name__ == '__main__':
         datetime.strptime(args.d, '%d-%m-%Y') if isinstance(args.d, str) else args.d
     )
 
-    init_batch()
+    init_batch(worker_memory='highmem', worker_cores=8)
 
     main(
         submissions_file=args.s,

--- a/clinvar/run_conflict_huntr.sh
+++ b/clinvar/run_conflict_huntr.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# set the date, or provide a default
+DATE=${1:-$(date +%F)}
+
+# run
+analysis-runner \
+    --config clinvar/config.toml \
+    --dataset acute-care \
+    --description "Process clinvar annotations" \
+    -o "clinvar_${DATE}" \
+    --access-level test \
+    --cpu 8 \
+        python3 clinvar/conflict_huntr.py \
+        -s gs://cpg-acute-care-test/clinvar_annotations/submission_summary.txt.gz \
+        -v gs://cpg-acute-care-test/clinvar_annotations/variant_summary.txt.gz \
+        -o clinvar_reprocessed.ht

--- a/clinvar/run_conflict_huntr.sh
+++ b/clinvar/run_conflict_huntr.sh
@@ -7,7 +7,7 @@ DATE=${1:-$(date +%F)}
 
 # run
 analysis-runner \
-    --config clinvar/config.toml \
+    --config clinvar/clinvar.toml \
     --dataset acute-care \
     --description "Process clinvar annotations" \
     -o "clinvar_${DATE}" \

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -6,7 +6,7 @@ which may be shared across reanalysis components
 from collections import defaultdict
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
-from itertools import combinations_with_replacement
+from itertools import chain, combinations_with_replacement, islice
 from pathlib import Path
 from typing import Any, Union
 
@@ -40,6 +40,41 @@ CHROM_ORDER = list(map(str, range(1, 23))) + [
 
 X_CHROMOSOME = {'X'}
 NON_HOM_CHROM = {'Y', 'MT', 'M'}
+
+
+def chunks(iterable, chunk_size):
+    """
+    Yield successive n-sized chunks from an iterable
+
+    Args:
+        iterable (): any iterable - tuple, str, list, set
+        chunk_size (): size of intervals to return
+
+    Returns:
+        intervals of requested size across the collection
+    """
+
+    if isinstance(iterable, set):
+        iterable = list(iterable)
+
+    for i in range(0, len(iterable), chunk_size):
+        yield iterable[i : (i + chunk_size)]
+
+
+def generator_chunks(generator, size):
+    """
+    Iterates across a generator, returning specifically sized chunks
+
+    Args:
+        generator (): any generator or method implementing yield
+        size (): size of iterator to return
+
+    Returns:
+        a subset of the generator results
+    """
+    iterator = iter(generator)
+    for first in iterator:
+        yield list(chain([first], islice(iterator, size - 1)))
 
 
 class FileTypes(Enum):

--- a/test/clinvar/test_clinvar_resolutions.py
+++ b/test/clinvar/test_clinvar_resolutions.py
@@ -10,7 +10,7 @@ from clinvar.conflict_huntr import (
     ACMG_THRESHOLD,
     Consequence,
     Submission,
-    county_county,
+    consequence_decision,
     check_stars,
     acmg_filter_submissions,
     sort_decisions,
@@ -98,76 +98,76 @@ def tests_acmg_filter_gte():
 
 def test_county_empty():
     """No entries == Uncertain"""
-    assert county_county(subs=[]) == Consequence.UNCERTAIN
+    assert consequence_decision(subs=[]) == Consequence.UNCERTAIN
 
 
 def test_county_all_path():
     """pathogenic if everything is pathogenic"""
-    assert county_county([PATH_SUB] * 10) == Consequence.PATHOGENIC
+    assert consequence_decision([PATH_SUB] * 10) == Consequence.PATHOGENIC
 
 
 def test_county_all_benign():
     """benign if everything is benign"""
-    assert county_county([BENIGN_SUB] * 10) == Consequence.BENIGN
+    assert consequence_decision([BENIGN_SUB] * 10) == Consequence.BENIGN
 
 
 def test_county_all_uncertain():
     """uncertain if everything is uncertain"""
-    assert county_county([UNCERTAIN_SUB] * 10) == Consequence.UNCERTAIN
+    assert consequence_decision([UNCERTAIN_SUB] * 10) == Consequence.UNCERTAIN
 
 
 def test_county_equal_path_benign():
     """equal path and benign == conflicting"""
     subs = ([BENIGN_SUB] * 10) + ([PATH_SUB] * 10)
-    assert county_county(subs) == Consequence.CONFLICTING
+    assert consequence_decision(subs) == Consequence.CONFLICTING
 
 
 def test_county_path_majority():
     """path on 60-20 split"""
     subs = ([BENIGN_SUB] * 2) + ([PATH_SUB] * 6) + ([UNCERTAIN_SUB] * 2)
-    assert county_county(subs) == Consequence.PATHOGENIC
+    assert consequence_decision(subs) == Consequence.PATHOGENIC
 
 
 def test_county_path_almost_majority():
     """conflicting on borderline ratios"""
     subs = ([BENIGN_SUB] * 2) + ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 2)
-    assert county_county(subs) == Consequence.CONFLICTING
+    assert consequence_decision(subs) == Consequence.CONFLICTING
 
 
 def test_county_benign_majority():
     """benign on 60-20 split"""
     subs = ([BENIGN_SUB] * 6) + ([PATH_SUB] * 2) + ([UNCERTAIN_SUB] * 2)
-    assert county_county(subs) == Consequence.BENIGN
+    assert consequence_decision(subs) == Consequence.BENIGN
 
 
 def test_county_benign_almost_majority():
     """conflicting on borderline ratios"""
     subs = ([BENIGN_SUB] * 5) + ([PATH_SUB] * 2) + ([UNCERTAIN_SUB] * 2)
-    assert county_county(subs) == Consequence.CONFLICTING
+    assert consequence_decision(subs) == Consequence.CONFLICTING
 
 
 def test_county_benign_vs_unknown():
     """benign on slim majority vs VUS"""
     subs = ([BENIGN_SUB] * 5) + ([UNCERTAIN_SUB] * 4)
-    assert county_county(subs) == Consequence.BENIGN
+    assert consequence_decision(subs) == Consequence.BENIGN
 
 
 def test_county_pathogenic_vs_unknown():
     """pathogenic on slim majority vs VUS"""
     subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 4)
-    assert county_county(subs) == Consequence.PATHOGENIC
+    assert consequence_decision(subs) == Consequence.PATHOGENIC
 
 
 def test_county_uncertain_from_mix():
     """VUS if 50% or more VUS"""
     subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 5)
-    assert county_county(subs) == Consequence.UNCERTAIN
+    assert consequence_decision(subs) == Consequence.UNCERTAIN
 
 
 def test_county_uncertain_from_majority():
     """VUS if 50% or more VUS"""
     subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 6)
-    assert county_county(subs) == Consequence.UNCERTAIN
+    assert consequence_decision(subs) == Consequence.UNCERTAIN
 
 
 def test_county_take_reviewed():
@@ -176,7 +176,7 @@ def test_county_take_reviewed():
     sub1.review_status = 'reviewed by expert panel'
     sub1.classification = Consequence.PATHOGENIC
     subs = [sub1] + ([BENIGN_SUB] * 6)
-    assert county_county(subs) == Consequence.PATHOGENIC
+    assert consequence_decision(subs) == Consequence.PATHOGENIC
 
 
 def test_sort_decisions():

--- a/test/clinvar/test_clinvar_resolutions.py
+++ b/test/clinvar/test_clinvar_resolutions.py
@@ -13,6 +13,7 @@ from clinvar.conflict_huntr import (
     county_county,
     check_stars,
     acmg_filter_submissions,
+    sort_decisions,
 )
 
 
@@ -176,3 +177,22 @@ def test_county_take_reviewed():
     sub1.classification = Consequence.PATHOGENIC
     subs = [sub1] + ([BENIGN_SUB] * 6)
     assert county_county(subs) == Consequence.PATHOGENIC
+
+
+def test_sort_decisions():
+    """blah"""
+
+    subs = [
+        {'contig': 'chr1', 'position': 1234},
+        {'contig': 'chr3', 'position': 1234},
+        {'contig': 'chrM', 'position': 1234},
+        {'contig': 'chr2', 'position': 1234},
+        {'contig': 'chr2', 'position': 1},
+    ]
+    assert sort_decisions(subs) == [
+        {'contig': 'chr1', 'position': 1234},
+        {'contig': 'chr2', 'position': 1},
+        {'contig': 'chr2', 'position': 1234},
+        {'contig': 'chr3', 'position': 1234},
+        {'contig': 'chrM', 'position': 1234},
+    ]

--- a/test/clinvar/test_clinvar_resolutions.py
+++ b/test/clinvar/test_clinvar_resolutions.py
@@ -1,0 +1,178 @@
+"""
+tests for clinvar manual summaries
+"""
+
+
+from copy import deepcopy
+from datetime import datetime
+
+from clinvar.conflict_huntr import (
+    ACMG_THRESHOLD,
+    Consequence,
+    Submission,
+    county_county,
+    check_stars,
+    acmg_filter_submissions,
+)
+
+
+CURRENT_TIME = datetime.now()
+BASIC_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.UNKNOWN, 'review')
+BENIGN_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.BENIGN, 'review')
+PATH_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.PATHOGENIC, 'review')
+UNCERTAIN_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.UNCERTAIN, 'review')
+
+
+def test_check_stars_practice():
+    """
+
+    Returns:
+
+    """
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.review_status = 'practice guideline'
+    subs = [BASIC_SUB, sub1]
+    assert check_stars(subs) == 4
+
+
+def test_check_stars_expert():
+    """
+
+    Returns:
+
+    """
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.review_status = 'reviewed by expert panel'
+    subs = [BASIC_SUB, sub1]
+    assert check_stars(subs) == 3
+
+
+def test_check_stars_criteria_prov():
+    """
+
+    Returns:
+
+    """
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.review_status = 'something, something, criteria provided'
+    subs = [BASIC_SUB, sub1]
+    assert check_stars(subs) == 1
+
+
+def test_check_stars_none():
+    """
+
+    Returns:
+
+    """
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.review_status = 'smithsonian'
+    subs = [BASIC_SUB, sub1, BASIC_SUB]
+    assert check_stars(subs) == 0
+
+
+def tests_acmg_filter_neutral():
+    """filter submissions against ACMG date threshold"""
+    subs = [BASIC_SUB, BASIC_SUB]
+    assert acmg_filter_submissions(subs) == subs
+
+
+def tests_acmg_filter_removes():
+    """filter submissions against ACMG date threshold"""
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.date = datetime(year=1970, month=1, day=1)
+    sub2 = deepcopy(BASIC_SUB)
+    sub2.date = datetime(year=2000, month=1, day=1)
+    subs = [BASIC_SUB, sub1, sub2]
+    assert acmg_filter_submissions(subs) == [BASIC_SUB]
+
+
+def tests_acmg_filter_gte():
+    """filter submissions against ACMG date threshold"""
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.date = ACMG_THRESHOLD
+    subs = [BASIC_SUB, sub1]
+    assert acmg_filter_submissions(subs) == subs
+
+
+def test_county_empty():
+    """No entries == Uncertain"""
+    assert county_county(subs=[]) == Consequence.UNCERTAIN
+
+
+def test_county_all_path():
+    """pathogenic if everything is pathogenic"""
+    assert county_county([PATH_SUB] * 10) == Consequence.PATHOGENIC
+
+
+def test_county_all_benign():
+    """benign if everything is benign"""
+    assert county_county([BENIGN_SUB] * 10) == Consequence.BENIGN
+
+
+def test_county_all_uncertain():
+    """uncertain if everything is uncertain"""
+    assert county_county([UNCERTAIN_SUB] * 10) == Consequence.UNCERTAIN
+
+
+def test_county_equal_path_benign():
+    """equal path and benign == conflicting"""
+    subs = ([BENIGN_SUB] * 10) + ([PATH_SUB] * 10)
+    assert county_county(subs) == Consequence.CONFLICTING
+
+
+def test_county_path_majority():
+    """path on 60-20 split"""
+    subs = ([BENIGN_SUB] * 2) + ([PATH_SUB] * 6) + ([UNCERTAIN_SUB] * 2)
+    assert county_county(subs) == Consequence.PATHOGENIC
+
+
+def test_county_path_almost_majority():
+    """conflicting on borderline ratios"""
+    subs = ([BENIGN_SUB] * 2) + ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 2)
+    assert county_county(subs) == Consequence.CONFLICTING
+
+
+def test_county_benign_majority():
+    """benign on 60-20 split"""
+    subs = ([BENIGN_SUB] * 6) + ([PATH_SUB] * 2) + ([UNCERTAIN_SUB] * 2)
+    assert county_county(subs) == Consequence.BENIGN
+
+
+def test_county_benign_almost_majority():
+    """conflicting on borderline ratios"""
+    subs = ([BENIGN_SUB] * 5) + ([PATH_SUB] * 2) + ([UNCERTAIN_SUB] * 2)
+    assert county_county(subs) == Consequence.CONFLICTING
+
+
+def test_county_benign_vs_unknown():
+    """benign on slim majority vs VUS"""
+    subs = ([BENIGN_SUB] * 5) + ([UNCERTAIN_SUB] * 4)
+    assert county_county(subs) == Consequence.BENIGN
+
+
+def test_county_pathogenic_vs_unknown():
+    """pathogenic on slim majority vs VUS"""
+    subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 4)
+    assert county_county(subs) == Consequence.PATHOGENIC
+
+
+def test_county_uncertain_from_mix():
+    """VUS if 50% or more VUS"""
+    subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 5)
+    assert county_county(subs) == Consequence.UNCERTAIN
+
+
+def test_county_uncertain_from_majority():
+    """VUS if 50% or more VUS"""
+    subs = ([PATH_SUB] * 5) + ([UNCERTAIN_SUB] * 6)
+    assert county_county(subs) == Consequence.UNCERTAIN
+
+
+def test_county_take_reviewed():
+    """VUS if 50% or more VUS"""
+    sub1 = deepcopy(BASIC_SUB)
+    sub1.review_status = 'reviewed by expert panel'
+    sub1.classification = Consequence.PATHOGENIC
+    subs = [sub1] + ([BENIGN_SUB] * 6)
+    assert county_county(subs) == Consequence.PATHOGENIC


### PR DESCRIPTION
# Fixes

  - Contributes to #147

## Proposed Changes

  - First PR for making a private consensus from the clinvar raw data
  - This script takes pointers to a file of individual submissions and the file of `variant <-> locus <-> alleles`
  - Clusters all submissions by allele, applies the manual reconciliation process [here](https://miro.com/app/board/uXjVPcOGkd8=/) to all submissions on a single allele
  - Makes a decision based on retained submissions at an allele, discarding alleles which don't cleanly fall into Benign or Pathogenic conclusions (See `Issues`)
  - Sorts all decisions based on a dual-layered sort (contig, position)
  - Iterates over contigs in order, and generates a per-contig Hail Table from the list of dictionaries
  - Progressive merging of the single-contig hail tables into one large table
  - Write that out to GCP

## Issues

- Hail kept exploding due to memory issues. That's... surprising, as parsing 200MB of dictionaries into a Hail Table managed to kill a 60GB worker machine
- AIP only uses benign or pathogenic clinvar entries, to reduce table size we remove anything that isn't cleanly categorised into those two types
- Similarly we're dumping out all submissions which are submitted without evidence. `This could be harmful, happy to reconsider here`
- Instead of converting all entries into a Hail Table at once, each contig is made into a separate table, written to a separate contig checkpoint, then the contents are progressively merged into the main tables
- The sorting of all decisions could solve this... The submissions file is sorted by auto-incrementing ID, rather than genomic position, so when they are added to the Hail Table the table needs to be sorted and re-indexed each time. By joining this with the allele location data and sorting, hopefully Hail doesn't have to continually re-sort to ingest the data. Not excusing the massive memory leak, but hopefully this behaviour could mitigate the issues

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
