### PR TITLE
Filter to new results

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -100,13 +100,14 @@ def set_job_resources(
     )
 
 
-def mt_to_vcf(batch: hb.Batch, input_file: str):
+def mt_to_vcf(batch: hb.Batch, input_file: str) -> hb.batch.job.Job:
     """
     takes a MT and converts to VCF
     :param batch:
     :param input_file:
     :return:
     """
+
     mt_to_vcf_job = batch.new_job(name='Convert MT to VCF')
     set_job_resources(mt_to_vcf_job)
 
@@ -313,7 +314,9 @@ def main(
             ANNOTATED_MT = input_path
 
         else:
-            prior_job = mt_to_vcf(batch=get_batch(), input_file=input_path)
+            if not to_path(INPUT_AS_VCF).exists():
+                prior_job = mt_to_vcf(batch=get_batch(), input_file=input_path)
+
             # overwrite input path with file we just created
             input_path = INPUT_AS_VCF
     # endregion

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -41,7 +41,7 @@ from cpg_workflows.jobs.vep import add_vep_jobs
 from utils import FileTypes, identify_file_type
 
 # exact time that this run occurred
-EXECUTION_TIME = f'{datetime.now():%Y-%m-%d %H:%M}'
+EXECUTION_TIME = f'{datetime.now():%Y-%m-%d_%H:%M}'
 
 # static paths to write outputs
 INPUT_AS_VCF = output_path('prior_to_annotation.vcf.bgz')

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -339,7 +339,6 @@ class DominantAutosomal(BaseMoi):
                     gene=principal_var.info.get('gene_id'),
                     var_data=principal_var,
                     reasons={self.applied_moi},
-                    supported=False,
                     flags=principal_var.get_sample_flags(sample_id),
                 )
             )
@@ -419,7 +418,6 @@ class RecessiveAutosomal(BaseMoi):
                     gene=principal_var.info.get('gene_id'),
                     var_data=principal_var,
                     reasons={f'{self.applied_moi} Homozygous'},
-                    supported=False,
                     flags=principal_var.get_sample_flags(sample_id),
                 )
             )
@@ -577,7 +575,6 @@ class XDominant(BaseMoi):
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
-                    supported=False,
                     flags=principal_var.get_sample_flags(sample_id),
                 )
             )
@@ -706,9 +703,8 @@ class XRecessive(BaseMoi):
                         reasons={f'{self.applied_moi} Compound-Het Female'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
-                        flags=principal_var.get_sample_flags(sample_id).extend(
-                            partner_variant.get_sample_flags(sample_id),
-                        ),
+                        flags=principal_var.get_sample_flags(sample_id)
+                        + partner_variant.get_sample_flags(sample_id),
                     )
                 )
 
@@ -758,7 +754,6 @@ class XRecessive(BaseMoi):
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
-                    supported=False,
                     flags=principal_var.get_sample_flags(sample_id),
                 )
             )
@@ -843,7 +838,6 @@ class YHemi(BaseMoi):
                     gene=principal_var.info.get('gene_id'),
                     var_data=principal_var,
                     reasons={self.applied_moi},
-                    supported=False,
                     flags=principal_var.get_sample_flags(sample_id),
                 )
             )

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -4,6 +4,7 @@ tmp_suffix = 'tmp'
 analysis_suffix = 'analysis'
 
 [workflow]
+image_registry_prefix = "australia-southeast1-docker.pkg.dev/cpg-common/images"
 name = 'AIP'
 scatter_count = 50
 sequencing_type = 'genome'
@@ -42,8 +43,8 @@ default_memory = 'highmem'
 [images]
 vep = 'vep:105.0'
 gatk = 'gatk:4.2.6.1'
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
-hail = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
+cpg_workflows = 'cpg_workflows:latest'
+hail = 'cpg_workflows:latest'
 picard = 'picard_samtools:v0'
 picard_samtools = 'picard_samtools:v0'
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -706,8 +706,12 @@ def filter_results(results: dict) -> dict:
         logging.info('No `dataset_specific` key in config - no filtering took place')
         return results
 
+    logging.info(f'filtering current results against data in {historic}')
     # get the latest result file from the folder
     latest_results = find_latest(results_folder=historic)
+
+    logging.info(f'latest results: {latest_results}')
+
     if latest_results is None:
         # no results to subtract - current data IS cumulative data
         mini_results = make_cumulative_representation(results)
@@ -761,7 +765,7 @@ def save_new_cumulative(directory: str, results: dict):
         results ():
     """
 
-    new_file = to_path(directory) / f'{datetime.now():%Y-%m-%d_%H:%M}'
+    new_file = to_path(directory) / f'{datetime.now():%Y-%m-%d_%H:%M}.json'
     with new_file.open('w') as handle:
         json.dump(results, handle, indent=4)
     logging.info(f'Wrote new cumulative data to {str(new_file)}')
@@ -834,16 +838,19 @@ def subtract_results(
 
             # if supported, allow if the support is new
             if variant.support_vars:
+
+                # if novel supporting variants, don't need to check
+                # categories, we want to show this. WALRUS
                 if sups := [
                     sup
                     for sup in variant.support_vars
                     if sup not in cumulative[sample][var_id]['support_vars']
                 ]:
                     variant.support_vars = sups
-                return_results[sample].append(variant)
-                continue
+                    return_results[sample].append(variant)
+                    continue
 
-            # if seen, check for novel categories
+            # if seen, check for novel categories. Also, WALRUS
             if cats := [
                 cat
                 for cat in variant.var_data.categories

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -677,3 +677,30 @@ def find_comp_hets(var_list: list[AbstractVariant], pedigree) -> CompHetDict:
                 ).append(var_1)
 
     return comp_het_results
+
+
+def filter_results(results: dict) -> dict:
+    """
+    takes a set of results
+    loads the most recent prior result set (if it exists)
+    subtract
+    write two files (total, and latest - previous)
+    p.stat().st_mtime to find latest
+    Args:
+        results ():
+
+    Returns:
+
+    """
+    # try to pull out the historic results folder
+    try:
+        if (
+            historic := get_config()['dataset_specific'].get('historic_results')
+        ) is None:
+            return results
+    except KeyError:
+        logging.info('No `dataset_specific` key in config - not filtering took place')
+        return results
+
+    print(historic)
+    return results

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -4,7 +4,8 @@ which may be shared across reanalysis components
 """
 
 from collections import defaultdict
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, is_dataclass, field
+from datetime import datetime
 from enum import Enum
 from itertools import combinations_with_replacement
 from pathlib import Path
@@ -388,16 +389,16 @@ class ReportedVariant:
     gene: str
     var_data: AbstractVariant
     reasons: set[str]
-    supported: bool
-    support_vars: list[str] | None = None
-    flags: list[str] | None = None
+    supported: bool = field(default=False)
+    support_vars: list[str] = field(default_factory=list)
+    flags: list[str] = field(default_factory=list)
 
     def __eq__(self, other):
         """
         makes reported variants comparable
         """
-        self_supvar = set() if self.support_vars is None else set(self.support_vars)
-        other_supvar = set() if other.support_vars is None else set(other.support_vars)
+        self_supvar = set(self.support_vars)
+        other_supvar = set(other.support_vars)
         return (
             self.sample == other.sample
             and self.var_data.coords == other.var_data.coords
@@ -687,7 +688,7 @@ def filter_results(results: dict) -> dict:
     write two files (total, and latest - previous)
     p.stat().st_mtime to find latest
     Args:
-        results ():
+        results (): the results produced during this run
 
     Returns:
 
@@ -697,10 +698,211 @@ def filter_results(results: dict) -> dict:
         if (
             historic := get_config()['dataset_specific'].get('historic_results')
         ) is None:
+            logging.info(
+                'No `historic_results` key in config - no filtering took place'
+            )
             return results
     except KeyError:
-        logging.info('No `dataset_specific` key in config - not filtering took place')
+        logging.info('No `dataset_specific` key in config - no filtering took place')
         return results
 
-    print(historic)
+    # get the latest result file from the folder
+    latest_results = find_latest(results_folder=historic)
+    if latest_results is None:
+        # no results to subtract - current data IS cumulative data
+        mini_results = make_cumulative_representation(results)
+
+        save_new_cumulative(directory=historic, results=mini_results)
+
+    else:
+        cum_results = read_json_from_path(bucket_path=latest_results)
+
+        # remove previously seen entries
+        results = subtract_results(current=results, cumulative=cum_results)
+
+        # add new entries into cumulative results
+        add_results(results, cum_results)
+
+        # save updated cumulative results
+        save_new_cumulative(directory=historic, results=cum_results)
+
     return results
+
+
+def make_cumulative_representation(results: dict[str, list[ReportedVariant]]) -> dict:
+    """
+    for the 'cumulative' representation, keep a minimised format
+    the first time we generate a minimal format we need to translate
+
+    Args:
+        results (): the full results of the current run
+
+    Returns:
+        minimised form
+    """
+
+    mini_results = defaultdict(dict)
+    for sample, variants in results.items():
+        for var in variants:
+            mini_results[sample][var.var_data.coords.string_format] = {
+                'categories': var.var_data.categories,
+                'support_vars': var.support_vars,
+            }
+    return mini_results
+
+
+def save_new_cumulative(directory: str, results: dict):
+    """
+    save the new cumulative results in the results dir
+    include time & date in filename
+
+    Args:
+        directory ():
+        results ():
+    """
+
+    new_file = to_path(directory) / f'{datetime.now():%Y-%m-%d_%H:%M}'
+    with new_file.open('w') as handle:
+        json.dump(results, handle, indent=4)
+    logging.info(f'Wrote new cumulative data to {str(new_file)}')
+
+
+def find_latest(results_folder: str, ext: str = 'json') -> str | None:
+    """
+    takes a directory of files, and finds the latest
+    Args:
+        results_folder (): local or remote folder
+        ext (): the type of files we're looking for
+
+    Returns:
+        timestamp-sorted latest file path, or None
+    """
+
+    date_sorted_files = sorted(
+        to_path(results_folder).glob(f'*.{ext}'),
+        key=lambda x: x.stat().st_mtime,
+        reverse=True,
+    )
+    if not date_sorted_files:
+        return None
+
+    return str(date_sorted_files[0].absolute())
+
+
+def subtract_results(
+    current: dict[str, list[ReportedVariant]], cumulative: dict
+) -> dict[str, list[ReportedVariant]]:
+    """
+    take datasets of new and previous results (cumulative for this cohort)
+    subtract all the previously seen results (exact)
+        i.e. comp-het with a new partner should appear?
+            - how does this gel with the category subtraction...
+            - new partner = show all categories
+    return the new-only
+
+    Args:
+        current (): results produced by this run
+        cumulative (): results previously seen
+
+    Returns:
+        a diff between the two
+    """
+
+    # create a dict to contain novel results
+    return_results = defaultdict(list)
+
+    # iterate over all samples and their variants
+    for sample, variants in current.items():
+
+        # sample not seen before - take all variants
+        if sample not in cumulative:
+            return_results[sample] = variants
+            continue
+
+        # otherwise get ready to contain some variants
+        return_results[sample] = []
+
+        # check what has previously been reported for this sample
+        for variant in variants:
+
+            var_id = variant.var_data.coords.string_format
+
+            # not seen - take in full
+            if var_id not in cumulative[sample]:
+                return_results[sample].append(variant)
+                continue
+
+            # if supported, allow if the support is new
+            if variant.support_vars:
+                if sups := [
+                    sup
+                    for sup in variant.support_vars
+                    if sup not in cumulative[sample][var_id]['support_vars']
+                ]:
+                    variant.support_vars = sups
+                return_results[sample].append(variant)
+                continue
+
+            # if seen, check for novel categories
+            if cats := [
+                cat
+                for cat in variant.var_data.categories
+                if cat not in cumulative[sample][var_id]['categories']
+            ]:
+                # reduce the categories of interest for this round
+                variant.var_data.categories = cats
+
+                # and append the variant
+                return_results[sample].append(variant)
+
+    return dict(return_results)
+
+
+def add_results(current: dict[str, list[ReportedVariant]], cumulative: dict):
+    """
+    take datasets of new and previous results (cumulative for this cohort)
+    integrate the new results to form a new cumulative dataset
+
+    Args:
+        current (): results produced by this run
+        cumulative (): results previously seen
+
+    Returns:
+        N/A - in place modification
+        a union of all results, inc new categories for prev. variants
+    """
+
+    # iterate over all samples and their variants
+    for sample, variants in current.items():
+
+        # sample not seen before - take all variants
+        if sample not in cumulative:
+            cumulative[sample] = {}
+
+        # each variant is an AbstractVariant
+        for variant in variants:
+
+            var_id = variant.var_data.coords.string_format
+
+            # not seen - take in full
+            if var_id not in cumulative[sample]:
+                cumulative[sample][var_id] = {
+                    'categories': variant.var_data.categories,
+                    'support_vars': variant.support_vars,
+                }
+
+            else:
+
+                # if seen, check for novel categories
+                cumulative[sample][var_id]['categories'] = sorted(
+                    set(
+                        variant.var_data.categories
+                        + cumulative[sample][var_id]['categories']
+                    )
+                )
+                cumulative[sample][var_id]['support_vars'] = sorted(
+                    set(
+                        variant.support_vars
+                        + cumulative[sample][var_id]['support_vars']
+                    )
+                )

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -856,7 +856,7 @@ def subtract_results(
             if cats := [
                 cat
                 for cat in variant.var_data.categories
-                if cat not in cumulative[sample][var_id]['categories']
+                if cat not in cumulative[sample][var_id]['categories'].keys()
             ]:
                 # reduce the categories of interest for this round
                 variant.var_data.categories = cats

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -386,6 +386,8 @@ def main(
         input_path=input_path,
     )
 
+    # remove previously seen results
+
     # store a full version of the results here
     # dump results using the custom-encoder to transform sets & DataClasses
     with to_path(f'{out_json}_full.json').open('w') as fh:

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass, field
 from os.path import join
 from time import sleep
 
-from reanalysis.utils import subtract_results, add_results, find_latest, Coordinates
+from reanalysis.utils import (
+    subtract_results,
+    add_results,
+    find_latest,
+    Coordinates,
+    TODAY,
+)
 
 
 # pylint: disable=consider-using-with
@@ -104,7 +110,7 @@ def test_subtraction_new_partner():
     }
     old = {
         'sample': {
-            COORD_1.string_format: {'categories': ['1'], 'support_vars': ['bar']}
+            COORD_1.string_format: {'categories': {'1': 1}, 'support_vars': ['bar']}
         }
     }
     assert subtract_results(new, old) == {
@@ -124,7 +130,9 @@ def test_add_new_sample():
     new = {'sample': [GENERIC_REPORT]}
     add_results(new, cum)
     assert cum == {
-        'sample': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}}
+        'sample': {
+            COORD_1.string_format: {'categories': {'1': TODAY}, 'support_vars': []}
+        }
     }
 
 
@@ -137,7 +145,7 @@ def test_add_new_sample_variant():
     add_results(new, cum)
     assert cum == {
         'sample': {
-            COORD_1.string_format: {'categories': ['1'], 'support_vars': []},
+            COORD_1.string_format: {'categories': {'1': TODAY}, 'support_vars': []},
             '1': {'2'},
         }
     }
@@ -153,7 +161,10 @@ def test_add_new_category_vardup():
     add_results(new, cum)
     assert cum == {
         'sample': {
-            COORD_1.string_format: {'categories': ['1', '2'], 'support_vars': []}
+            COORD_1.string_format: {
+                'categories': {'1': TODAY, '2': TODAY},
+                'support_vars': [],
+            }
         }
     }
 
@@ -173,14 +184,17 @@ def test_add_support_vars():
     }
     cum = {
         'sample': {
-            COORD_1.string_format: {'categories': ['1', '2'], 'support_vars': []}
+            COORD_1.string_format: {
+                'categories': {'1': 1, '2': 1},
+                'support_vars': [],
+            }
         }
     }
     add_results(new, cum)
     assert cum == {
         'sample': {
             COORD_1.string_format: {
-                'categories': ['1', '2', '999'],
+                'categories': {'1': 1, '2': 1, '999': TODAY},
                 'support_vars': ['foobar'],
             }
         }
@@ -210,31 +224,36 @@ def test_add_various():
     }
     cum = {
         'sample': {
-            COORD_1.string_format: {'categories': ['A', 'C'], 'support_vars': []},
-            COORD_2.string_format: {'categories': ['1'], 'support_vars': ['foo']},
-            COORD_3.string_format: {'categories': ['A', 'B', 'C'], 'support_vars': []},
+            COORD_1.string_format: {'categories': {'A': 1, 'C': 2}, 'support_vars': []},
+            COORD_2.string_format: {'categories': {'1': 1}, 'support_vars': ['foo']},
+            COORD_3.string_format: {
+                'categories': {'A': 1, 'B': 2, 'C': 3},
+                'support_vars': [],
+            },
         },
         'sample3': {
-            COORD_3.string_format: {'categories': ['B'], 'support_vars': ['batman']}
+            COORD_3.string_format: {'categories': {'B': 1}, 'support_vars': ['batman']}
         },
     }
     add_results(new, cum)
     assert cum == {
         'sample': {
             COORD_1.string_format: {
-                'categories': ['999', 'A', 'B', 'C'],
+                'categories': {'A': 1, 'B': TODAY, 'C': 2, '999': TODAY},
                 'support_vars': ['foobar'],
             },
-            COORD_2.string_format: {'categories': ['1'], 'support_vars': ['foo']},
+            COORD_2.string_format: {'categories': {'1': 1}, 'support_vars': ['foo']},
             COORD_3.string_format: {
-                'categories': ['A', 'B', 'C'],
+                'categories': {'A': 1, 'B': 2, 'C': 3},
                 'support_vars': [],
             },
         },
-        'sample2': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}},
+        'sample2': {
+            COORD_1.string_format: {'categories': {'1': TODAY}, 'support_vars': []}
+        },
         'sample3': {
             COORD_3.string_format: {
-                'categories': ['B'],
+                'categories': {'B': 1},
                 'support_vars': ['batman', 'foobar'],
             }
         },

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -73,7 +73,9 @@ def test_subtraction_one_exact():
         'sample': [GENERIC_REPORT],
         'sample2': [GENERIC_REPORT],
     }
-    old = {'sample': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}}}
+    old = {
+        'sample': {COORD_1.string_format: {'categories': {'1': 1}, 'support_vars': []}}
+    }
     assert subtract_results(new, old) == {'sample': [], 'sample2': [GENERIC_REPORT]}
 
 
@@ -82,7 +84,9 @@ def test_subtraction_match_no_categories():
     variant matches, but categories do not
     """
     new = {'sample': [GENERIC_REPORT]}
-    old = {'sample': {COORD_1.string_format: {'categories': ['2'], 'support_vars': []}}}
+    old = {
+        'sample': {COORD_1.string_format: {'categories': {'2': 1}, 'support_vars': []}}
+    }
     assert subtract_results(new, old) == new
 
 
@@ -91,7 +95,7 @@ def test_subtraction_partial_categories():
     variant matches, but categories only partially match
     """
     new = {'sample': [MiniReport(MiniVariant(categories=['1', '2'], coords=COORD_1))]}
-    old = {'sample': {COORD_1.string_format: {'categories': ['2']}}}
+    old = {'sample': {COORD_1.string_format: {'categories': {'2': 1}}}}
     assert subtract_results(new, old) == {
         'sample': [MiniReport(MiniVariant(categories=['1'], coords=COORD_1))]
     }

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -1,0 +1,265 @@
+"""
+test file for the results subtraction methods in utils
+"""
+
+from dataclasses import dataclass, field
+from os.path import join
+from time import sleep
+
+from reanalysis.utils import subtract_results, add_results, find_latest, Coordinates
+
+
+# pylint: disable=consider-using-with
+
+
+@dataclass
+class MiniVariant:
+    """
+    tiny class to simulate the variants
+    """
+
+    categories: list
+    coords: Coordinates
+
+
+@dataclass
+class MiniReport:
+    """
+    tiny class to simulate the reports
+    """
+
+    var_data: MiniVariant
+    support_vars: list[str] = field(default_factory=list)
+
+
+COORD_1 = Coordinates('1', 1, 'A', 'G')
+COORD_2 = Coordinates('2', 2, 'A', 'G')
+COORD_3 = Coordinates('3', 3, 'A', 'G')
+GENERIC_REPORT = MiniReport(MiniVariant(categories=['1'], coords=COORD_1))
+GENERIC_REPORT_2 = MiniReport(MiniVariant(categories=['2'], coords=COORD_2))
+GENERIC_REPORT_3 = MiniReport(MiniVariant(categories=['3'], coords=COORD_3))
+GENERIC_REPORT_12 = MiniReport(MiniVariant(categories=['1', '2'], coords=COORD_1))
+
+
+def test_subtraction_null():
+    """
+    subtraction if nothing to subtract
+    """
+    new = {'sample': [GENERIC_REPORT]}
+    old = {}
+    assert subtract_results(new, old) == new
+
+
+def test_subtraction_no_matches():
+    """
+    no previous results for this sample
+    """
+    new = {'sample': [GENERIC_REPORT]}
+    old = {'sample2': [1]}
+    assert subtract_results(new, old) == new
+
+
+def test_subtraction_one_exact():
+    """
+    one variant fully removed
+    """
+    new = {
+        'sample': [GENERIC_REPORT],
+        'sample2': [GENERIC_REPORT],
+    }
+    old = {'sample': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}}}
+    assert subtract_results(new, old) == {'sample': [], 'sample2': [GENERIC_REPORT]}
+
+
+def test_subtraction_match_no_categories():
+    """
+    variant matches, but categories do not
+    """
+    new = {'sample': [GENERIC_REPORT]}
+    old = {'sample': {COORD_1.string_format: {'categories': ['2'], 'support_vars': []}}}
+    assert subtract_results(new, old) == new
+
+
+def test_subtraction_partial_categories():
+    """
+    variant matches, but categories only partially match
+    """
+    new = {'sample': [MiniReport(MiniVariant(categories=['1', '2'], coords=COORD_1))]}
+    old = {'sample': {COORD_1.string_format: {'categories': ['2']}}}
+    assert subtract_results(new, old) == {
+        'sample': [MiniReport(MiniVariant(categories=['1'], coords=COORD_1))]
+    }
+
+
+def test_subtraction_new_partner():
+    """
+    variant matches, categories match, but new comp-het
+    """
+    new = {
+        'sample': [
+            MiniReport(
+                MiniVariant(categories=['1'], coords=COORD_1), support_vars=['foo']
+            )
+        ]
+    }
+    old = {
+        'sample': {
+            COORD_1.string_format: {'categories': ['1'], 'support_vars': ['bar']}
+        }
+    }
+    assert subtract_results(new, old) == {
+        'sample': [
+            MiniReport(
+                MiniVariant(categories=['1'], coords=COORD_1), support_vars=['foo']
+            )
+        ]
+    }
+
+
+def test_add_new_sample():
+    """
+    add a novel sample
+    """
+    cum = {}
+    new = {'sample': [GENERIC_REPORT]}
+    add_results(new, cum)
+    assert cum == {
+        'sample': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}}
+    }
+
+
+def test_add_new_sample_variant():
+    """
+    integrate a new sample for an existing sample
+    """
+    new = {'sample': [GENERIC_REPORT]}
+    cum = {'sample': {'1': {'2'}}}
+    add_results(new, cum)
+    assert cum == {
+        'sample': {
+            COORD_1.string_format: {'categories': ['1'], 'support_vars': []},
+            '1': {'2'},
+        }
+    }
+
+
+def test_add_new_category_vardup():
+    """
+    integrate a new sample for an existing sample
+    """
+    # ludicrous situation, but should be manageable
+    new = {'sample': [GENERIC_REPORT, GENERIC_REPORT_12]}
+    cum = {'sample': {}}
+    add_results(new, cum)
+    assert cum == {
+        'sample': {
+            COORD_1.string_format: {'categories': ['1', '2'], 'support_vars': []}
+        }
+    }
+
+
+def test_add_support_vars():
+    """
+    integrate a new sample for an existing sample
+    """
+    # ludicrous situation, but should be manageable
+    new = {
+        'sample': [
+            GENERIC_REPORT,
+            MiniReport(
+                MiniVariant(categories=['999'], coords=COORD_1), support_vars=['foobar']
+            ),
+        ]
+    }
+    cum = {
+        'sample': {
+            COORD_1.string_format: {'categories': ['1', '2'], 'support_vars': []}
+        }
+    }
+    add_results(new, cum)
+    assert cum == {
+        'sample': {
+            COORD_1.string_format: {
+                'categories': ['1', '2', '999'],
+                'support_vars': ['foobar'],
+            }
+        }
+    }
+
+
+def test_add_various():
+    """
+    add a bunch of things
+    """
+    new = {
+        'sample': [
+            MiniReport(
+                MiniVariant(categories=['999'], coords=COORD_1), support_vars=['foobar']
+            ),
+            MiniReport(
+                MiniVariant(categories=['A', 'B'], coords=COORD_1),
+                support_vars=[],
+            ),
+        ],
+        'sample2': [GENERIC_REPORT],
+        'sample3': [
+            MiniReport(
+                MiniVariant(categories=['B'], coords=COORD_3), support_vars=['foobar']
+            )
+        ],
+    }
+    cum = {
+        'sample': {
+            COORD_1.string_format: {'categories': ['A', 'C'], 'support_vars': []},
+            COORD_2.string_format: {'categories': ['1'], 'support_vars': ['foo']},
+            COORD_3.string_format: {'categories': ['A', 'B', 'C'], 'support_vars': []},
+        },
+        'sample3': {
+            COORD_3.string_format: {'categories': ['B'], 'support_vars': ['batman']}
+        },
+    }
+    add_results(new, cum)
+    assert cum == {
+        'sample': {
+            COORD_1.string_format: {
+                'categories': ['999', 'A', 'B', 'C'],
+                'support_vars': ['foobar'],
+            },
+            COORD_2.string_format: {'categories': ['1'], 'support_vars': ['foo']},
+            COORD_3.string_format: {
+                'categories': ['A', 'B', 'C'],
+                'support_vars': [],
+            },
+        },
+        'sample2': {COORD_1.string_format: {'categories': ['1'], 'support_vars': []}},
+        'sample3': {
+            COORD_3.string_format: {
+                'categories': ['B'],
+                'support_vars': ['batman', 'foobar'],
+            }
+        },
+    }
+
+
+def test_find_latest(tmp_path):
+    """
+    check that we find the correct latest file
+    """
+    open(join(str(tmp_path), 'file1.json'), 'w', encoding='utf-8')
+    sleep(0.2)
+    open(join(str(tmp_path), 'file2.json'), 'w', encoding='utf-8')
+    sleep(0.2)
+    open(join(str(tmp_path), 'file3.json'), 'w', encoding='utf-8')
+    assert 'file3.json' in find_latest(str(tmp_path))
+
+
+def test_find_latest_with_ext(tmp_path):
+    """
+    check that we find the correct latest file
+    """
+    open(join(str(tmp_path), 'file1.txt'), 'w', encoding='utf-8')
+    sleep(0.2)
+    open(join(str(tmp_path), 'file2.txt'), 'w', encoding='utf-8')
+    sleep(0.2)
+    open(join(str(tmp_path), 'file3.txt'), 'w', encoding='utf-8')
+    assert 'file3.txt' in find_latest(str(tmp_path), ext='txt')

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -6,7 +6,7 @@ import json
 import os
 from dataclasses import dataclass
 
-from reanalysis.validate_categories import gene_clean_results, update_result_meta
+from reanalysis.validate_categories import gene_clean_results, count_families
 
 
 @dataclass
@@ -51,41 +51,12 @@ def test_update_results_meta(peddy_ped):
     testing the dict update
     """
 
-    results = {}
-    panelapp = {
-        'metadata': [
-            {'name': 'biff', 'version': 'pow', 'id': 'wallop'},
-            {'name': 'extra_panel', 'version': 'extra_version', 'id': 2},
-        ]
-    }
-
     ped_samples = ['male', 'female', 'mother_1', 'father_1', 'mother_2', 'father_2']
 
-    big_results = update_result_meta(
-        results=results,
-        pedigree=peddy_ped,
-        panelapp=panelapp,
-        samples=ped_samples,
-        input_path='this',
-    )
-
-    # either this or mock the entry
-    del big_results['metadata']['run_datetime']
-
-    assert big_results == {
-        'metadata': {
-            'input_file': 'this',
-            'cohort': 'cohort',
-            'family_breakdown': {
-                'affected': 2,
-                'male': 3,
-                'female': 3,
-                'trios': 2,
-                '3': 2,
-            },
-            'panels': [
-                {'name': 'biff', 'version': 'pow', 'id': 'wallop'},
-                {'name': 'extra_panel', 'version': 'extra_version', 'id': 2},
-            ],
-        }
+    assert count_families(pedigree=peddy_ped, samples=ped_samples,) == {
+        'affected': 2,
+        'male': 3,
+        'female': 3,
+        'trios': 2,
+        '3': 2,
     }


### PR DESCRIPTION
# Fixes

  - closes #155 
  - enables #154

## Proposed Changes

@cassimons in particular, can you check that this implementation feels fit for purpose?

  - This is a pretty THICC change, with 2 Cs
  - Introduces the concept of filtering current results by removing previously seen results
  - Admittedly this all needs documenting, but the docs need a user-focused overhaul anyway so this will be done at that time

1. The config can now contain the key `dataset_specific.historic_results` - this will be the path to a cloud folder containing cumulative results files - this would be a candidate use of metamist's `analysis` objects if we wanted to tie AIP to CPG.
2. When AIP runs, the results will be cleaned against these prior results:
    a. The latest file in the `historic_results` folder will be identified using the `stat().st_mtime` attribute of the files (most recent modification time)
    b. This check doesn't fail if the directory is empty, but in that situation `None` will be returned instead of a file path
    c. If no file was found, the current data is saved in a minimal representation (`See Below`) into that folder, and all current results will reach the report
    d. If a file is returned, it is loaded as a dictionary, and the current data is filtered against it (`See Below... again`)
    e. The historic data is updated to include all new results not previously seen, and is saved back into the same folder (under a new file name, which will include the date/time to prevent write clashes)
    f. Filtered results are returned to be made into a report

I could write the results of any given run out before and after this filter is applied, if that might be of interest.

## See Below

The historic data doesn't require all the variant details, so we only save 3 items per variant: coordinates (in chr-pos-ref-alt form), assigned categories, and variants supporting (comp-het). This is the only data written as the 'historic' results, which means manually adding prior external results could be prepared as a simple bit of JSON (probably not a likely use case). Each time a new reportable variant is seen, this data is extended - if we see the same variant but in a new category, the on-file cumulative representation only grows by ~1 Byte.

```python
{
    'sampleID': {
        'chr-pos-ref-alt': {
            'categories': ['1', '4', ...],
            'support_vars': ['chr-pos-ref-alt', ...]
        },
        ...
   }
}
```

## See Below... Again

When we filter current results against historic results, it goes something like this:

1. Sample: Have we seen variants for this sample previously? If not, keep everything
2. Variant: Have we seen `this` variant in this sample previously? If not, keep this variant in full
3. Partners: When we previously saw this variant - was it supported in a comp-het?
    - if yes, but this time it's supported by a different comp-het pair, keep the whole variant and all categories
    - if yes, and the same partner is seen again, go to checking categories
4. Categories: Comparing current results with the previous sighting of this variant:
    - are there any new categories assigned? If so, keep only the new categories
    - if not, we don't want to see this variant again - remove from the report
 

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
