### PR TITLE
corrected command spacing

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -119,7 +119,7 @@ def handle_clinvar() -> tuple[hb.batch.job.Job | None, str]:
 
     bash_job.command(
         (
-            f'wget -q {directory}{sub_file} -O {bash_job.subs} &&'
+            f'wget -q {directory}{sub_file} -O {bash_job.subs} && '
             f'wget -q {directory}{var_file} -O {bash_job.vars}'
         )
     )


### PR DESCRIPTION
# Fixes

  - Corrects spacing in the `wget && wget`, spotted by @illusional