### PR TITLE
Mods for singleton runs

### DIFF
--- a/helpers/prepare_aip_cohort.py
+++ b/helpers/prepare_aip_cohort.py
@@ -6,6 +6,7 @@ master script for preparing a run
 - optionally takes a seqr metadata file
 - copies relevant files to GCP
 - generates the cohort-specific TOML file
+- tweaks for making singleton versions of the given cohort
 """
 
 
@@ -139,24 +140,30 @@ PED_KEYS = [
 
 
 def get_ped_with_permutations(
-    pedigree_dicts: list[dict],
-    sample_to_cpg_dict: dict,
+    pedigree_dicts: list[dict], sample_to_cpg_dict: dict, make_singletons: bool = False
 ) -> list[dict]:
     """
     Take the pedigree entry representations from the pedigree endpoint
     translates sample IDs of all members to CPG values
     sample IDs are replaced with lists, containing all permutations
     where multiple samples exist
+    Optionally, overwrite all family structures and render as singletons
+    If we're running singletons, remove all unaffected
 
-    :param pedigree_dicts:
-    :param sample_to_cpg_dict:
-    :return:
+    Args:
+        pedigree_dicts ():
+        sample_to_cpg_dict ():
+        make_singletons ():
+
+    Returns:
+        list of dicts representing rows of the pedigree
     """
 
     new_entries = []
     failures: list[str] = []
 
-    for ped_entry in pedigree_dicts:
+    # enumerate to get ints - use these as family IDs if singletons
+    for counter, ped_entry in enumerate(pedigree_dicts, 1):
 
         if ped_entry['individual_id'] not in sample_to_cpg_dict:
             failures.append(ped_entry['individual_id'])
@@ -164,13 +171,21 @@ def get_ped_with_permutations(
         # update the sample IDs
         ped_entry['individual_id'] = sample_to_cpg_dict[ped_entry['individual_id']]
 
-        # remove parents and assign an individual sample ID
-        ped_entry['paternal_id'] = sample_to_cpg_dict.get(
-            ped_entry['paternal_id'], ['0']
-        )
-        ped_entry['maternal_id'] = sample_to_cpg_dict.get(
-            ped_entry['maternal_id'], ['0']
-        )
+        if make_singletons:
+            # skip unaffected singletons
+            if ped_entry['affected'] == 0:
+                continue
+            ped_entry['paternal_id'] = ['0']
+            ped_entry['maternal_id'] = ['0']
+            ped_entry['family_id'] = str(counter)
+        else:
+            # remove parents and assign an individual sample ID
+            ped_entry['paternal_id'] = sample_to_cpg_dict.get(
+                ped_entry['paternal_id'], ['0']
+            )
+            ped_entry['maternal_id'] = sample_to_cpg_dict.get(
+                ped_entry['maternal_id'], ['0']
+            )
 
         new_entries.append(ped_entry)
 
@@ -183,7 +198,10 @@ def get_ped_with_permutations(
 
 
 def process_pedigree(
-    ped_with_permutations: list[dict], local_dir: Path, remote_dir: Path
+    ped_with_permutations: list[dict],
+    local_dir: Path,
+    remote_dir: Path,
+    singletons: bool = False,
 ) -> str:
     """
     take the pedigree data, and write out as a correctly formatted PED file
@@ -193,6 +211,7 @@ def process_pedigree(
         ped_with_permutations (): the PED content with sample lists
         local_dir ():
         remote_dir ():
+        singletons (bool):
 
     Returns:
         The path we're writing the remote data to
@@ -220,11 +239,14 @@ def process_pedigree(
     # condense all lines into one
     single_line = ''.join(ped_lines)
 
+    # make the pedigree name
+    ped_name = f'{"singletons_" if singletons else ""}pedigree.ped'
+
     # write to a local file
-    (local_dir / 'pedigree.ped').write_text(single_line)
+    (local_dir / ped_name).write_text(single_line)
 
     # also write to the remote path
-    remote_path = remote_dir / 'pedigree.ped'
+    remote_path = remote_dir / ped_name
     remote_path.write_text(single_line)
     logging.info(f'Wrote pedigree with {len(ped_lines)} lines to {remote_path}')
 
@@ -236,8 +258,12 @@ def get_pedigree_for_project(project: str) -> list[dict[str, str]]:
     """
     fetches the project pedigree from sample-metadata
     list, one dict per participant
-    :param project:
-    :return: all content retrieved from API
+
+    Args:
+        project (str): project/dataset to use in query
+
+    Returns:
+        All API returned content
     """
 
     return FamilyApi().get_pedigree(project=project)
@@ -278,9 +304,12 @@ def hash_reduce_dicts(pedigree_dicts: list[dict], hash_threshold: int) -> list[d
     Normalises the Hash value to the range 0 - 99
     if the normalised value exceeds the threshold, remove
 
-    :param pedigree_dicts:
-    :param hash_threshold: int
-    :return:
+    Args:
+        pedigree_dicts ():
+        hash_threshold ():
+
+    Returns:
+
     """
 
     logging.info(f'Reducing families to {hash_threshold}%')
@@ -298,9 +327,22 @@ def hash_reduce_dicts(pedigree_dicts: list[dict], hash_threshold: int) -> list[d
     return reduced_pedigree
 
 
-def main(project: str, obo: str, seqr_file: str | None = None, exome: bool = False):
+def main(
+    project: str,
+    obo: str,
+    seqr_file: str | None = None,
+    exome: bool = False,
+    singletons: bool = False,
+):
     """
     Who runs the world? main()
+
+    Args:
+        project ():
+        obo ():
+        seqr_file ():
+        exome ():
+        singletons ():
     """
 
     local_root = to_path(LOCAL_TEMPLATE.format(dataset=project))
@@ -329,16 +371,23 @@ def main(project: str, obo: str, seqr_file: str | None = None, exome: bool = Fal
     ped_with_permutations = get_ped_with_permutations(
         pedigree_dicts=pedigree_dicts,
         sample_to_cpg_dict=sample_to_cpg_dict,
+        make_singletons=singletons,
     )
 
     # store a way of reversing this lookup in future
     reverse_lookup = process_reverse_lookup(sample_to_cpg_dict, local_root, remote_root)
 
+    # try a more universal way of preparing output paths
+    path_prefixes = []
+    if exome:
+        path_prefixes.append('exomes')
+    if singletons:
+        path_prefixes.append('singleton')
+    hist_prefixes = path_prefixes + ['historic_results']
+
     cohort_config = {
         'dataset_specific': {
-            'historic_results': str(remote_root / 'exome' / 'historic_results')
-            if exome
-            else str(remote_root / 'historic_results'),
+            'historic_results': str(remote_root / '/'.join(hist_prefixes)),
             'external_lookup': reverse_lookup,
         }
     }
@@ -354,12 +403,12 @@ def main(project: str, obo: str, seqr_file: str | None = None, exome: bool = Fal
             }
         )
 
-    ped_file = process_pedigree(ped_with_permutations, local_root, remote_root)
+    ped_file = process_pedigree(
+        ped_with_permutations, local_root, remote_root, singletons=singletons
+    )
 
-    if exome:
-        cohort_path = local_root / 'exome_config.toml'
-    else:
-        cohort_path = local_root / 'cohort_config.toml'
+    path_prefixes.append('cohort_config.toml')
+    cohort_path = local_root / '_'.join(path_prefixes)
 
     with cohort_path.open('w') as handle:
         toml.dump(cohort_config, handle)
@@ -415,4 +464,5 @@ if __name__ == '__main__':
         obo=args.obo,
         seqr_file=args.seqr,
         exome=args.e,
+        singletons=args.singletons,
     )

--- a/helpers/prepare_aip_cohort.py
+++ b/helpers/prepare_aip_cohort.py
@@ -383,6 +383,8 @@ def main(
         path_prefixes.append('exomes')
     if singletons:
         path_prefixes.append('singleton')
+
+    logging.info(f'Output Prefix:\n---\nreanalysis/{"/".join(path_prefixes)}\n---')
     hist_prefixes = path_prefixes + ['historic_results']
 
     cohort_config = {

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -211,7 +211,7 @@ def handle_hail_filtering(
     """
 
     labelling_job = get_batch().new_job(name='hail filtering')
-    set_job_resources(labelling_job, prior_job=prior_job, memory='16Gi')
+    set_job_resources(labelling_job, prior_job=prior_job, memory='32Gi')
     labelling_command = (
         f'python3 {hail_filter_and_label.__file__} '
         f'--mt {ANNOTATED_MT} '
@@ -229,7 +229,7 @@ def handle_results_job(
     labelled_vcf: str,
     pedigree: str,
     input_path: str,
-    output_dict: dict[str, dict[str, str]],
+    output_dict: dict[str, str],
     prior_job: Job | None = None,
     participant_panels: str | None = None,
 ):
@@ -274,7 +274,7 @@ def main(
     input_path: str,
     pedigree: str,
     participant_panels: str | None,
-    singletons: str | None = None,
+    singletons: bool = False,
     skip_annotation: bool = False,
 ):
     """
@@ -284,7 +284,7 @@ def main(
         input_path (): path to the VCF/MT
         pedigree (): family file for this analysis
         participant_panels (): file containing panels-per-family (optional)
-        singletons (): optional second Pedigree file without families
+        singletons (): run as Singletons (with appropriate output paths)
         skip_annotation (): if the input is annotated, don't re-run
     """
 
@@ -296,15 +296,19 @@ def main(
 
     # region: output files lookup
     # separate paths for familial and singleton analysis
+    if singletons:
+        assert (
+            'singleton' in get_config()['workflow']['output_prefix']
+        ), 'To keep singletons separate, include "singleton" in the file path'
+
+    # modify output paths depending on analysis type
     output_dict = {
-        'default': {
-            'web_html': output_path('summary_output.html', 'web'),
-            'results': output_path('summary_results.json', 'analysis'),
-        },
-        'singletons': {
-            'web_html': output_path('singleton_output.html', 'web'),
-            'results': output_path('singleton_results.json', 'analysis'),
-        },
+        'web_html': output_path(
+            f'{"singleton" if singletons else "summary"}_output.html', 'web'
+        ),
+        'results': output_path(
+            f'{"singleton" if singletons else "summary"}_results.json', 'analysis'
+        ),
     }
     # endregion
 
@@ -412,29 +416,16 @@ def main(
         get_batch().read_input_group(vcf=HAIL_VCF_OUT, tbi=HAIL_VCF_OUT + '.tbi').vcf
     )
 
-    # region: singleton decisions
-    # if singleton PED supplied, also run as singletons w/separate outputs
-    analysis_rounds = [(pedigree_in_batch, 'default')]
-    if singletons and to_path(singletons).exists():
-        to_path(singletons).copy(
-            output_path(f'singletons_{EXECUTION_TIME}.fam', 'analysis')
-        )
-        pedigree_singletons = get_batch().read_input(singletons)
-        analysis_rounds.append((pedigree_singletons, 'singletons'))
-    # endregion
-
     # region: run results job
     # pointing this analysis at the updated config file, including input metadata
-    for relationships, analysis_index in analysis_rounds:
-        logging.info(f'running analysis in {analysis_index} mode')
-        handle_results_job(
-            labelled_vcf=labelled_vcf_in_batch,
-            pedigree=relationships,
-            input_path=input_path,
-            output_dict=output_dict[analysis_index],
-            prior_job=prior_job,
-            participant_panels=participant_panels,
-        )
+    handle_results_job(
+        labelled_vcf=labelled_vcf_in_batch,
+        pedigree=pedigree_in_batch,
+        input_path=input_path,
+        output_dict=output_dict,
+        prior_job=prior_job,
+        participant_panels=participant_panels,
+    )
     # endregion
 
     # region: copy data out
@@ -473,8 +464,12 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('-i', help='variant data to analyse', required=True)
     parser.add_argument('--pedigree', help='in Plink format', required=True)
-    parser.add_argument('--singletons', help='singletons in Plink format')
     parser.add_argument('--participant_panels', help='per-participant panel details')
+    parser.add_argument(
+        '--singletons',
+        help='boolean, set if this run is a singleton pedigree',
+        action='store_true',
+    )
     parser.add_argument(
         '--skip_annotation',
         help='if set, annotation will not be repeated',


### PR DESCRIPTION
# Fixes

  - Closes #266 

## Proposed Changes

  - alters how singleton runs are operated; instead of pairing a 'regular' and a 'singleton' run at the same time, AIP can run in singleton mode, with appropriate output paths
  - Helper method for setting up a run has the singleton mode reimplemented (this was removed a while back)
  - The pairing of the singleton and regular versions was logical, based on being able to share workflow components (PanelApp, Hail), but falls down in the current situation where a family analysis was already run, and running singleton analysis would require that to be repeated

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
