### PR TITLE
Fix genotype bug

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -56,7 +56,9 @@ PANELAPP_JSON_OUT = output_path(
 )
 
 # output of labelling task in Hail
-HAIL_VCF_OUT = output_path('hail_categorised.vcf.bgz')
+HAIL_VCF_OUT = output_path(
+    'hail_categorised.vcf.bgz', get_config()['buckets'].get('analysis_suffix')
+)
 
 
 # local script references

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -443,10 +443,14 @@ class RecessiveAutosomal(BaseMoi):
         valid if present as hom, or compound het
         counts as being phased if a compound het is split between parents
         Clarify if we want to consider a homozygous variant as 2 hets
-        :param principal_var:
-        :param comp_het:
-        :param partial_penetrance:
-        :return:
+
+        Args:
+            principal_var (AbstractVariant): main variant being evaluated
+            comp_het (dict): comp-het partners
+            partial_penetrance (bool):
+
+        Returns:
+            list[ReportedVariant]: data object if RecessiveAutosomal fits
         """
 
         if comp_het is None:

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -276,7 +276,7 @@ class BaseMoi:
             elif member_id in variant.het_samples:
                 return 'Het'
             elif member_id in variant.hom_samples:
-                return 'Het'
+                return 'Hom'
 
             return 'WT'
 

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -76,7 +76,7 @@ def set_up_inheritance_filters(
     # iterate over all genes
     for gene_data in panelapp_data['genes'].values():
 
-        # extract the per-gene MOI, and SIMPLIFY
+        # extract the per-gene MOI, don't re-simplify
         gene_moi = get_simple_moi(gene_data.get('moi'))
 
         # if we haven't seen this MOI before, set up the appropriate filter

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -43,7 +43,7 @@ from reanalysis.utils import (
 
 
 def set_up_inheritance_filters(
-    panelapp_data: dict[str, dict[str, Union[str, bool]]],
+    panelapp_data: dict,
     pedigree: Ped,
 ) -> dict[str, MOIRunner]:
     """
@@ -74,10 +74,7 @@ def set_up_inheritance_filters(
     moi_dictionary = {}
 
     # iterate over all genes
-    for key, gene_data in panelapp_data.items():
-
-        if key == 'metadata':
-            continue
+    for gene_data in panelapp_data['genes'].values():
 
         # extract the per-gene MOI, and SIMPLIFY
         gene_moi = get_simple_moi(gene_data.get('moi'))
@@ -188,8 +185,6 @@ def clean_and_filter(
         }
 
     gene_details = {}
-
-    print(result_list)
 
     for each_event in result_list:
 

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -189,6 +189,8 @@ def clean_and_filter(
 
     gene_details = {}
 
+    print(result_list)
+
     for each_event in result_list:
 
         # grab some attributes from the event


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

  - there was a genotype display bug where both Het and Hom would display as `Het` - a silly conditional copy/paste error
  - unrelated to, but found because of that error there is also an MOI issue:

1. PanelApp has a whole range of MOI options, including niche variations like `X-LINKED: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)`. I'm parsing these options into small Monoallelic/Biallelic/mono_and_biallelic instead of implementing an MOI test 1:1. For this example I'm reducing this to `X-linked Monoallelic` based on a conditional check flow.
2. Initially the PanelApp query JSON contained the full strings, and they were reduced later on to the 'simple' representation
3. Recently I moved the simplification logic so that the JSON already contains the simplified string
4. I forgot to update the downstream logic, so it was trying to re-simplify the simplified MOI string, e.g. 

```
PanelApp : BOTH monoallelic and biallelic, autosomal or pseudoautosomal
Conditional: "Starts with 'both', not on X"
Simplified : Mono_and_Biallelic

Stored: 'Mono_and_Biallelic'
Conditional: "starts with 'mono', not on X"
Simplified: Monoallelic
```

Pretty stupid, but AFAIK that's the reason POLG isn't being evaluated as both recessive and dominant

The fix here is to remove the re-simplification, and just use the contents of the PanelApp JSON directly

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
