### PR TITLE
For thresholds, permit exact match

### DIFF
--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -386,7 +386,7 @@ class RecessiveAutosomal(BaseMoi):
         # no stricter AF here - if we choose to, we can apply while labelling
         if any(
             {
-                principal_var.info.get(hom_key, 0) >= self.hom_threshold
+                principal_var.info.get(hom_key, 0) > self.hom_threshold
                 for hom_key in INFO_HOMS
             }
         ) and not principal_var.info.get('categoryboolean1'):
@@ -448,7 +448,7 @@ class RecessiveAutosomal(BaseMoi):
                     )
                     or any(  # allow for clinvar here
                         {
-                            partner_variant.info.get(hom_key, 0) >= self.hom_threshold
+                            partner_variant.info.get(hom_key, 0) > self.hom_threshold
                             for hom_key in INFO_HOMS
                         }
                     )
@@ -627,7 +627,7 @@ class XRecessive(BaseMoi):
         # remove from analysis if too many homs are present in population databases
         if any(
             {
-                principal_var.info.get(hom_key, 0) >= self.hom_dom_threshold
+                principal_var.info.get(hom_key, 0) > self.hom_dom_threshold
                 for hom_key in INFO_HOMS
             }
         ) and not principal_var.info.get('categoryboolean1'):
@@ -711,7 +711,7 @@ class XRecessive(BaseMoi):
         # remove from analysis if too many homs are present in population databases
         if any(
             {
-                principal_var.info.get(hom_key, 0) >= self.hom_rec_threshold
+                principal_var.info.get(hom_key, 0) > self.hom_rec_threshold
                 for hom_key in INFO_HOMS
             }
         ) and not principal_var.info.get('categoryboolean1'):
@@ -803,8 +803,8 @@ class YHemi(BaseMoi):
 
         # more stringent Pop.Freq checks for dominant
         if (
-            principal_var.info.get('gnomad_af') >= self.ad_threshold
-            or principal_var.info.get('gnomad_ac') >= self.ac_threshold
+            principal_var.info.get('gnomad_af') > self.ad_threshold
+            or principal_var.info.get('gnomad_ac') > self.ac_threshold
             or any(
                 {
                     principal_var.info.get(hemi_key, 0) > self.hemi_threshold

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -361,7 +361,7 @@ def test_recessive_autosomal_comp_het_fails_no_paired_call(peddy_ped):
     )
 
 
-@pytest.mark.parametrize('info', [{'gnomad_hom': 2}])
+@pytest.mark.parametrize('info', [{'gnomad_hom': 3}])  # threshold is 2
 def test_recessive_autosomal_hom_fails(info, peddy_ped):
     """
     check that when the info values are failures


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

  - See https://centrepopgen.slack.com/archives/C035QN8C0DN/p1669938940053829?thread_ts=1669856845.568669&cid=C035QN8C0DN
  - Now that the thresholds for HOM/HEMI in reference databases are much lower (since #151), the conditionals which were previously 'greater or equal' are now invalid
  - e.g. 'remove this variant if the number of GnomAD HOMS **>=** threshold' doesn't make sense if the threshold is 0
  - Move all threshold AF/AC tests to exclusively use greater than during MOI tests

## Checklist

- [ ] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
