### PR TITLE
`reference_path` and `image_path` now expect absolute path in configs

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -332,7 +332,7 @@ def main(
         # generate the jobs which run VEP & collect the results
         vep_jobs = add_vep_jobs(
             b=get_batch(),
-            input_siteonly_vcf_path=to_path(input_path),
+            vcf_path=to_path(input_path),
             tmp_prefix=to_path(
                 output_path('vep_temp', get_config()['buckets'].get('tmp_suffix'))
             ),

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -332,7 +332,7 @@ def main(
         # generate the jobs which run VEP & collect the results
         vep_jobs = add_vep_jobs(
             b=get_batch(),
-            vcf_path=to_path(input_path),
+            input_siteonly_vcf_path=to_path(input_path),
             tmp_prefix=to_path(
                 output_path('vep_temp', get_config()['buckets'].get('tmp_suffix'))
             ),

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -41,23 +41,7 @@ default_timeout = 6000
 default_memory = 'highmem'
 
 [images]
-vep = 'vep:105.0'
-gatk = 'gatk:4.2.6.1'
-cpg_workflows = 'cpg_workflows:latest'
-hail = 'cpg_workflows:latest'
-picard = 'picard_samtools:v0'
-picard_samtools = 'picard_samtools:v0'
+hail = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
 
 [references]
-vep_mount = 'vep/105.0/mount'
 genome_build = 'GRCh38'
-
-[references.broad]
-prefix = 'hg38/v0'
-ref_fasta = 'dragen_reference/Homo_sapiens_assembly38_masked.fasta'
-genome_calling_interval_lists = 'wgs_calling_regions.hg38.interval_list'
-
-[references.seqr]
-prefix = 'seqr/v0-1'
-combined_reference = 'combined_reference_data_grch38-2.0.4.ht'
-clinvar = 'clinvar.GRCh38.ht'

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -40,6 +40,11 @@ default_timeout = 6000
 default_memory = 'highmem'
 
 [images]
+vep = 'australia-southeast1-docker.pkg.dev/cpg-common/images/vep:105.0'
+gatk = 'australia-southeast1-docker.pkg.dev/cpg-common/images/gatk:4.2.6.1'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
+picard = 'australia-southeast1-docker.pkg.dev/cpg-common/images/picard:2.27.4'
+samtools = 'australia-southeast1-docker.pkg.dev/cpg-common/images/samtools:1.16.1'
 hail = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
 
 [references]

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -4,7 +4,6 @@ tmp_suffix = 'tmp'
 analysis_suffix = 'analysis'
 
 [workflow]
-image_registry_prefix = "australia-southeast1-docker.pkg.dev/cpg-common/images"
 name = 'AIP'
 scatter_count = 50
 sequencing_type = 'genome'
@@ -44,4 +43,11 @@ default_memory = 'highmem'
 hail = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest'
 
 [references]
+vep_mount = 'gs://cpg-common-main/references/vep/105.0/mount'
 genome_build = 'GRCh38'
+seqr_combined_reference_data = 'gs://cpg-common-main/references/seqr/v0/combined_reference_data_grch38.ht'
+seqr_clinvar = 'gs://cpg-common-main/references/seqr/v0/clinvar.GRCh38.ht'
+
+[references.broad]
+ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+genome_calling_interval_lists = 'gs://cpg-common-main/references/hg38/v0/wgs_calling_regions.hg38.interval_list'


### PR DESCRIPTION
We switched to generating config [by merging templates in AR](https://github.com/populationgenomics/analysis-runner/pull/559), with templates generated by Pulumi in [cpg-infra](https://github.com/populationgenomics/cpg-infrastructure/pull/20) as well as by the CI in corresponding [images](https://github.com/populationgenomics/images/pull/56/files) and [references](https://github.com/populationgenomics/references/pull/2) repositories. When running outside of our infra, absolute paths are expected now, so modifying AIP configs accordingly.