### PR TITLE
removes forbidden genes in first pass

### DIFF
--- a/test/input/reanalysis_cohort.toml
+++ b/test/input/reanalysis_cohort.toml
@@ -4,7 +4,6 @@ seqr_lookup = "e.g. gs://cpg-acute-care-test/reanalysis/parsed_seqr.json"
 external_lookup = "e.g. gs://cpg-acute-care-test/reanalysis/cpg_to_external_id.json"
 seqr_instance = "e.g. https://seqr.populationgenomics.org.au"
 seqr_project = "R0011_acute_care"
-forbidden = ""
 
 [workflow]
 dataset = "cohort"


### PR DESCRIPTION
# Fixes

  - The current approach is to let forbidden genes linger in the analysis results until the HTML is generated, and remove them later. This approach doesn't work for the historic analysis where we want to artificially back-filter results using a gene list, as it means that genes will be blocked from Cat2 status (as they are already in the historic results), but they will then be removed. This creates a weird gap where it's tough to do a meaningful historic interval analysis.

## Proposed Changes

  - Remove genes from the panel data completely if they're blacklisted, so that when they stop being blacklisted (artificially representing the point in time where the gene was marked green on the relevant panel) they will populate properly as a new gene.
  - This is a relatively minor change, but it's getting to the point where this interval analysis should almost be its own fork 😓 
  - Please leave un-merged, may require some extra thinking about whether the 12-month interval can still be used for historic analysis (when running as-of 2020-07-01, really the interval we're trying to represent is the 12 months between 44 and 32 months ago 🤮)

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
