### PR TITLE
fix grouping by individual

### DIFF
--- a/reanalysis/templates/index.html.jinja
+++ b/reanalysis/templates/index.html.jinja
@@ -133,6 +133,7 @@
             group_collapsible : true,
             group_collapsed   : false,
             group_count       : false,
+            group_separator : " "
             }
         })
 

--- a/reanalysis/templates/variant_table.html.jinja
+++ b/reanalysis/templates/variant_table.html.jinja
@@ -1,7 +1,7 @@
 <table class="table tablesorter" id="variant-table">
 <thead>
     <tr>
-    <th class="group-word">Individual </th>
+    <th class="group-separator">Individual </th>
     <th class="group-false">Variant</th>
     <th class="group-false">Gene (MOI)</th>
     <th class="group-false">Categories</th>


### PR DESCRIPTION
# Fixes

Fixes variant grouping that was broken by having a dash in a extID. It looks like this still can result in some odd line wrapping in IDs, but we can figure that our another time.

