### PR TITLE
Overrides for historical runs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,8 @@
 # 3. Q003 ("Change outer quotes to avoid escaping inner quotes")
 # 4. F841 unused-variable, covered using pylint
 # 5. E501 line-too-long, covered using pylint
-extend-ignore: F541,E203,Q003,F841,E501
+# 6. E402 import position error, covered using pylint
+extend-ignore: F541,E203,Q003,F841,E501,E402
 
 # Maximum number of characters on a single line. Default for black, see:
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -100,6 +100,11 @@ def handle_clinvar() -> tuple[Job | None, str]:
         the path to the current clinvar summary file
     """
 
+    if clinvar_table := get_config()['workflow'].get('forced_clinvar'):
+        logging.info(f'This run will be using the Clinvar data in {clinvar_table}')
+        if to_path(clinvar_table).exists():
+            return None, clinvar_table
+
     # is it time to re-process clinvar?
     clinvar_prefix = dataset_path(
         f'clinvar_summaries/{datetime.now().strftime("%Y_%m")}'

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -472,7 +472,7 @@ def main(
         participant_panels=participant_panels,
     )
 
-    # remove previously seen results using cumulative data file(s)
+    # annotate previously seen results using cumulative data file(s)
     analysis_results = filter_results(
         analysis_results, singletons=bool('singleton' in pedigree)
     )
@@ -482,7 +482,9 @@ def main(
         'metadata': {
             'input_file': input_path,
             'cohort': get_config()['workflow']['dataset'],
-            'run_datetime': f'{datetime.now():%Y-%m-%d %H:%M}',
+            'run_datetime': get_config()['workflow'].get(
+                'fake_date', f'{datetime.now():%Y-%m-%d %H:%M}'
+            ),
             'family_breakdown': count_families(
                 pedigree_digest, samples=vcf_opened.samples
             ),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,12 +13,22 @@ from peddy.peddy import Ped
 from cpg_utils import to_path
 from cpg_utils.config import set_config_paths
 
-from reanalysis.utils import AbstractVariant, read_json_from_path
-from reanalysis.hail_filter_and_label import MISSING_INT, MISSING_STRING
-
 
 PWD = to_path(__file__).parent
 INPUT = PWD / 'input'
+
+# force this to come first
+CONF_BASE = INPUT / 'reanalysis_global.toml'
+CONF_COHORT = INPUT / 'reanalysis_cohort.toml'
+
+hl.init(default_reference='GRCh38')
+set_config_paths([str(CONF_BASE), str(CONF_COHORT)])
+
+
+# pylint: disable=wrong-import-position
+from reanalysis.utils import AbstractVariant, read_json_from_path
+from reanalysis.hail_filter_and_label import MISSING_INT, MISSING_STRING
+
 
 LABELLED = INPUT / '1_labelled_variant.vcf.bgz'
 AIP_OUTPUT = INPUT / 'aip_output_example.json'
@@ -28,8 +38,6 @@ FAKE_OBO = INPUT / 'hpo_test.obo'
 LOOKUP_PED = INPUT / 'mock_sm_lookup.json'
 PHASED_TRIO = INPUT / 'newphase.vcf.bgz'
 PED_FILE = INPUT / 'pedfile.ped'
-CONF_BASE = INPUT / 'reanalysis_global.toml'
-CONF_COHORT = INPUT / 'reanalysis_cohort.toml'
 SEQR_OUTPUT = INPUT / 'seqr_tags.tsv'
 HAIL_VCF = INPUT / 'single_hail.vcf.bgz'
 QUAD_PED = INPUT / 'trio_plus_sibling.fam'
@@ -38,11 +46,6 @@ QUAD_PED = INPUT / 'trio_plus_sibling.fam'
 PANELAPP_LATEST = INPUT / 'panelapp_current_137.json'
 PANELAPP_INCIDENTALOME = INPUT / 'incidentalome.json'
 FAKE_PANELAPP_OVERVIEW = INPUT / 'panel_overview.json'
-
-
-# force this to come first
-hl.init(default_reference='GRCh38')
-set_config_paths([str(CONF_BASE), str(CONF_COHORT)])
 
 
 @pytest.fixture(name='cleanup', scope='session', autouse=True)

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -12,12 +12,9 @@ from copy import deepcopy
 from reanalysis.utils import (
     date_annotate_results,
     find_latest_file,
+    get_granular_date,
     Coordinates,
-    GRANULAR,
 )
-
-
-# pylint: disable=consider-using-with
 
 
 @dataclass
@@ -38,7 +35,7 @@ class MiniReport:
 
     var_data: MiniVariant
     support_vars: list[str] = field(default_factory=list)
-    first_seen: str = GRANULAR
+    first_seen: str = get_granular_date()
 
 
 COORD_1 = Coordinates('1', 1, 'A', 'G')
@@ -60,7 +57,10 @@ def test_date_annotate_one():
     assert results == new_results
     assert cumulative == {
         'sample': {
-            COORD_1.string_format: {'categories': {'1': GRANULAR}, 'support_vars': []}
+            COORD_1.string_format: {
+                'categories': {'1': get_granular_date()},
+                'support_vars': [],
+            }
         }
     }
 
@@ -102,7 +102,7 @@ def test_date_annotate_three():
     assert cumulative == {
         'sample': {
             COORD_1.string_format: {
-                'categories': {'1': OLD_DATE, '2': GRANULAR},
+                'categories': {'1': OLD_DATE, '2': get_granular_date()},
                 'support_vars': [],
             }
         }
@@ -156,13 +156,13 @@ def test_date_annotate_five():
     assert historic == {
         'sample': {
             COORD_1.string_format: {
-                'categories': {'1': GRANULAR, '2': OLD_DATE},
+                'categories': {'1': get_granular_date(), '2': OLD_DATE},
                 'support_vars': [],
             }
         },
         'sample2': {
             COORD_2.string_format: {
-                'categories': {'2': GRANULAR},
+                'categories': {'2': get_granular_date()},
                 'support_vars': [],
             }
         },
@@ -173,7 +173,7 @@ def test_date_annotate_five():
             'variants': [
                 MiniReport(
                     MiniVariant(categories=['1'], coords=COORD_1),
-                    first_seen=GRANULAR,
+                    first_seen=get_granular_date(),
                 )
             ]
         },
@@ -181,11 +181,17 @@ def test_date_annotate_five():
             'variants': [
                 MiniReport(
                     MiniVariant(categories=['2'], coords=COORD_2),
-                    first_seen=GRANULAR,
+                    first_seen=get_granular_date(),
                 )
             ]
         },
     }
+
+
+def touch(filepath: str):
+    """simulates a touch"""
+    with open(filepath, 'w', encoding='utf-8'):
+        pass
 
 
 def test_find_latest(tmp_path):
@@ -194,11 +200,11 @@ def test_find_latest(tmp_path):
     """
     tmp_str = str(tmp_path)
 
-    open(join(tmp_str, 'file1.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file1.json'))
     sleep(0.2)
-    open(join(tmp_str, 'file2.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file2.json'))
     sleep(0.2)
-    open(join(tmp_str, 'file3.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file3.json'))
     assert 'file3.json' in find_latest_file(tmp_str)
 
 
@@ -207,11 +213,11 @@ def test_find_latest_singletons(tmp_path):
     check that we find the correct latest file
     """
     tmp_str = str(tmp_path)
-    open(join(tmp_str, 'singletons_file1.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'singletons_file1.json'))
     sleep(0.2)
-    open(join(tmp_str, 'file2.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file2.json'))
     sleep(0.2)
-    open(join(tmp_str, 'file3.json'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file3.json'))
     assert 'singletons_file1.json' in find_latest_file(tmp_str, start='singletons')
 
 
@@ -220,9 +226,9 @@ def test_find_latest_with_ext(tmp_path):
     check that we find the correct latest file
     """
     tmp_str = str(tmp_path)
-    open(join(tmp_str, 'file1.txt'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file1.txt'))
     sleep(0.2)
-    open(join(tmp_str, 'file2.txt'), 'w', encoding='utf-8')
+    touch(join(tmp_str, 'file2.txt'))
     sleep(0.2)
-    open(join(tmp_str, 'file3.txt'), 'w', encoding='utf-8')
-    assert 'file3.txt' in find_latest_file(tmp_str, ext='txt')
+    touch(join(tmp_str, 'file3.json'))
+    assert 'file2.txt' in find_latest_file(tmp_str, ext='txt')


### PR DESCRIPTION
# Fixes

  - < the issue solved by this PR >

## Proposed Changes

  - allows for a config override for 'todays date' - historical data will use this manually overridden date, used in synthetic historic interval analysis 
  - allows for a config override to use a specific clinvar re-summary table, same as above
  - counts a comp-het pair as a single unique event, instead of as 2 variants

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
