### PR TITLE
add shebang to report finder script

### DIFF
--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+
+
 """
 track down the latest version of all reports
 generate an index HTML page with links to all reports


### PR DESCRIPTION
## Proposed Changes

  - adds a shebang to prevent bash running a python script
  - The alternative would be `"script": ["python3", "./report_hunter.py"]`?
 