### PR TITLE
Annotate common tx csq

### DIFF
--- a/reanalysis/clinvar_by_codon.py
+++ b/reanalysis/clinvar_by_codon.py
@@ -1,0 +1,78 @@
+"""
+method file for re-sorting clinvar annotations by codon
+utilises the latest in-house clinvar summary data
+"""
+import logging
+
+import hail as hl
+
+from reanalysis.hail_filter_and_label import PATHOGENIC
+
+
+def protein_indexed_clinvar(mt: hl.MatrixTable, write_path: str, new_decisions: str):
+    """
+    takes a MatrixTable of annotated Clinvar Variants
+    re-annotates these loci with the latest in-house decisions
+    reduces dataset to only pathogenic
+
+    re-indexes the data to be queryable on Transcript and Codon
+    writes the resulting Table to the specified path
+
+    This was prototyped and executed in a notebook
+
+    Args:
+        mt (): MatrixTable of Clinvar variants with VEP anno.
+        write_path (): location to write new file to
+        new_decisions (str): path to a local clinvar re-summary file
+
+    Returns:
+        N/A - write completes within method
+    """
+
+    # 1. re-annotate to use the latest decisions
+    logging.info(f'loading private clinvar annotations from {new_decisions}')
+    clinvar_ht: hl.Table = hl.read_table(new_decisions)
+
+    # remove all non-pathogenic sites
+    clinvar_ht = clinvar_ht.filter(
+        clinvar_ht.clinvar_significance.lower().contains(PATHOGENIC)
+    )
+
+    # minimise MT content
+    mt = mt.rows()
+    mt = mt.select(tx_csq=mt.vep.transcript_consequences)
+
+    # 1. reduce the annotated clinvar to a minimal representation
+    clinvar_ht = mt.rows().join(clinvar_ht)
+
+    # 1. split rows out to separate consequences
+    clinvar_ht = clinvar_ht.explode_rows(clinvar_ht.tx_csq)
+
+    # 2. filter down to rows with the relevant content, as a Table
+    # i.e. remove non-protein changes, and non-clinvar
+    clinvar_ht = clinvar_ht.filter(
+        clinvar_ht.tx_csq.consequence_terms.contains('missense_variant')
+    )
+
+    # 3. squash the clinvar and protein content into strings
+    clinvar_ht = clinvar_ht.annotate(
+        clinvar_entry=hl.str('::').join(
+            [
+                hl.str(clinvar_ht.allele_id),
+                clinvar_ht.clinical_significance,
+                hl.str(clinvar_ht.gold_stars),
+            ]
+        ),
+        newkey=hl.str('::').join(
+            [
+                clinvar_ht.tx_csq.protein_id,
+                hl.str(clinvar_ht.tx_csq.protein_start),
+            ]
+        ),
+    )
+
+    # create a new table keyed on transcript&position
+    temp = clinvar_ht.key_by(clinvar_ht.newkey)
+    temp = temp.select(temp.clinvar_entry).collect_by_key()
+    temp = temp.annotate(values=hl.set(hl.map(lambda x: x.clinvar_entry, temp.values)))
+    temp.write(write_path, overwrite=True)

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -228,7 +228,9 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     codon_variants.show(1, handler=logging.info)
 
     codon_variants = codon_variants.annotate(
-        clinvar_variations=hl.str(';').join(codon_variants.clinvar_variations)
+        clinvar_variations=hl.str(';').join(
+            hl.map(lambda x: x.clinvar_alleles, codon_variants.clinvar_variations)
+        )
     )
 
     logging.info('describe 7')

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -210,21 +210,24 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     codon_variants = codon_variants.transmute(
         locus=codon_variants.positions.locus, alleles=codon_variants.positions.alleles
     )
-    logging.info('describe 5')
+    logging.info('describe 4')
     codon_variants.show(1, handler=logging.info)
 
     # re-key by locus/allele
     codon_variants = codon_variants.key_by(codon_variants.locus, codon_variants.alleles)
 
-    logging.info('describe 4')
+    logging.info('describe 5')
     codon_variants.show(1, handler=logging.info)
 
     # aggregate back to position and alleles
-    codon_variants = codon_variants.select(codon_variants.clinvar_set).collect_by_key(
-        name='clinvar_variations'
-    )
+    codon_variants = codon_variants.select(
+        codon_variants.clinvar_alleles
+    ).collect_by_key(name='clinvar_variations')
 
     logging.info('describe 6')
+    codon_variants = codon_variants.transmute(
+        clinvar_variations=hl.str(';').join(codon_clinvar.clinvar_variations)
+    )
     codon_variants.show(1, handler=logging.info)
 
     # conditional annotation back into the original MT

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -240,7 +240,7 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     mt = mt.annotate_rows(
         info=mt.info.annotate(
             categorydetailsPM5=hl.or_else(
-                codon_variants[mt.row_key].clinvar_variations, MISSING_INT
+                codon_variants[mt.row_key].clinvar_variations, MISSING_STRING
             )
         )
     )

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -229,7 +229,9 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
 
     codon_variants = codon_variants.annotate(
         clinvar_variations=hl.str(';').join(
-            hl.map(lambda x: x.clinvar_alleles, codon_variants.clinvar_variations)
+            hl.set(
+                hl.map(lambda x: x.clinvar_alleles, codon_variants.clinvar_variations)
+            )
         )
     )
 

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -771,7 +771,7 @@ def filter_to_categorised(mt: hl.MatrixTable) -> hl.MatrixTable:
         | (mt.info.categorysample4 != 'missing')
         | (mt.info.categoryboolean5 == 1)
         | (mt.info.categorysupport == 1)
-        | (mt.info.categorydetailsPM5 != MISSING_INT)
+        | (mt.info.categorydetailsPM5 != MISSING_STRING)
     )
 
 
@@ -1039,8 +1039,8 @@ def main(mt_path: str, panelapp: str, plink: str, clinvar: str):
     mt = annotate_category_1(mt=mt)
     mt = annotate_category_2(mt=mt, new_genes=new_expression)
     mt = annotate_category_3(mt=mt)
-    mt = annotate_category_5(mt=mt)
     mt = annotate_category_4(mt=mt, plink_family_file=plink)
+    mt = annotate_category_5(mt=mt)
     mt = annotate_category_support(mt=mt)
 
     # if a clinvar-codon table is supplied, use that for PM5

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -189,10 +189,14 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     # boom those variants out by consequence
     codon_variants = mt.explode_rows(mt.vep.transcript_consequences).rows()
 
-    # filter for missense
+    # filter for missense, no indels (don't trust VEP)
     codon_variants = codon_variants.filter(
-        codon_variants.vep.transcript_consequences.consequence_terms.contains(
-            'missense_variant'
+        (hl.len(codon_variants.alleles[0]) == ONE_INT)
+        & (hl.len(codon_variants.alleles[1]) == ONE_INT)
+        & (
+            codon_variants.vep.transcript_consequences.consequence_terms.contains(
+                'missense_variant'
+            )
         )
     )
 

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -159,7 +159,9 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     # read in the codon table
     logging.info(f'reading clinvar alleles by codon from {codon_table_path}')
     codon_clinvar = hl.read_table(codon_table_path)
-    codon_clinvar = codon_clinvar.transmute(clinvar_set=codon_clinvar.values)
+    codon_clinvar = codon_clinvar.transmute(
+        clinvar_alleles=hl.str(';').join(codon_clinvar.values)
+    )
 
     logging.info('describe 1')
     codon_clinvar.show(1, handler=logging.info)
@@ -183,8 +185,6 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
             ]
         )
     )
-    logging.info('describe 2')
-    codon_variants.show(1, handler=logging.info)
 
     # 4. re-key the table on Transcript::Codon
     codon_variants = codon_variants.key_by(codon_variants.residue_affected)
@@ -208,8 +208,9 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
 
     # annotate positions back to normal names (not required?)
     codon_variants = codon_variants.transmute(
-        locus=codon_variants.values.locus, alleles=codon_variants.values.alleles
+        locus=codon_variants.positions.locus, alleles=codon_variants.positions.alleles
     )
+    logging.info('describe 5')
     codon_variants.show(1, handler=logging.info)
 
     # re-key by locus/allele
@@ -223,7 +224,7 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
         name='clinvar_variations'
     )
 
-    logging.info('describe 5')
+    logging.info('describe 6')
     codon_variants.show(1, handler=logging.info)
 
     # conditional annotation back into the original MT

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -1039,8 +1039,11 @@ def main(mt_path: str, panelapp: str, plink: str, clinvar: str):
     mt = annotate_category_1(mt=mt)
     mt = annotate_category_2(mt=mt, new_genes=new_expression)
     mt = annotate_category_3(mt=mt)
-    mt = annotate_category_4(mt=mt, plink_family_file=plink)
     mt = annotate_category_5(mt=mt)
+
+    # ordering is important - category4 (de novo) makes
+    # use of category 5, so it must follow
+    mt = annotate_category_4(mt=mt, plink_family_file=plink)
     mt = annotate_category_support(mt=mt)
 
     # if a clinvar-codon table is supplied, use that for PM5

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -193,24 +193,24 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     codon_variants = codon_variants.join(codon_clinvar)
 
     # explode back out to release the positions
-    codon_variants = codon_variants.explode(codon_variants.positions)
+    codon_variants = codon_variants.explode(codon_variants.values)
 
     # annotate positions back to normal names (not required?)
     codon_variants = codon_variants.annotate(
-        locus=codon_variants.positions.locus, alleles=codon_variants.positions.alleles
+        locus=codon_variants.values.locus, alleles=codon_variants.values.alleles
     )
 
     # re-key by locus/allele
     codon_variants = codon_variants.key_by(codon_variants.locus, codon_variants.alleles)
 
     # aggregate back to position and alleles
-    codon_variants = codon_variants.select(codon_variants.values).collect_by_key()
+    codon_variants = codon_variants.select(codon_variants.newkey).collect_by_key()
 
     # conditional annotation back into the original MT
     mt = mt.annotate_rows(
         info=mt.info.annotate(
             categorydetailsPM5=hl.or_else(
-                codon_variants[mt.row_key].values, MISSING_INT
+                codon_variants[mt.row_key].newkey, MISSING_INT
             )
         )
     )

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -228,7 +228,7 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     codon_variants.show(1, handler=logging.info)
 
     codon_variants = codon_variants.annotate(
-        clinvar_variations=hl.str(';').join(codon_clinvar.clinvar_variations)
+        clinvar_variations=hl.str(';').join(codon_variants.clinvar_variations)
     )
 
     logging.info('describe 7')

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -160,6 +160,9 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     logging.info(f'reading clinvar alleles by codon from {codon_table_path}')
     codon_clinvar = hl.read_table(codon_table_path)
 
+    logging.info('describe 1')
+    codon_clinvar.describe()
+
     # boom those variants out by consequence
     codon_variants = mt.explode_rows(mt.vep.transcript_consequences).rows()
 
@@ -179,6 +182,8 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
             ]
         )
     )
+    logging.info('describe 2')
+    codon_variants.describe()
 
     # 4. re-key the table on Transcript::Codon
     codon_variants = codon_variants.key_by(codon_variants.newkey)
@@ -187,6 +192,8 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     codon_variants = codon_variants.select(
         codon_variants.locus, codon_variants.alleles
     ).collect_by_key()
+    logging.info('describe 3')
+    codon_variants.describe()
 
     # join the real variant positions with aggregated clinvar
     # 'values' here is the array of all positions
@@ -203,8 +210,14 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     # re-key by locus/allele
     codon_variants = codon_variants.key_by(codon_variants.locus, codon_variants.alleles)
 
+    logging.info('describe 4')
+    codon_variants.describe()
+
     # aggregate back to position and alleles
     codon_variants = codon_variants.select(codon_variants.newkey).collect_by_key()
+
+    logging.info('describe 5')
+    codon_variants.describe()
 
     # conditional annotation back into the original MT
     mt = mt.annotate_rows(

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -235,7 +235,7 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     ).collect_by_key(name='clinvar_variations')
 
     codon_variants = codon_variants.annotate(
-        clinvar_variations=hl.str('||').join(
+        clinvar_variations=hl.str('+').join(
             hl.set(
                 hl.map(lambda x: x.clinvar_alleles, codon_variants.clinvar_variations)
             )

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -225,9 +225,13 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     ).collect_by_key(name='clinvar_variations')
 
     logging.info('describe 6')
-    codon_variants = codon_variants.transmute(
+    codon_variants.show(1, handler=logging.info)
+
+    codon_variants = codon_variants.annotate(
         clinvar_variations=hl.str(';').join(codon_clinvar.clinvar_variations)
     )
+
+    logging.info('describe 7')
     codon_variants.show(1, handler=logging.info)
 
     # conditional annotation back into the original MT

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -159,9 +159,10 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
     # read in the codon table
     logging.info(f'reading clinvar alleles by codon from {codon_table_path}')
     codon_clinvar = hl.read_table(codon_table_path)
+    codon_clinvar = codon_clinvar.transmute(clinvar_set=codon_clinvar.values)
 
     logging.info('describe 1')
-    codon_clinvar.describe()
+    codon_clinvar.show(1, handler=logging.info)
 
     # boom those variants out by consequence
     codon_variants = mt.explode_rows(mt.vep.transcript_consequences).rows()
@@ -175,7 +176,7 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
 
     # set the protein residue as an attribute
     codon_variants = codon_variants.annotate(
-        newkey=hl.str('::').join(
+        residue_affected=hl.str('::').join(
             [
                 codon_variants.vep.transcript_consequences.protein_id,
                 hl.str(codon_variants.vep.transcript_consequences.protein_start),
@@ -183,47 +184,53 @@ def annotate_codon_clinvar(mt: hl.MatrixTable, codon_table_path: str | None):
         )
     )
     logging.info('describe 2')
-    codon_variants.describe()
+    codon_variants.show(1, handler=logging.info)
 
     # 4. re-key the table on Transcript::Codon
-    codon_variants = codon_variants.key_by(codon_variants.newkey)
+    codon_variants = codon_variants.key_by(codon_variants.residue_affected)
 
     # 5. extract the position table (protein change linked to all loci)
     codon_variants = codon_variants.select(
         codon_variants.locus, codon_variants.alleles
-    ).collect_by_key()
+    ).collect_by_key(name='positions')
+
     logging.info('describe 3')
-    codon_variants.describe()
+    codon_variants.show(1, handler=logging.info)
 
     # join the real variant positions with aggregated clinvar
     # 'values' here is the array of all positions
     codon_variants = codon_variants.join(codon_clinvar)
+    codon_variants.show(1, handler=logging.info)
 
     # explode back out to release the positions
-    codon_variants = codon_variants.explode(codon_variants.values)
+    codon_variants = codon_variants.explode(codon_variants.positions)
+    codon_variants.show(1, handler=logging.info)
 
     # annotate positions back to normal names (not required?)
-    codon_variants = codon_variants.annotate(
+    codon_variants = codon_variants.transmute(
         locus=codon_variants.values.locus, alleles=codon_variants.values.alleles
     )
+    codon_variants.show(1, handler=logging.info)
 
     # re-key by locus/allele
     codon_variants = codon_variants.key_by(codon_variants.locus, codon_variants.alleles)
 
     logging.info('describe 4')
-    codon_variants.describe()
+    codon_variants.show(1, handler=logging.info)
 
     # aggregate back to position and alleles
-    codon_variants = codon_variants.select(codon_variants.newkey).collect_by_key()
+    codon_variants = codon_variants.select(codon_variants.clinvar_set).collect_by_key(
+        name='clinvar_variations'
+    )
 
     logging.info('describe 5')
-    codon_variants.describe()
+    codon_variants.show(1, handler=logging.info)
 
     # conditional annotation back into the original MT
     mt = mt.annotate_rows(
         info=mt.info.annotate(
             categorydetailsPM5=hl.or_else(
-                codon_variants[mt.row_key].newkey, MISSING_INT
+                codon_variants[mt.row_key].clinvar_variations, MISSING_INT
             )
         )
     )

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -20,7 +20,7 @@ from cpg_utils.config import get_config
 from reanalysis.utils import read_json_from_path, get_cohort_config
 
 
-CATEGORY_ORDERING = ['any', '1', '2', '3', '4', '5', 'support']
+CATEGORY_ORDERING = ['any', '1', '2', '3', '4', '5', 'PM5', 'support']
 JINJA_TEMPLATE_DIR = Path(__file__).absolute().parent / 'templates'
 
 

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -20,7 +20,7 @@ from cpg_utils.config import get_config
 from reanalysis.utils import read_json_from_path, get_cohort_config
 
 
-CATEGORY_ORDERING = ['any', '1', '2', '3', '4', '5', 'PM5', 'support']
+CATEGORY_ORDERING = ['any', '1', '2', '3', '4', '5', 'pm5', 'support']
 JINJA_TEMPLATE_DIR = Path(__file__).absolute().parent / 'templates'
 
 

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -32,6 +32,7 @@ ac_threshold = 0.01
 additional_csq = ['missense_variant']
 af_semi_rare = 0.01
 cadd = 28.1
+codon_table = "gs://cpg-common-test/clinvar/codon_indexed.ht"
 critical_csq = ['frameshift_variant', 'splice_acceptor_variant', 'splice_donor_variant', 'start_lost', 'stop_gained', 'stop_lost', 'transcript_ablation']
 gerp = 1.0
 eigen = 0.25
@@ -40,6 +41,7 @@ polyphen = 0.99
 revel = 0.77
 sift = 0.0
 spliceai = 0.5
+
 
 [hail]
 cancel_after_n_failures = 1

--- a/reanalysis/templates/variant_table.html.jinja
+++ b/reanalysis/templates/variant_table.html.jinja
@@ -92,15 +92,12 @@
     </td>
     <td>
         {# PM5 ClinVar #}
-        {% if 'pm5' in variant.categories %}
-            {% for allele, stars in variant.var_data.info.pm5_data %}
+        {% if 'pm5' in variant.var_data.categories %}
+            {% for allele, stars in variant.var_data.info.pm5_data.items() %}
 
-                <a href="http://www.ncbi.nlm.nih.gov/clinvar?term={{allele}}[allele]"
+                <a href="http://www.ncbi.nlm.nih.gov/clinvar?term={{allele}}[alleleid]"
                     target="_blank">
                     {{allele}}
-                    {% for i in range(stars|int) -%}
-                        <i class="bi-star"></i>
-                    {%- endfor %}
                 </a>
             {%- endfor %}
         {% endif %}

--- a/reanalysis/templates/variant_table.html.jinja
+++ b/reanalysis/templates/variant_table.html.jinja
@@ -7,7 +7,8 @@
     <th class="group-false">Categories</th>
     <th class="group-false sorter-shortDate" data-date-format="yyyymmdd">First Seen</th>
     <th class="group-false">MANE CSQ</th>
-    <th class="group-false">Clinvar</th>
+    <th class="group-false">ClinVar</th>
+    <th class="group-false">PM5 ClinVar</th>
     <th class="group-false">Flags</th>
     <th class="group-false">Support</th>
     </tr>
@@ -86,6 +87,21 @@
             <br>
             {% for i in range(variant.var_data.info.clinvar_stars|int) -%}
                 <i class="bi-star"></i>
+            {%- endfor %}
+        {% endif %}
+    </td>
+    <td>
+        {# PM5 ClinVar #}
+        {% if 'PM5' in variant.categories %}
+            {% for allele, stars in variant.var_data.info.pm5_data %}
+
+                <a href="http://www.ncbi.nlm.nih.gov/clinvar?term={{allele}}[allele]"
+                    target="_blank">
+                    {{allele}}
+                    {% for i in range(stars|int) -%}
+                        <i class="bi-star"></i>
+                    {%- endfor %}
+                </a>
             {%- endfor %}
         {% endif %}
     </td>

--- a/reanalysis/templates/variant_table.html.jinja
+++ b/reanalysis/templates/variant_table.html.jinja
@@ -92,7 +92,7 @@
     </td>
     <td>
         {# PM5 ClinVar #}
-        {% if 'PM5' in variant.categories %}
+        {% if 'pm5' in variant.categories %}
             {% for allele, stars in variant.var_data.info.pm5_data %}
 
                 <a href="http://www.ncbi.nlm.nih.gov/clinvar?term={{allele}}[allele]"

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -379,6 +379,9 @@ class AbstractVariant:
             else:
                 _boolcat = self.info.pop('categoryboolean2')
 
+        # do something spicy with PM5 - weird logic here
+        self.organise_pm5()
+
         # set the class attributes
         self.boolean_categories = [
             key for key in self.info.keys() if key.startswith('categoryboolean')
@@ -421,6 +424,54 @@ class AbstractVariant:
         self.ab_ratios = dict(zip(samples, map(float, var.gt_alt_freqs)))
         self.depths = dict(zip(samples, map(float, var.gt_depths)))
         self.categories = []
+
+    def organise_pm5(self):
+        """
+        method dedicated to handling the new pm5 annotations
+
+        e.g. categorydetailsPM5=27037::Pathogenic::1+27048::Pathogenic::1;
+        1. break into component allele data
+
+        Returns:
+            None, updates self. attributes
+        """
+        try:
+            pm5_content = self.info.pop('categorydetailsPM5')
+        except KeyError:
+            return
+
+        # nothing to do here
+        if pm5_content == 'missing':
+            return
+
+        # current clinvar annotation, if any
+        current_clinvar = self.info.get('clinvar_allele', 'not_this')
+
+        # instantiate a dict to store csq-matched results
+        pm5_data = {}
+
+        # break the strings into a set
+        pm5_strings = set(pm5_content.split('+'))
+        for clinvar_entry in pm5_strings:
+
+            # fragment each entry
+            allele_id, rating, stars = clinvar_entry.split('::')
+
+            # never consider the exact match, pm5 is always separate
+            if allele_id == current_clinvar:
+                continue
+
+            # if non-self, add to the dict
+            pm5_data[allele_id] = (rating, stars)
+
+        # case where no non-self alleles were found
+        # assigning False and not-assigning are equivalent, just return
+        if not pm5_data:
+            return
+
+        # set boolean category and specific data
+        self.info['categorybooleanPM5'] = 1
+        self.info['pm5_data'] = pm5_data
 
     def __str__(self):
         return repr(self)

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -379,7 +379,7 @@ class AbstractVariant:
             else:
                 _boolcat = self.info.pop('categoryboolean2')
 
-        # do something spicy with PM5 - weird logic here
+        # do something spicy with PM5
         self.organise_pm5()
 
         # set the class attributes
@@ -442,10 +442,11 @@ class AbstractVariant:
 
         # nothing to do here
         if pm5_content == 'missing':
+            self.info['categorybooleanpm5'] = 0
             return
 
         # current clinvar annotation, if any
-        current_clinvar = self.info.get('clinvar_allele', 'not_this')
+        current_clinvar = str(self.info.get('clinvar_allele', 'not_this'))
 
         # instantiate a dict to store csq-matched results
         pm5_data = {}
@@ -466,7 +467,7 @@ class AbstractVariant:
 
         # case where no non-self alleles were found
         # assigning False and not-assigning are equivalent, just return
-        if not pm5_data:
+        if pm5_data:
             # set boolean category and specific data
             self.info['categorybooleanpm5'] = 1
             self.info['pm5_data'] = pm5_data
@@ -560,7 +561,6 @@ class AbstractVariant:
             new_cat = category.replace('categorysample', 'categoryboolean')
             self.info[new_cat] = bool(sample in sample_list)
             self.boolean_categories.append(new_cat)
-
         categories = [
             bool_cat.replace('categoryboolean', '')
             for bool_cat in self.boolean_categories

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -436,7 +436,7 @@ class AbstractVariant:
             None, updates self. attributes
         """
         try:
-            pm5_content = self.info.pop('categorydetailsPM5')
+            pm5_content = self.info.pop('categorydetailspm5')
         except KeyError:
             return
 
@@ -468,10 +468,10 @@ class AbstractVariant:
         # assigning False and not-assigning are equivalent, just return
         if not pm5_data:
             # set boolean category and specific data
-            self.info['categorybooleanPM5'] = 1
+            self.info['categorybooleanpm5'] = 1
             self.info['pm5_data'] = pm5_data
         else:
-            self.info['categorybooleanPM5'] = 0
+            self.info['categorybooleanpm5'] = 0
 
     def __str__(self):
         return repr(self)

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -455,23 +455,23 @@ class AbstractVariant:
         for clinvar_entry in pm5_strings:
 
             # fragment each entry
-            allele_id, rating, stars = clinvar_entry.split('::')
+            allele_id, _rating, stars = clinvar_entry.split('::')
 
             # never consider the exact match, pm5 is always separate
             if allele_id == current_clinvar:
                 continue
 
             # if non-self, add to the dict
-            pm5_data[allele_id] = (rating, stars)
+            pm5_data[allele_id] = stars
 
         # case where no non-self alleles were found
         # assigning False and not-assigning are equivalent, just return
         if not pm5_data:
-            return
-
-        # set boolean category and specific data
-        self.info['categorybooleanPM5'] = 1
-        self.info['pm5_data'] = pm5_data
+            # set boolean category and specific data
+            self.info['categorybooleanPM5'] = 1
+            self.info['pm5_data'] = pm5_data
+        else:
+            self.info['categorybooleanPM5'] = 0
 
     def __str__(self):
         return repr(self)

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -347,20 +347,21 @@ def test_filter_to_green_genes_and_split__consequence(hail_matrix):
 
 
 @pytest.mark.parametrize(
-    'one,two,three,four,five,support,length',
+    'one,two,three,four,five,support,pm5,length',
     [
-        (0, 0, 0, 'missing', 0, 0, 0),
-        (0, 1, 0, 'missing', 0, 0, 1),
-        (0, 0, 1, 'missing', 0, 0, 1),
-        (0, 0, 0, 'missing', 0, 1, 1),
-        (0, 0, 0, 'not_blank', 0, 0, 1),
-        (0, 0, 0, 'missing', 1, 0, 1),
-        (0, 1, 1, 'missing', 0, 1, 1),
-        (1, 0, 0, 'missing', 0, 1, 1),
+        (0, 0, 0, 'missing', 0, 0, 'missing', 0),
+        (0, 0, 0, 'missing', 0, 0, 'notmissing', 1),
+        (0, 1, 0, 'missing', 0, 0, 'missing', 1),
+        (0, 0, 1, 'missing', 0, 0, 'missing', 1),
+        (0, 0, 0, 'missing', 0, 1, 'missing', 1),
+        (0, 0, 0, 'not_blank', 0, 0, 'missing', 1),
+        (0, 0, 0, 'missing', 1, 0, 'missing', 1),
+        (0, 1, 1, 'missing', 0, 1, 'missing', 1),
+        (1, 0, 0, 'missing', 0, 1, 'missing', 1),
     ],
 )
 def test_filter_to_classified(
-    one, two, three, four, five, support, length, hail_matrix
+    one, two, three, four, five, support, pm5, length, hail_matrix
 ):
     """
     :param hail_matrix:
@@ -373,6 +374,7 @@ def test_filter_to_classified(
             categorysample4=four,
             categoryboolean5=five,
             categorysupport=support,
+            categorydetailsPM5=pm5,
         )
     )
     matrix = filter_to_categorised(anno_matrix)


### PR DESCRIPTION
# Fixes

  - Implements a new category based on the PM5 ACMG criteria
  - Closes #140

## Proposed Changes

  - Includes a helper script with code used to take a clinvar VCF annotated by VEP, reshuffle the content into a Hail Table linking all Protein_ID and residue number with all relevant clinvar alleles
  - This helper isn't being built up into a proper wrapper script because once VEP is released on Hail Query that will be much easier to develop. Pretty manual until then
  - Includes a `categorydetailspm5` which will collect all clinvar missense submissions at the same residue as a current missense
  - any matched submissions that are an exact match to this current variant are removed
  - This data is processed to create a new column in the report HTML with hyperlinks to the other entries (if appropriate)
  - needs further testing, but happy to force this through for now to freeze functional code - happy to increase test coverage

Waiting for tweaks to downgrade the pm5 from being a full category to being a type of support

## Checklist

- [x] Related Issue created
- [] Tests covering new change
- [x] Linting checks pass
