### PR TITLE
Copy variant each time

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -260,7 +260,7 @@ class HTMLBuilder:
             ),
             'Meta': pd.DataFrame(
                 {'Data': key.capitalize(), 'Value': self.results['metadata'][key]}
-                for key in ['cohort', 'input_file', 'run_datetime']
+                for key in ['cohort', 'input_file', 'run_datetime', 'commit_id']
             ).to_html(index=False, escape=False),
             'Families': pd.DataFrame(
                 [

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -488,4 +488,5 @@ if __name__ == '__main__':
         extra_panels=args.extra_panels,
         participant_panels=args.participant_panels,
         skip_annotation=args.skip_annotation,
+        singletons=args.singletons,
     )

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -12,6 +12,7 @@ to a Monogenic MOI
 
 import logging
 from abc import abstractmethod
+from copy import deepcopy
 
 from peddy.peddy import Ped, PHENOTYPE
 
@@ -337,7 +338,7 @@ class DominantAutosomal(BaseMoi):
                 ReportedVariant(
                     sample=sample_id,
                     gene=principal_var.info.get('gene_id'),
-                    var_data=principal_var,
+                    var_data=deepcopy(principal_var),
                     reasons={self.applied_moi},
                     flags=principal_var.get_sample_flags(sample_id),
                 )
@@ -416,7 +417,7 @@ class RecessiveAutosomal(BaseMoi):
                 ReportedVariant(
                     sample=sample_id,
                     gene=principal_var.info.get('gene_id'),
-                    var_data=principal_var,
+                    var_data=deepcopy(principal_var),
                     reasons={f'{self.applied_moi} Homozygous'},
                     flags=principal_var.get_sample_flags(sample_id),
                 )
@@ -467,7 +468,7 @@ class RecessiveAutosomal(BaseMoi):
                     ReportedVariant(
                         sample=sample_id,
                         gene=principal_var.info.get('gene_id'),
-                        var_data=principal_var,
+                        var_data=deepcopy(principal_var),
                         reasons={f'{self.applied_moi} Compound-Het'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
@@ -570,7 +571,7 @@ class XDominant(BaseMoi):
                 ReportedVariant(
                     sample=sample_id,
                     gene=principal_var.info.get('gene_id'),
-                    var_data=principal_var,
+                    var_data=deepcopy(principal_var),
                     reasons={
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
@@ -699,7 +700,7 @@ class XRecessive(BaseMoi):
                     ReportedVariant(
                         sample=sample_id,
                         gene=principal_var.info.get('gene_id'),
-                        var_data=principal_var,
+                        var_data=deepcopy(principal_var),
                         reasons={f'{self.applied_moi} Compound-Het Female'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
@@ -749,7 +750,7 @@ class XRecessive(BaseMoi):
                 ReportedVariant(
                     sample=sample_id,
                     gene=principal_var.info.get('gene_id'),
-                    var_data=principal_var,
+                    var_data=deepcopy(principal_var),
                     reasons={
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
@@ -836,7 +837,7 @@ class YHemi(BaseMoi):
                 ReportedVariant(
                     sample=sample_id,
                     gene=principal_var.info.get('gene_id'),
-                    var_data=principal_var,
+                    var_data=deepcopy(principal_var),
                     reasons={self.applied_moi},
                     flags=principal_var.get_sample_flags(sample_id),
                 )

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -367,7 +367,7 @@ class DominantAutosomal(BaseMoi):
                     gene=var_copy.info.get('gene_id'),
                     var_data=var_copy,
                     reasons={self.applied_moi},
-                    flags=var_copy.get_sample_flags(sample_id),
+                    flags=principal_var.get_sample_flags(sample_id),
                 )
             )
 
@@ -447,7 +447,7 @@ class RecessiveAutosomal(BaseMoi):
                     gene=var_copy.info.get('gene_id'),
                     var_data=var_copy,
                     reasons={f'{self.applied_moi} Homozygous'},
-                    flags=var_copy.get_sample_flags(sample_id),
+                    flags=principal_var.get_sample_flags(sample_id),
                 )
             )
 
@@ -502,7 +502,7 @@ class RecessiveAutosomal(BaseMoi):
                         reasons={f'{self.applied_moi} Compound-Het'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
-                        flags=var_copy.get_sample_flags(sample_id)
+                        flags=principal_var.get_sample_flags(sample_id)
                         + partner_variant.get_sample_flags(sample_id),
                     ),
                 )
@@ -608,7 +608,7 @@ class XDominant(BaseMoi):
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
-                    flags=var_copy.get_sample_flags(sample_id),
+                    flags=principal_var.get_sample_flags(sample_id),
                 )
             )
         return classifications
@@ -737,7 +737,7 @@ class XRecessive(BaseMoi):
                         reasons={f'{self.applied_moi} Compound-Het Female'},
                         supported=True,
                         support_vars=[partner_variant.coords.string_format],
-                        flags=var_copy.get_sample_flags(sample_id)
+                        flags=principal_var.get_sample_flags(sample_id)
                         + partner_variant.get_sample_flags(sample_id),
                     )
                 )
@@ -789,7 +789,7 @@ class XRecessive(BaseMoi):
                         f'{self.applied_moi} '
                         f'{self.pedigree[sample_id].sex.capitalize()}'
                     },
-                    flags=var_copy.get_sample_flags(sample_id),
+                    flags=principal_var.get_sample_flags(sample_id),
                 )
             )
         return classifications
@@ -875,7 +875,7 @@ class YHemi(BaseMoi):
                     gene=var_copy.info.get('gene_id'),
                     var_data=var_copy,
                     reasons={self.applied_moi},
-                    flags=var_copy.get_sample_flags(sample_id),
+                    flags=principal_var.get_sample_flags(sample_id),
                 )
             )
 

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -58,7 +58,8 @@ def minimise_variant(variant: AbstractVariant, sample_id: str) -> AbstractVarian
     var_copy = deepcopy(variant)
     var_copy.categories = var_copy.category_values(sample=sample_id)
     for key in VAR_FIELDS_TO_REMOVE:
-        del var_copy.__dict__[key]
+        if key in var_copy.__dict__:
+            del var_copy.__dict__[key]
     return var_copy
 
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -751,7 +751,7 @@ def make_cumulative_representation(results: dict[str, list[ReportedVariant]]) ->
     for sample, variants in results.items():
         for var in variants:
             mini_results[sample][var.var_data.coords.string_format] = {
-                'categories': var.var_data.categories,
+                'categories': {cat: TODAY for cat in var.var_data.categories},
                 'support_vars': var.support_vars,
             }
     return mini_results

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -281,34 +281,6 @@ def count_families(pedigree: Ped, samples: list[str]) -> dict:
     return dict(family_counter)
 
 
-def minimise(clean_results: dict) -> dict:
-    """
-    removes a number of fields we don't want or need in the persisted JSON
-    Args:
-        clean_results ():
-
-    Returns:
-        same objects, minus a few attributes
-    """
-
-    var_fields_to_remove = [
-        'het_samples',
-        'hom_samples',
-        'boolean_categories',
-        'sample_categories',
-        'sample_support',
-        'ab_ratios',
-    ]
-    for sample, variants in clean_results.items():
-        for variant in variants:
-            print(variant)
-            var_obj = variant.var_data
-            var_obj.categories = var_obj.category_values(sample=sample)
-            for key in var_fields_to_remove:
-                del var_obj.__dict__[key]
-    return clean_results
-
-
 def main(
     labelled_vcf: str,
     out_json: str,
@@ -374,12 +346,8 @@ def main(
         results, samples=vcf_opened.samples, pedigree=pedigree_digest
     )
 
-    # shrink the final on-file representation by cutting fields
-    # maybe this could be done using the CustomEncoder?
-    minimised_data = minimise(cleaned_results)
-
     # remove previously seen results using cumulative data files
-    incremental_data = filter_results(minimised_data)
+    incremental_data = filter_results(cleaned_results)
 
     # add summary metadata to the dict
     incremental_data['metadata'] = {

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -25,6 +25,7 @@ from peddy.peddy import Ped
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
+from cpg_utils.git import get_git_commit_ref_of_current_repository
 
 from reanalysis.moi_tests import MOIRunner, PEDDY_AFFECTED
 from reanalysis.utils import (
@@ -356,6 +357,7 @@ def main(
         'run_datetime': f'{datetime.now():%Y-%m-%d %H:%M}',
         'family_breakdown': count_families(pedigree_digest, samples=vcf_opened.samples),
         'panels': panelapp_data['metadata'],
+        'commit_id': get_git_commit_ref_of_current_repository(),
     }
 
     # store a full version of the results here

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -301,6 +301,7 @@ def minimise(clean_results: dict) -> dict:
     ]
     for sample, variants in clean_results.items():
         for variant in variants:
+            print(variant)
             var_obj = variant.var_data
             var_obj.categories = var_obj.category_values(sample=sample)
             for key in var_fields_to_remove:

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -55,11 +55,11 @@ class SimpleVariant:
             pass
         return []
 
-    def category_values(self, sample_id):
+    def category_values(self, sample):
         """
         quick mock method
         """
-        return [sample_id]
+        return [sample]
 
 
 @dataclass
@@ -113,11 +113,11 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
         """
         return self.check_ab_ratio(sample)
 
-    def category_values(self, sample_id):
+    def category_values(self, sample):
         """
         quick mock method
         """
-        return [sample_id]
+        return [sample]
 
 
 @pytest.mark.parametrize(

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -63,7 +63,7 @@ class SimpleVariant:
 
 
 @dataclass
-class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
+class RecessiveSimpleVariant:
     """
     a fake version of AbstractVariant
     """

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -55,6 +55,12 @@ class SimpleVariant:
             pass
         return []
 
+    def category_values(self, sample_id):
+        """
+        quick mock method
+        """
+        return [sample_id]
+
 
 @dataclass
 class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
@@ -106,6 +112,12 @@ class RecessiveSimpleVariant:  # pylint: disable=too-many-instance-attributes
         gets all report flags for this sample
         """
         return self.check_ab_ratio(sample)
+
+    def category_values(self, sample_id):
+        """
+        quick mock method
+        """
+        return [sample_id]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

A couple of tweaks
  - Grabbing a 'minimised variant' representation is done much earlier on in the reporting stage, instead of leaving all the cleaning steps until the last minute
  - the first time we write the 'cumulative data' file, include the dates of all variants

## Checklist

- [ ] Linting checks pass
