### PR TITLE
tag using version, not SHA. Parametrise test tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,12 +37,11 @@ jobs:
         gcloud auth configure-docker australia-southeast1-docker.pkg.dev
     - name: build
       run: |
-        docker build . -f Dockerfile --tag $BASE_IMAGE:${{ github.sha }}
+        docker build . -f Dockerfile --tag $BASE_IMAGE:$VERSION
 
     - name: push latest
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        docker tag $BASE_IMAGE:${{ github.sha }} $BASE_IMAGE:$VERSION
-        docker tag $BASE_IMAGE:${{ github.sha }} $BASE_IMAGE:latest
+        docker tag $BASE_IMAGE:$VERSION $BASE_IMAGE:latest
         docker push $BASE_IMAGE:$VERSION
         docker push $BASE_IMAGE:latest

--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -34,7 +34,7 @@ jobs:
         gcloud auth configure-docker australia-southeast1-docker.pkg.dev
     - name: build
       run: |
-        docker build . -f Dockerfile --tag $BASE_IMAGE:test
+        docker build . -f Dockerfile --tag $BASE_IMAGE:${tag}
     - name: push test
       run: |
-        docker push $BASE_IMAGE:test
+        docker push $BASE_IMAGE:${tag}


### PR DESCRIPTION
# Fixes

  - parametrises the test tag (which should allow the arg to be overwritten)
  - removed the github SHA from the image name - @illusional mentioned this on a prior PR, but I hadn't realised how massive that name was until the images started being pushed