### PR TITLE
allow for no new genes in hail

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -208,7 +208,7 @@ def annotate_category_1(mt: hl.MatrixTable) -> hl.MatrixTable:
 
 
 def annotate_category_2(
-    mt: hl.MatrixTable, new_genes: hl.SetExpression
+    mt: hl.MatrixTable, new_genes: hl.SetExpression | None
 ) -> hl.MatrixTable:
     """
     - Gene is new in PanelApp
@@ -224,6 +224,10 @@ def annotate_category_2(
     """
 
     critical_consequences = hl.set(get_config()['filter']['critical_csq'])
+
+    # permit scenario with no new genes
+    if new_genes is None:
+        return mt.annotate_rows(info=mt.info.annotate(categoryboolean2=MISSING_INT))
 
     # check for new - if new, allow for in silico, CSQ, or clinvar to confirm
     return mt.annotate_rows(
@@ -714,7 +718,7 @@ def write_matrix_to_vcf(mt: hl.MatrixTable):
 
 def green_and_new_from_panelapp(
     panel_genes: dict[str, dict[str, str]]
-) -> tuple[hl.SetExpression, hl.SetExpression]:
+) -> tuple[hl.SetExpression, hl.SetExpression | None]:
     """
     Pull all ENSGs from PanelApp data relating to Green Genes
     Also identify the subset of those genes which relate to NEW in panel
@@ -724,6 +728,7 @@ def green_and_new_from_panelapp(
 
     Returns:
         two set expressions - Green, and (Green and New) genes
+        can return None if no genes are currently new
     """
 
     # take all the green genes, remove the metadata
@@ -735,9 +740,10 @@ def green_and_new_from_panelapp(
         gene for gene in green_genes if len(panel_genes[gene].get('new', [])) > 0
     }
     logging.info(f'Extracted {len(new_genes)} NEW genes')
-    new_gene_set_expression = hl.literal(new_genes)
+    if new_genes:
+        return green_gene_set_expression, hl.literal(new_genes)
 
-    return green_gene_set_expression, new_gene_set_expression
+    return green_gene_set_expression, None
 
 
 def checkpoint_and_repartition(
@@ -986,9 +992,7 @@ if __name__ == '__main__':
     parser.add_argument('--mt', required=True, help='path to input MT')
     parser.add_argument('--panelapp', type=str, required=True, help='panelapp JSON')
     parser.add_argument('--plink', type=str, required=True, help='Cohort Pedigree')
-    parser.add_argument(
-        '--clinvar', type=str, default='absent', help='Custom Clinvar Summary HT'
-    )
+    parser.add_argument('--clinvar', default='absent', help='Custom Clinvar HT')
     args = parser.parse_args()
     main(
         mt_path=args.mt, panelapp=args.panelapp, plink=args.plink, clinvar=args.clinvar

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -65,3 +65,4 @@ genome_calling_interval_lists = 'gs://cpg-common-main/references/hg38/v0/wgs_cal
 
 [dataset_specific]
 description = 'placeholder for per-cohort data'
+require_pheno_match = ["FLG"]

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -370,11 +370,7 @@ def prepare_results_shell(
 @click.option(
     '--input_path', help='source data', default='Not supplied', show_default=True
 )
-@click.option(
-    '--participant_panels',
-    help='dict of panels per participant',
-    default=None,
-)
+@click.option('--participant_panels', help='panels per participant', default=None)
 def main(
     labelled_vcf: str,
     out_json: str,


### PR DESCRIPTION
# Fixes

  - Hail stage breaks when no genes are new - Hail cannot impute the member types of an empty set so it just falls over

## Proposed Changes

  - If no genes are New, pass back None instead 
  - During Cat. 2 annotation if new genes is None, just flat annotate 0 as the category value for all rows

Not an urgent fix

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
