### PR TITLE
Update data_model.py

### DIFF
--- a/reanalysis/data_model.py
+++ b/reanalysis/data_model.py
@@ -31,6 +31,7 @@ from os.path import join
 from dataclasses import dataclass, field
 
 import hail as hl
+from cloudpathlib import AnyPath
 
 from reanalysis.utils import CustomEncoder
 
@@ -330,7 +331,7 @@ class SneakyTable:
 
         # write all variants in this object
         json_temp = join(self.tmp_path, 'vep.json')
-        with open(json_temp, 'w', encoding='utf-8') as f:
+        with AnyPath(json_temp).open('w') as f:
             for variant in self.variants:
                 f.write(variant.to_string())
         return json_temp


### PR DESCRIPTION
# Fixes

  - Closes #283  (hopefully)

## Proposed Changes

  - The path a JSON file is written to is derived from the ultimate output path
  - To support use in cloud and local versions, this open/write needs to be able to adapt to both situations
  - This JSON file doesn't need to be persisted at all, but removing the possibility of write clashes is required to parallelise this behaviour in unit test fixtures