### PR TITLE
include genomic-autopsy in report runner

### DIFF
--- a/.github/workflows/clinvar_runner.yaml
+++ b/.github/workflows/clinvar_runner.yaml
@@ -32,5 +32,5 @@ jobs:
           curl --fail --silent --show-error -X POST \
               -H "Authorization: Bearer $TOKEN" \
               -H "Content-Type:application/json" \
-              -d '{"output": "generate_clinvar_${{ steps.date.outputs.date }}", "dataset": "talos", "accessLevel": "full", "repo": "automated-interpretation-pipeline", "commit": "${{ github.sha }}", "cwd": "reanalysis", "script": ["./clinvar_runner.py"], "description": "Generate Latest Clinvar Summaries", "image": "australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.1", "config": {"workflow": {"sequencing_type": "genome"}}, "wait": false}' \
+              -d '{"output": "generate_clinvar_${{ steps.date.outputs.date }}", "dataset": "talos", "accessLevel": "full", "repo": "automated-interpretation-pipeline", "commit": "${{ github.sha }}", "cwd": "reanalysis", "script": ["./clinvar_runner.py"], "description": "Generate Latest Clinvar Summaries", "image": "australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.1", "config": {"workflow": {"sequencing_type": "genome"}, "cohorts": {}}, "wait": false}' \
               https://server-a2pko7ameq-ts.a.run.app

--- a/helpers/clinvar_conf.toml
+++ b/helpers/clinvar_conf.toml
@@ -1,6 +1,6 @@
 [workflow]
 name = 'Annotate_Clinvar'
-scatter_count = 5
+scatter_count = 50
 vcf_size_in_gb = 30
 sequencing_type = 'genome'
 
@@ -11,7 +11,10 @@ default_memory = 'highmem'
 
 [images]
 vep = 'australia-southeast1-docker.pkg.dev/cpg-common/images/vep:105.0'
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:test'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.1'
 
 [clinvar]
 filter_benign = ['illumina laboratory services; illumina']
+
+[cohorts]
+placeholder = "placeholder"

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -113,6 +113,9 @@ clinvar_filter = ['victorian clinical genetics services,murdoch childrens resear
 gene_prior = 'gs://cpg-epileptic-enceph-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [202]
 
+[cohorts.genomic-autopsy]
+cohort_panels = [3763]
+
 [cohorts.heartkids]
 gene_prior = 'gs://cpg-heartkids-test/reanalysis/pre_panelapp_mendeliome.json'
 


### PR DESCRIPTION
# Fixes

  - makes sure that genomic-autopsy will be caught by the report hunter script

## Proposed Changes

  - adds GA with the fetal abnormalities panel
  - amends the clinvar POST config so that the `get_cohort_config()` method won't fail
  - updates the scatter count for ClinVar (splitting the genome into 5 resulted in ~4 hour VEP runtimes, 50 is pretty reasonable)

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
