### PR TITLE
Clinvar passes filters

### DIFF
--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -519,7 +519,7 @@ class RecessiveAutosomalHomo(BaseMoi):
     def __init__(
         self,
         pedigree: Ped,
-        applied_moi: str = 'Autosomal Recessive',
+        applied_moi: str = 'Autosomal Recessive Homozygous',
     ):
         """ """
         self.hom_threshold = get_config()['moi_tests'][GNOMAD_REC_HOM_THRESHOLD]
@@ -545,14 +545,11 @@ class RecessiveAutosomalHomo(BaseMoi):
 
         classifications = []
 
-        if principal.support_only:
-            return classifications
-
         # remove if too many homs are present in population databases
-        # no stricter AF here - if we choose to, we can apply while labelling
-        if self.check_frequency(
-            principal.info, INFO_HOMS, self.hom_threshold
-        ) and not principal.info.get('categoryboolean1'):
+        if principal.support_only or (
+            self.check_frequency(principal.info, INFO_HOMS, self.hom_threshold)
+            and not principal.info.get('categoryboolean1')
+        ):
             return classifications
 
         for sample_id in principal.hom_samples:
@@ -583,7 +580,7 @@ class RecessiveAutosomalHomo(BaseMoi):
                     genotypes=self.get_family_genotypes(
                         variant=principal, sample_id=sample_id
                     ),
-                    reasons={f'{self.applied_moi} Homozygous'},
+                    reasons={self.applied_moi},
                     flags=principal.get_sample_flags(sample_id),
                 )
             )
@@ -768,7 +765,7 @@ class XRecessiveMale(BaseMoi):
                     genotypes=self.get_family_genotypes(
                         variant=principal, sample_id=sample_id
                     ),
-                    reasons={f'{self.applied_moi}'},
+                    reasons={self.applied_moi},
                     flags=principal.get_sample_flags(sample_id),
                 )
             )

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -313,11 +313,17 @@ def test_ac_threshold(
 
 
 @pytest.mark.parametrize(
-    'filters,results',
-    [({'FAILURE'}, ['QC: Variant has assigned quality flags']), (None, [])],
+    'filters,clinvar,results',
+    [
+        ({'FAILURE'}, 0, ['QC: Variant has assigned quality flags']),
+        ({'FAILURE'}, 1, []),
+        (None, 0, []),
+        (None, 1, []),
+    ],
 )
 def test_run_quality_flag_check(
     filters: list[str],
+    clinvar: int,
     results: list[str],
     hail_matrix: hl.MatrixTable,
 ):
@@ -326,7 +332,9 @@ def test_run_quality_flag_check(
     """
     if filters is None:
         filters = hl.empty_set(t=hl.tstr)
-    anno_mt = hail_matrix.annotate_rows(filters=filters)
+    anno_mt = hail_matrix.annotate_rows(
+        filters=filters, info=hail_matrix.info.annotate(clinvar_aip=clinvar)
+    )
     assert run_quality_flag_check(anno_mt) == results
 
 

--- a/test/test_hail_broad_filters.py
+++ b/test/test_hail_broad_filters.py
@@ -42,25 +42,24 @@ def test_ac_filter_no_filt(
 
 
 @pytest.mark.parametrize(
-    'filters,length',
+    'filters,clinvar,length',
     [
-        (hl.empty_set(hl.tstr), 1),
-        (hl.literal({'fail'}), 0),
-        (hl.literal({'VQSR'}), 0),
+        (hl.empty_set(hl.tstr), 0, 1),
+        (hl.literal({'fail'}), 0, 0),
+        (hl.literal({'fail'}), 1, 1),
+        (hl.literal({'VQSR'}), 0, 0),
+        (hl.literal({'VQSR'}), 1, 1),
     ],
 )
-def test_filter_on_quality_flags(filters, length, hail_matrix):
+def test_filter_on_quality_flags(filters, clinvar, length, hail_matrix):
     """
     annotate filters and run tests
-
-    :param filters:
-    :param length:
-    :param hail_matrix:
-    :return:
     """
     # to add new alleles, we need to scrub alleles from the key fields
     hail_matrix = hail_matrix.key_rows_by('locus')
-    anno_matrix = hail_matrix.annotate_rows(filters=filters)
+    anno_matrix = hail_matrix.annotate_rows(
+        filters=filters, info=hail_matrix.info.annotate(clinvar_aip=clinvar)
+    )
 
     assert filter_on_quality_flags(anno_matrix).count_rows() == length
 


### PR DESCRIPTION
# Fixes

  - Permit FILTER flagged variants to pass through Hail stage, if registered as Pathogenic in Clinvar

## Proposed Changes

  - Escape clause in FILTER test
  - updates relevant tests
  - 'ronseal' isn't a very good docstring message, is it...

## Checklist

- [x] Tests covering new change
- [x] Linting checks pass
