### PR TITLE
script for release copy

### DIFF
--- a/release_scripts/broad_rgp_release.sh
+++ b/release_scripts/broad_rgp_release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+gsutil -m -u broad-rgp cp -r \
+    gs://cpg-broad-rgp-main/mt/3355c9263be6d4b6e13c88b95fb0e3bc1bc99d_1559-broad-rgp.mt \
+    gs://cpg-broad-rgp-main-release/mt/3355c9263be6d4b6e13c88b95fb0e3bc1bc99d_1559-broad-rgp.mt

--- a/release_scripts/broad_rgp_release.sh
+++ b/release_scripts/broad_rgp_release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-gsutil -m -u broad-rgp cp -r \
+gcloud storage --project=broad-rgp cp --recursive \
     gs://cpg-broad-rgp-main/mt/3355c9263be6d4b6e13c88b95fb0e3bc1bc99d_1559-broad-rgp.mt \
-    gs://cpg-broad-rgp-main-release/mt/3355c9263be6d4b6e13c88b95fb0e3bc1bc99d_1559-broad-rgp.mt
+    gs://cpg-broad-rgp-release/3355c9263be6d4b6e13c88b95fb0e3bc1bc99d_1559-broad-rgp.mt


### PR DESCRIPTION
# Fixes

  - Script to release some data to MSFT/Broad

## Proposed Changes

  - This should probably be replaced with `gcloud storage`, but I'm not 100% sure of the argument order to use a specific order
  - `gcloud storage -u broad-rgp copy -r ...`?
  -

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
