### PR TITLE
don't fail if the sample is absent from the seqr lookup

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -152,7 +152,7 @@ class Sample:
         self.ext_id = metadata['ext_id']
         self.panel_ids = metadata['panel_ids']
         self.panel_names = metadata['panel_names']
-        self.seqr_id = html_builder.seqr[name]
+        self.seqr_id = html_builder.seqr.get(name, name)
         self.html_builder = html_builder
 
         # Ingest variants excluding any on the forbidden gene list


### PR DESCRIPTION
# Fixes

  - HTML generation crashes when not all samples are present in the Seqr lookup. This is a patch fix, and would go away if we have an operational Seqr API to retrieve this data instead

## Proposed Changes

  - When looking up the Seqr-ID for a participant, don't crash and burn if the sample ID is not in the Seqr lookup
  - I ran into this situation when there was a new joint call, and the seqr lookup file had not been updated to reflect the new samples. This could also happen if a cohort was run through AIP prior to being loaded into Seqr
  - Basically it shouldn't happen often/ever, but it shouldn't fatally fail - it will be clear in the report HTML which samples don't have links to Seqr, and this can be updated as required

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
