### PR TITLE
correction of MOI parsing

### DIFF
--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -755,11 +755,11 @@ def get_simple_moi(input_moi: str | None, chrom: str) -> str | None:
         case ['monoallelic', *_additional]:
             return 'Monoallelic'
         case [
-            'x-linked',
+            'xlinked',
             *additional,
         ] if 'biallelic' in additional:  # pylint: disable='used-before-assignment'
             return 'Hemi_Bi_In_Female'
-        case ['x-linked', *_additional]:
+        case ['xlinked', *_additional]:
             return 'Hemi_Mono_In_Female'
         case _:
             return default

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -152,4 +152,4 @@ def test_get_best_moi_x():
 
     d = {'ensg1': {'moi': {'x-linked biallelic', 'x-linked'}, 'chrom': 'X'}}
     get_best_moi(d)
-    assert d['ensg1']['moi'] == 'Hemi_Bi_In_Female'
+    assert d['ensg1']['moi'] == 'Hemi_Mono_In_Female'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -123,7 +123,7 @@ def test_file_types_exception():
         ('both something,something', 'Mono_And_Biallelic', '1'),
         (None, 'Biallelic', '1'),
         ('monoallelic, something', 'Monoallelic', '1'),
-        ('x-linked', 'Hemi_Bi_In_Female', 'X'),
+        ('x-linked', 'Hemi_Mono_In_Female', 'X'),
         (None, 'Hemi_Bi_In_Female', 'X'),
         ('x-linked biallelic', 'Hemi_Bi_In_Female', 'X'),
     ],


### PR DESCRIPTION
# Fixes

  - N/A

## Proposed Changes

  - When moving to the match/case syntax, I inserted a preparation stage that stripped out all punctuation (i.e. to make sure that 'biallelic,' matched to 'biallelic'
  - This also strips out the hyphen in `x-linked`, so none of the X chromosome MOIs were matching to any of the cases, which were unchanged as `x-linked` instead of `xlinked`
  - This results in them falling through and hitting the default condition, which assigned `Hemi_Bi...` to all chrX genes
  - The test case that would have caught this was also changed to expecting X_Biallelic, as we also changed the nominated default leniency at the same time, leaving no test case for X_Mono

## Checklist

- [ ] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
