### PR TITLE
Clean up output json

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -549,7 +549,7 @@ def vep_struct_to_csq(vep_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpres
     """
 
     def get_csq_from_struct(
-        element: hl.expr.StructExpression, feature_type: str
+        element: hl.expr.StructExpression,
     ) -> hl.expr.StringExpression:
 
         # Most fields are 1-1, just lowercase
@@ -558,42 +558,12 @@ def vep_struct_to_csq(vep_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpres
         # Add general exceptions
         fields.update(
             {
-                'allele': element.variant_allele,
                 'consequence': hl.delimit(element.consequence_terms, delimiter='&'),
-                'feature_type': feature_type,
-                'feature': (
-                    element.transcript_id
-                    if 'transcript_id' in element
-                    else element.regulatory_feature_id
-                    if 'regulatory_feature_id' in element
-                    else element.motif_feature_id
-                    if 'motif_feature_id' in element
-                    else ''
-                ),
+                'feature': element.transcript_id,
                 'variant_class': vep_expr.variant_class,
-                'canonical': hl.if_else(element.canonical == 1, 'YES', ''),
                 'ensp': element.protein_id,
                 'gene': element.gene_id,
                 'symbol': element.gene_symbol,
-                'symbol_source': element.gene_symbol_source,
-                'cdna_position': hl.str(element.cdna_start)
-                + hl.if_else(
-                    element.cdna_start == element.cdna_end,
-                    '',
-                    '-' + hl.str(element.cdna_end),
-                ),
-                'cds_position': hl.str(element.cds_start)
-                + hl.if_else(
-                    element.cds_start == element.cds_end,
-                    '',
-                    '-' + hl.str(element.cds_end),
-                ),
-                'protein_position': hl.str(element.protein_start)
-                + hl.if_else(
-                    element.protein_start == element.protein_end,
-                    '',
-                    '-' + hl.str(element.protein_end),
-                ),
                 'sift': element.sift_prediction
                 + '('
                 + hl.format('%.3f', element.sift_score)
@@ -614,11 +584,10 @@ def vep_struct_to_csq(vep_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpres
         )
 
     csq = hl.empty_array(hl.tstr)
+    # pylint: disable=unnecessary-lambda
     csq = csq.extend(
         hl.or_else(
-            vep_expr['transcript_consequences'].map(
-                lambda x: get_csq_from_struct(x, feature_type='Transcript')
-            ),
+            vep_expr['transcript_consequences'].map(lambda x: get_csq_from_struct(x)),
             hl.empty_array(hl.tstr),
         )
     )

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -54,27 +54,6 @@ def make_coord_string(var_coord: dict[str, str]) -> str:
     )
 
 
-def category_strings(var_data: dict[str, Any], sample: str) -> list[str]:
-    """
-    get a list of strings representing the categories present on this variant
-    :param var_data:
-    :param sample:
-    :return:
-    """
-    strings = [
-        cat.replace('categoryboolean', '')
-        for cat in var_data['info'].keys()
-        if cat.startswith('categoryboolean') and var_data['info'][cat]
-    ]
-    if var_data['info'].get('categorysupport'):
-        strings.append('support')
-
-    if sample in var_data['info'].get('categorysample4', []):
-        strings.append('de_novo')
-
-    return strings
-
-
 def color_csq(all_csq: set[str], mane_csq: set[str]) -> str:
     """
     takes the collection of all consequences, and MANE csqs
@@ -242,9 +221,7 @@ class HTMLBuilder:
 
                 # find all categories associated with this variant
                 # for each category, add to corresponding list and set
-                for category_value in category_strings(
-                    variant['var_data'], sample=sample
-                ):
+                for category_value in variant['var_data'].get('categories'):
                     if category_value == 'support':
                         continue
                     sample_variants[category_value].add(var_string)
@@ -377,11 +354,6 @@ class HTMLBuilder:
                 # pull out the string representation
                 var_string = make_coord_string(variant['var_data']['coords'])
 
-                # find list of all categories assigned
-                variant_categories = category_strings(
-                    variant['var_data'], sample=sample
-                )
-
                 csq_string, mane_string = get_csq_details(variant)
                 candidate_dictionaries.setdefault(variant['sample'], []).append(
                     {
@@ -395,7 +367,7 @@ class HTMLBuilder:
                                     lambda x: COLOR_STRING.format(
                                         color=COLORS[x], content=x
                                     ),
-                                    variant_categories,
+                                    variant['var_data']['categories'],
                                 )
                             )
                         ),

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -329,7 +329,7 @@ def main(
         # generate the jobs which run VEP & collect the results
         vep_jobs = add_vep_jobs(
             b=get_batch(),
-            vcf_path=to_path(input_path),
+            input_siteonly_vcf_path=to_path(input_path),
             tmp_prefix=to_path(
                 output_path('vep_temp', get_config()['buckets'].get('tmp_suffix'))
             ),

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -38,7 +38,6 @@ spliceai = 0.5
 cancel_after_n_failures = 1
 default_timeout = 6000
 default_memory = 'highmem'
-private_clinvar = 'gs://cpg-acute-care-test/clinvar_01-01-2022/clinvar_reprocessed.ht'
 
 [images]
 vep = 'vep:105.0'

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -18,7 +18,7 @@ gnomad_max_hemi = 1
 
 [csq]
 description = 'variables affecting how the VCF variants are parsed, and AnalysisVariant objects are populated'
-csq_string = ['allele', 'consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'amino_acids', 'codons', 'allele_num', 'variant_class', 'tsl', 'appris', 'ccds', 'ensp', 'swissprot', 'trembl', 'uniparc', 'gene_pheno', 'sift', 'polyphen', 'lof', 'lof_filter', 'lof_flags',]
+csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'variant_class', 'ensp', 'lof']
 
 [filter]
 description = 'variables for the hail operations, including CSQ sets and filter thresholds'

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -241,6 +241,7 @@ class AbstractVariant:  # pylint: disable=too-many-instance-attributes
         self.phased = get_phase_data(samples, var)
 
         self.ab_ratios = dict(zip(samples, map(float, var.gt_alt_freqs)))
+        self.categories = []
 
     def __str__(self):
         return repr(self)

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -281,6 +281,35 @@ def update_result_meta(
     return results
 
 
+def minimise(
+    clean_results: dict[str, list[ReportedVariant]]
+) -> dict[str, list[ReportedVariant]]:
+    """
+    removes a number of fields we don't want or need in the persisted JSON
+    Args:
+        clean_results ():
+
+    Returns:
+        same objects, minus a few attributes
+    """
+
+    var_fields_to_remove = [
+        'het_samples',
+        'hom_samples',
+        'boolean_categories',
+        'sample_categories',
+        'sample_support',
+        'ab_ratios',
+    ]
+    for sample, variants in clean_results.items():
+        for variant in variants:
+            var_obj = variant.var_data
+            var_obj.categories = var_obj.category_values(sample=sample)
+            for key in var_fields_to_remove:
+                del var_obj.__dict__[key]
+    return clean_results
+
+
 def main(
     labelled_vcf: str,
     out_json: str,
@@ -346,9 +375,11 @@ def main(
         results, samples=vcf_opened.samples, pedigree=pedigree_digest
     )
 
+    minimised_data = minimise(cleaned_results)
+
     # add metadata into the results
     meta_results = update_result_meta(
-        cleaned_results,
+        minimised_data,
         pedigree=pedigree_digest,
         panelapp=panelapp_data,
         samples=vcf_opened.samples,

--- a/test/test_html_builder.py
+++ b/test/test_html_builder.py
@@ -4,20 +4,7 @@ tests for the HTML generation script
 Not a huge number, this is not intended as a permanent solution
 """
 
-from reanalysis.html_builder import category_strings, COLORS
-
-
-def test_numerical_categories():
-    """
-
-    :return:
-    """
-    assert category_strings({'info': {}}, sample='') == []
-    var_data = {'info': {'categoryboolean2': True}}
-    assert category_strings(var_data, sample='') == ['2']
-    var_data = {'info': {'categorysample4': ['sam1']}}
-    assert category_strings(var_data, sample='') == []
-    assert category_strings(var_data, sample='sam1') == ['de_novo']
+from reanalysis.html_builder import COLORS
 
 
 def test_set_up_categories():


### PR DESCRIPTION
# Fixes

  - closes #156
  - This is not a FIX per se, but is a housekeeping change to reduce the output JSON size by about 80%, and reduce logic required to interpret the JSON downstream.

## Proposed Changes

  - The JSON dump is a huge file with low info density
  - The full collection of transcript consequences is currently stored, but much of this content is repetitive (e.g. storing the hgvsp `e.g. "ENSP00000329880.8:p.Met1?"`, alongside Protein ID, residue number, AA change, swissprot, trembl...). Reducing this to a minimal set of values will shrink all files downstream with no real loss of information.
  - The AB ratios of every sample are stored against every variant - majority of these are `0.0`, and serve no purpose after the report objects are generated. These alone make up ~half the lines in each output JSON
  - Each variant permanently stored a list of all sample IDs which were hom/het - this is not required as each result object is specifically generated in the context of an individual. It's not important which other samples have the same genotype.
  - The categories were stored in a really indirect way. To determine which categories were applied, we had to parse a number of True/False flags each time. Instead of doing this, prior to writing we generate a new field which contains the exact categories satisfied for this sample at this variant, which at the time of writing would be from the enum [1, 2, 3, 5, de_novo, support]
      - this method already existed in the report generation script, and had to be duplicated in the flagging script. Placing the results directly into the result json saves a decent amount of logic, and tidies up the output 

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
