### PR TITLE
Updates to ClinVar parsing

### DIFF
--- a/helpers/clinvar_conf.toml
+++ b/helpers/clinvar_conf.toml
@@ -1,6 +1,6 @@
 [workflow]
 name = 'Annotate_Clinvar'
-scatter_count = 50
+scatter_count = 25
 vcf_size_in_gb = 30
 sequencing_type = 'genome'
 
@@ -11,10 +11,10 @@ default_memory = 'highmem'
 
 [images]
 vep = 'australia-southeast1-docker.pkg.dev/cpg-common/images/vep:105.0'
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.1'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:latest'
 
 [clinvar]
 filter_benign = ['illumina laboratory services; illumina']
 
-[cohorts]
-placeholder = "placeholder"
+[cohorts.acute-care]
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -93,7 +93,7 @@ genome_calling_interval_lists = 'gs://cpg-common-main/references/hg38/v0/wgs_cal
 #gene_prior = if a specific gene list is to be used to determine Cat 2 (new gene-disease associations), provide the filepath here
 
 [cohorts.acute-care]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 #cohort_percentage = 80
 gene_prior = 'gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json'
 
@@ -101,12 +101,12 @@ gene_prior = 'gs://cpg-acute-care-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [4059]
 
 [cohorts.ag-hidden]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 gene_prior = 'gs://cpg-ag-hidden-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [275]
 
 [cohorts.brain-malf]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 #cohort_percentage = 80
 gene_prior = 'gs://cpg-brain-malf-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [3136]
@@ -123,7 +123,7 @@ gene_prior = "gs://cpg-broad-rgp-test-analysis/reanalysis/jan_2020_panels.json"
 cohort_panels = [239]
 
 [cohorts.epileptic-enceph]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 #cohort_percentage = 80
 gene_prior = 'gs://cpg-epileptic-enceph-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [202]
@@ -142,18 +142,18 @@ cohort_panels = [3120]
 cohort_panels = [56]
 
 [cohorts.kidgen]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 gene_prior = 'gs://cpg-kidgen-test-analysis/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [275]
 
 [cohorts.leukodystrophies]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 cohort_panels = [298, 299, 3094]
 #cohort_percentage = 80
 gene_prior = 'gs://cpg-leukodystrophies-test/reanalysis/pre_panelapp_mendeliome.json'
 
 [cohorts.mito-disease]
-clinvar_filter = ['victorian clinical genetics services,murdoch childrens research institute']
+clinvar_filter = ['victorian clinical genetics services, murdoch childrens research institute']
 #cohort_percentage = 80
 gene_prior = 'gs://cpg-mito-disease-test/reanalysis/pre_panelapp_mendeliome.json'
 cohort_panels = [203]

--- a/reanalysis/run_reanalysis.sh
+++ b/reanalysis/run_reanalysis.sh
@@ -8,12 +8,12 @@ DATE=${1:-$(date +%F)}
 analysis-runner \
   --config reanalysis/reanalysis_global.toml \
   --config reanalysis/reanalysis_cohort.toml \
-  --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip \
+  --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:latest \
   --dataset acute-care \
   --description "AIP run" \
   -o "reanalysis/${DATE}" \
   --access-level test \
   reanalysis/interpretation_runner.py \
     --i gs://cpg-acute-care-test/reanalysis/2011-11-11/prior_to_annotation.vcf.bgz \
-    --pedigree gs://cpg-acute-care-test/reanalysis/acute-care-plink.fam \
+    --pedigree gs://cpg-acute-care-test/reanalysis/pedigree.ped \
     --skip_annotation


### PR DESCRIPTION
# Fixes

  - See [Slack Discussion here](https://centrepopgen.slack.com/archives/C035QN8C0DN/p1690529235514449?thread_ts=1688629602.505809&cid=C035QN8C0DN)
  - Site filtering included a typo, so we were not correctly filtering out our own ClinVar submissions
  - Report Hunter is still vulnerable to any `web` analysis entries which aren't HTML files
  - Even new ClinVar entries can be un-dated, which will affect all date filtration we do

## Proposed Changes

  - If we run any date filtering, remove all un-dated entries from ClinVar (instead of allowing all undated entries to pass all date thresholds)
  - Correct the site blacklisting, and publish to logs to clarify the exact sites being removed
  - Correct Web Analysis entry parsing, allowing for soft failures