### PR TITLE
test tag fix

### DIFF
--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -37,4 +37,4 @@ jobs:
         docker build . -f Dockerfile --tag $BASE_IMAGE:{{ github.event.inputs.tag }}
     - name: push test
       run: |
-        docker push $BASE_IMAGE:$tag
+        docker push $BASE_IMAGE:{{ github.event.inputs.tag }}

--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -34,7 +34,7 @@ jobs:
         gcloud auth configure-docker australia-southeast1-docker.pkg.dev
     - name: build
       run: |
-        docker build . -f Dockerfile --tag $BASE_IMAGE:$tag
+        docker build . -f Dockerfile --tag $BASE_IMAGE:{{ github.event.inputs.tag }}
     - name: push test
       run: |
         docker push $BASE_IMAGE:$tag


### PR DESCRIPTION
# Fixes

  - completely biffed on how to get the input variable into the actual tag when designing the test workflow
  - I think it's still important to permit multiple separate in-development branch images to be built, so I'm avoiding hard-coding 'test' as the tag

## Proposed Changes

  - moved to the corrected (?) syntax, modelled on [this](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/deploy_server.yaml)
 
## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
