### PR TITLE
Make site-only VCF before passing to VEP

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -38,7 +38,6 @@ from cpg_workflows.batch import get_batch
 from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs
 from cpg_workflows.jobs.vep import add_vep_jobs
 from cpg_workflows.jobs.joint_genotyping import add_make_sitesonly_job
-from cpg_workflows.resources import storage_for_joint_vcf
 
 from utils import FileTypes, identify_file_type
 
@@ -335,7 +334,7 @@ def main(
             b=get_batch(),
             input_vcf=get_batch().read_input(input_path),
             output_vcf_path=siteonly_vcf_path,
-            storage_gb=300,
+            storage_gb=get_config()['workflow'].get('vcf_size_in_gb', 150) + 10,
         )
 
         vep_ht_tmp = to_path(

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -337,8 +337,8 @@ def main(
             storage_gb=get_config()['workflow'].get('vcf_size_in_gb', 150) + 10,
         )
 
-        vep_ht_tmp = to_path(
-            output_path('vep_annotations.ht', get_config()['buckets'].get('tmp_suffix'))
+        vep_ht_tmp = output_path(
+            'vep_annotations.ht', get_config()['buckets'].get('tmp_suffix')
         )
         # generate the jobs which run VEP & collect the results
         vep_jobs = add_vep_jobs(
@@ -348,7 +348,7 @@ def main(
                 output_path('vep_temp', get_config()['buckets'].get('tmp_suffix'))
             ),
             scatter_count=get_config()['workflow'].get('scatter_count', 50),
-            out_path=vep_ht_tmp,
+            out_path=to_path(vep_ht_tmp),
         )
 
         # if convert-to-VCF job exists, assign as an annotation dependency
@@ -360,7 +360,7 @@ def main(
         anno_job = annotate_cohort_jobs(
             b=get_batch(),
             vcf_path=to_path(input_path),
-            vep_ht_path=vep_ht_tmp,
+            vep_ht_path=to_path(vep_ht_tmp),
             out_mt_path=to_path(ANNOTATED_MT),
             checkpoint_prefix=to_path(
                 output_path(

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -37,6 +37,8 @@ from cpg_utils.hail_batch import (
 from cpg_workflows.batch import get_batch
 from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs
 from cpg_workflows.jobs.vep import add_vep_jobs
+from cpg_workflows.jobs.joint_genotyping import add_make_sitesonly_job
+from cpg_workflows.resources import storage_for_joint_vcf
 
 from utils import FileTypes, identify_file_type
 
@@ -326,18 +328,28 @@ def main(
         # need to run the annotation phase
         # uses default values from RefData
 
-        vep_ht_tmp = output_path(
-            'vep_annotations.ht', get_config()['buckets'].get('tmp_suffix')
+        siteonly_vcf_path = to_path(
+            output_path('siteonly.vcf.gz', get_config()['buckets'].get('tmp_suffix'))
+        )
+        add_make_sitesonly_job(
+            b=get_batch(),
+            input_vcf=get_batch().read_input(input_path),
+            output_vcf_path=siteonly_vcf_path,
+            storage_gb=300,
+        )
+
+        vep_ht_tmp = to_path(
+            output_path('vep_annotations.ht', get_config()['buckets'].get('tmp_suffix'))
         )
         # generate the jobs which run VEP & collect the results
         vep_jobs = add_vep_jobs(
             b=get_batch(),
-            input_siteonly_vcf_path=to_path(input_path),
+            input_siteonly_vcf_path=siteonly_vcf_path,
             tmp_prefix=to_path(
                 output_path('vep_temp', get_config()['buckets'].get('tmp_suffix'))
             ),
             scatter_count=get_config()['workflow'].get('scatter_count', 50),
-            out_path=to_path(vep_ht_tmp),
+            out_path=vep_ht_tmp,
         )
 
         # if convert-to-VCF job exists, assign as an annotation dependency
@@ -349,7 +361,7 @@ def main(
         anno_job = annotate_cohort_jobs(
             b=get_batch(),
             vcf_path=to_path(input_path),
-            vep_ht_path=to_path(vep_ht_tmp),
+            vep_ht_path=vep_ht_tmp,
             out_mt_path=to_path(ANNOTATED_MT),
             checkpoint_prefix=to_path(
                 output_path(

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -6,6 +6,7 @@ analysis_suffix = 'analysis'
 [workflow]
 name = 'AIP'
 scatter_count = 50
+vcf_size_in_gb = 300  # if the input is a VCF, specify enough storage to fit it
 sequencing_type = 'genome'
 
 [moi_tests]


### PR DESCRIPTION
The problem: VEP jobs expect a site-only VCF, and would run out of disk when used with a full VCF with genotypes. 

Adding a job to strip off genotypes.

Depends on https://github.com/populationgenomics/production-pipelines/pull/227