### PR TITLE
Link CSQ contents to the config file

### DIFF
--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -23,7 +23,7 @@ gnomad_max_hemi = 1
 
 [csq]
 # variables affecting how the VCF variants are parsed, and AnalysisVariant objects are populated
-csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'variant_class', 'ensp', 'lof']
+csq_string = ['allele', 'consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'amino_acids', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen']
 
 [filter]
 # variables for the hail operations, including CSQ sets and filter thresholds


### PR DESCRIPTION
# Fixes

  - Closes #273
  - This issue was identified by CSIRO collaborators digesting VCFs

## Proposed Changes

  - Originally we used a fixed CSQ string in the header, and stored all those components in the VCF
  - The retained fields can be edited in config, but this has not been reflected in the header (i.e. the CSQ header description will contain all fields, even if they're not written into the variant line)
  - This change means that the VCF header line will be composed explicitly based on the contents of the config file at runtime

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass

## For Posterity

The full CSQ header prior to this change:

```toml
[csq]
csq_string = [
 'allele',
 'consequence',
 'symbol',
 'gene',
 'feature',
 'mane_select',
 'biotype',
 'exon',
 'hgvsc',
 'hgvsp',
 'cdna_position',
 'cds_position',
 'protein_position',
 'amino_acids',
 'codons',
 'allele_num',
 'variant_class',
 'tsl',
 'appris',
 'ccds',
 'ensp',
 'swissprot',
 'trembl',
 'uniparc',
 'gene_pheno',
 'sift',
 'polyphen',
 'lof',
 'lof_filter',
 'lof_flags'
]
```
