### PR TITLE
re-works the family size counter

### DIFF
--- a/reanalysis/templates/index.html.jinja
+++ b/reanalysis/templates/index.html.jinja
@@ -52,7 +52,7 @@
         {# Run statistics #}
         <div class="tab-pane fade" id="stats-tab-pane" role="tabpanel"tabindex="0">
           <div>
-            <h3>Canditate variant statistics</h3>
+            <h3>Candidate variant statistics</h3>
             {% with table=summary_table %}
               {% include "datatable.html.jinja" %}
             {% endwith %}
@@ -66,7 +66,7 @@
           </div>
 
           <div>
-            <h3>Families with no canditate variants</h3>
+            <h3>Families with no candidate variants</h3>
             {% if zero_categorised_samples %}
               <ul>
                 {% for sample in zero_categorised_samples %}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -189,7 +189,7 @@ def fixture_quad_ped():
     :return:
     """
 
-    return QUAD_PED
+    return Ped(QUAD_PED)
 
 
 @pytest.fixture(name='trio_abs_variant')

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -82,11 +82,8 @@ def test_affected_finder_with_sibling(quad_ped):
     tests function to find probands from a Ped file
     contains the same trio as above ^^ plus an unaffected sibling
     :param quad_ped:
-    :return:
     """
-    # digest that Ped
-    ped_parsed = Ped(quad_ped)
-    samples = find_affected_samples(ped_parsed)
+    samples = find_affected_samples(quad_ped)
     assert samples == ['PROBAND']
 
 

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -205,5 +205,30 @@ def test_update_results_meta(peddy_ped):
         'male': 3,
         'female': 3,
         'trios': 2,
-        '3': 2,
     }
+
+
+def test_update_results_missing_father(peddy_ped):
+    """
+    testing the dict update
+    """
+
+    ped_samples = ['male', 'female', 'mother_1', 'mother_2', 'father_2']
+
+    assert count_families(
+        pedigree=peddy_ped,
+        samples=ped_samples,
+    ) == {'affected': 2, 'male': 2, 'female': 3, 'trios': 1, '2': 1}
+
+
+def test_update_results_quad(quad_ped):
+    """
+    testing the dict update
+    """
+
+    ped_samples = ['PROBAND', 'SIBLING', 'FATHER', 'MOTHER']
+
+    assert count_families(
+        pedigree=quad_ped,
+        samples=ped_samples,
+    ) == {'affected': 1, 'male': 3, 'female': 1, 'quads': 1}


### PR DESCRIPTION
# Fixes

  - Closes #196 

## Proposed Changes

  - removes reliance on the Peddy.summary function, which can't account for samples in the Pedigree but missing from the joint-call
  - inserts additional test for Trio, trio with missing participant, and quad structure
  - typo in report

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
