### PR TITLE
Clinvar summary in driver image

### DIFF
--- a/reanalysis/clinvar_runner.py
+++ b/reanalysis/clinvar_runner.py
@@ -30,6 +30,7 @@ def main(ht_out: str, date: str | None = None):
 
     # create a bash job to copy data from remote
     bash_job = get_batch().new_bash_job(name='copy clinvar files to local')
+    bash_job.image(get_config()['workflow']['driver_image'])
 
     directory = 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/'
     sub_file = 'submission_summary.txt.gz'

--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -515,8 +515,7 @@ if __name__ == '__main__':
         '-d',
         help=(
             'date, format DD-MM-YYYY. Individual submissions after this date are '
-            'removed. Un-dated submissions will pass this threshold. This logic is '
-            'retained, but unlikely to be used in any production work.'
+            'removed. Un-dated submissions will pass this threshold.'
         ),
         default=datetime.now(),
     )


### PR DESCRIPTION
# Fixes

  - unless the default job image is set, the jobs run in a basic `ubuntu:20.0` image, which lacks wget

## Proposed Changes

  - run the child jobs in the driver image