### PR TITLE
write web proxy path into metamist

### DIFF
--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -63,7 +63,7 @@ def main():
             # incorporate that into a key when gathering
             all_cohorts[f'{cohort}_{exome_output}_{singleton_output}'] = Report(
                 dataset=cohort,
-                address=analysis['output'],
+                address=analysis['meta']['display_url'],
                 genome_or_exome='Exome' if exome_output else 'Genome',
                 subtype='Singleton' if singleton_output else 'Familial',
                 date=analysis['timestamp_completed'].split('T')[0],

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass
+from os.path import join
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ from peddy.peddy import Ped
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import output_path
 
 from sample_metadata.apis import AnalysisApi
 from sample_metadata.model.analysis_type import AnalysisType
@@ -82,10 +84,16 @@ def register_html(pedigree: str, html_path: str):
     # the pedigree and the actual VCF/MT
     samples = sorted(s.sample_id for s in pedigree.samples())
 
-    # METAAAAAAAA -Exomes/genomes, Singletons/not
+    web_template = get_config()['storage']['default']['web_url']
+    display_url = join(
+        web_template, get_config()['workflow']['output_prefix'], html_path
+    )
+
+    # Create object Meta - Exomes/genomes, Singletons/not, proxied html path
     report_meta = {
-        'is_exome': bool('exome' in html_path),
-        'is_singleton': bool('singleton' in html_path),
+        'is_exome': bool('exome' in display_url),
+        'is_singleton': bool('singleton' in display_url),
+        'display_url': display_url,
     }
 
     # find any previous AnalysisEntries... Update to active=False
@@ -288,11 +296,15 @@ class HTMLBuilder:
 
         return tables
 
-    def write_html(self, output_path: str):
+    def write_html(self, output_filepath: str):
         """
         Uses the results to create the HTML tables
         writes all content to the output path
+
+        Args:
+            output_filepath ():
         """
+
         summary_table, zero_categorised_samples = self.get_summary_stats()
 
         template_context = {
@@ -335,7 +347,7 @@ class HTMLBuilder:
         )
         template = env.get_template('index.html.jinja')
         content = template.render(**template_context)
-        to_path(output_path).write_text(
+        to_path(output_filepath).write_text(
             '\n'.join(line for line in content.split('\n') if line.strip())
         )
 
@@ -461,13 +473,13 @@ if __name__ == '__main__':
     parser.add_argument('--results', help='Path to analysis results', required=True)
     parser.add_argument('--pedigree', help='PED file', required=True)
     parser.add_argument('--panelapp', help='PanelApp data', required=True)
-    parser.add_argument('--out_path', help='results path', required=True)
+    parser.add_argument('--out_path', help='final HTML filename', required=True)
     args = parser.parse_args()
 
     html = HTMLBuilder(
         results=args.results, panelapp=args.panelapp, pedigree=args.pedigree
     )
-    html.write_html(output_path=args.out_path)
+    html.write_html(output_path(args.out_path, 'web'))
 
     # upon success, register the results
     register_html(pedigree=args.pedigree, html_path=args.out_path)

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -126,7 +126,7 @@ def register_html(pedigree: str, html_path: str):
             sample_ids=samples,
             type=AnalysisType('web'),
             status=AnalysisStatus('completed'),
-            output=html_path,
+            output=output_path(html_path, 'web'),
             meta=report_meta,
             active=True,
         ),

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -303,12 +303,8 @@ def main(
 
     # modify output paths depending on analysis type
     output_dict = {
-        'web_html': output_path(
-            f'{"singleton" if singletons else "summary"}_output.html', 'web'
-        ),
-        'results': output_path(
-            f'{"singleton" if singletons else "summary"}_results.json', 'analysis'
-        ),
+        'web_html': f'{"singleton" if singletons else "summary"}_output.html',
+        'results': f'{"singleton" if singletons else "summary"}_results.json',
     }
     # endregion
 

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -26,6 +26,7 @@ from peddy.peddy import Ped
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import output_path
 
 from reanalysis.moi_tests import MOIRunner, PEDDY_AFFECTED
 from reanalysis.utils import (
@@ -494,7 +495,7 @@ def main(
     }
 
     # store results using the custom-encoder to transform sets & DataClasses
-    with to_path(out_json).open('w') as fh:
+    with to_path(output_path(out_json, 'analysis')).open('w') as fh:
         json.dump(final_results, fh, cls=CustomEncoder, indent=4)
 
 


### PR DESCRIPTION
# Fixes

  - Report Index page is still rekt - all the latest content is collected accurately, but the output path (exact GCP path to the HTML file) is not suitable for access by analysts
  - Until now the HTML script only received the full GCP path to write results to, so obtaining the proxied path would need to be reverse engineered - avoid this behaviour
  - The Report path (`gs://`) and proxied access path (`https://main-web.BUCKET.FILE`) are not the same - for the index page we need the latter

## Proposed Changes

  - Instead of passing the fully-resolved output paths to the result generation and HTML generation scripts, just pass the file name
  - When the file paths are due to be used for writing data, generate the full paths
  - This means we preserve the ability to join the `web_url` prefix, the `output_prefix`, and the file name to create both the web-proxied access URL, and the real absolute file path, both of which are needed in the HTML generation script.
  - When writing the MetaMist analysis entry for the HTML files, use the `web_url` prefix from the config file to generate the analyst accessible path, and store this in the meta as `display_url`
  - In the report_hunter script, pull out the analysis entries, and create a hyperlink to the `display_url`, not the exact file location
 
```
absolute filepath: 
gs://cpg-acute-care-main-web/reanalysis/2023-03-13/summary_output.html

proxied access URL: 
https://main-web.populationgenomics.org.au/acute-care/reanalysis/2023-03-13/summary_output.html

components to keep separate until used:

file name: 
summary_output.html

output_prefix: 
reanalysis/2023-03-13

main-web bucket:
gs://cpg-acute-care-main-web

web_url:
https://main-web.populationgenomics.org.au/acute-care
```

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
