### PR TITLE
various followup metamist changes

### DIFF
--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -66,7 +66,7 @@ def get_project_analyses(project: str) -> list[dict]:
         """
     query MyQuery($project: String!) {
         project(name: $project) {
-            analyses(active: true, type: WEB_REPORT) {
+            analyses(active: {eq: true}, type:  {eq: "web"}) {
                 output
                 meta
                 timestampCompleted
@@ -92,7 +92,7 @@ def main():
             continue
 
         for analysis in get_project_analyses(cohort):
-            # only look for reanalysis entries
+            # only look for HTML reanalysis entries
             if 'reanalysis' not in analysis['output']:
                 continue
 

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -496,7 +496,6 @@ def main(
         output=output_dict['web_html'],
         results=output_dict['results'],
     )
-    prior_job.always_run()
     # endregion
 
     # region: output registration job

--- a/reanalysis/metamist_registration.py
+++ b/reanalysis/metamist_registration.py
@@ -36,18 +36,21 @@ def register_html(file_path: str, samples: list[str]):
 
     # add HTML-specific elements
     if file_path.endswith('html'):
+        analysis_type = 'web'
         web_template = get_config()['storage']['default']['web_url']
         file_name = Path(file_path).name
         display_url = join(
             web_template, get_config()['workflow']['output_prefix'], file_name
         )
         report_meta['display_url'] = display_url
+    else:
+        analysis_type = 'custom'
 
     AnalysisApi().create_analysis(
         project=get_config()['workflow']['dataset'],
         analysis=Analysis(
             sample_ids=samples,
-            type='web',
+            type=analysis_type,
             status=AnalysisStatus('completed'),
             output=file_path,
             meta=report_meta,

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -5,7 +5,6 @@
 Complete revision
 """
 
-
 import logging
 import sys
 from datetime import datetime
@@ -26,12 +25,12 @@ from reanalysis.utils import (
     ORDERED_MOIS,
 )
 
-
 PanelData = dict[str, dict | list[dict]]
 PANELAPP_HARD_CODED_DEFAULT = 'https://panelapp.agha.umccr.org/api/v1/panels'
 PANELAPP_BASE = get_config()['panels'].get('panelapp', PANELAPP_HARD_CODED_DEFAULT)
 DEFAULT_PANEL = get_config()['panels'].get('default_panel', 137)
 FORBIDDEN_GENES = None
+
 
 # pylint: disable=no-value-for-parameter,unnecessary-lambda
 
@@ -383,7 +382,6 @@ def main(panels: str | None, out_path: str):
 
 
 if __name__ == '__main__':
-
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',

--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -330,6 +330,7 @@ def get_all_decisions(
     try:
         cohort_config = get_cohort_config()
         blacklist = cohort_config.get('clinvar_filter', [])
+        logging.info(f'Blacklisted sites: {blacklist}')
     except (AssertionError, KeyError):
         blacklist = []
 


### PR DESCRIPTION
# Fixes

  - A couple of the graphQL queries are not valid syntax, so the report-hunter script can't complete

## Proposed Changes

  - updates the `active:true` and `type:web` queries to be valid syntax
  - changes the metamist reporter script so that only `.html` files are created as web analyses

## Checklist

- [x] Linting checks pass