### PR TITLE
Correction to clinvar no date supplied

### DIFF
--- a/.github/workflows/clinvar_runner.yaml
+++ b/.github/workflows/clinvar_runner.yaml
@@ -32,5 +32,5 @@ jobs:
           curl --fail --silent --show-error -X POST \
               -H "Authorization: Bearer $TOKEN" \
               -H "Content-Type:application/json" \
-              -d '{"output": "generate_clinvar_${{ steps.date.outputs.date }}", "dataset": "talos", "accessLevel": "full", "repo": "automated-interpretation-pipeline", "commit": "${{ github.sha }}", "cwd": "reanalysis", "script": ["./clinvar_runner.py"], "description": "Generate Latest Clinvar Summaries", "image": "australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.4", "config": {"workflow": {"sequencing_type": "genome"}, "cohorts": {}}, "wait": false}' \
+              -d '{"output": "generate_clinvar_${{ steps.date.outputs.date }}", "dataset": "talos", "accessLevel": "full", "repo": "automated-interpretation-pipeline", "commit": "${{ github.sha }}", "cwd": "reanalysis", "script": ["./clinvar_runner.py"], "description": "Generate Latest Clinvar Summaries", "image": "australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip:1.1.4", "config": {"workflow": {"sequencing_type": "genome"}, "cohorts": {"talos": {"clinvar_filter": ["victorian clinical genetics services, murdoch childrens research institute"]}}}, "wait": false}' \
               https://server-a2pko7ameq-ts.a.run.app

--- a/helpers/prepare_aip_cohort.py
+++ b/helpers/prepare_aip_cohort.py
@@ -219,7 +219,9 @@ def process_pedigree(
     ped_lines = []
     for entry in ped_with_permutations:
         for sample, mother, father in product(
-            entry['individual_id'], entry['paternal_id'], entry['maternal_id']
+            entry['individual_id'],
+            entry['paternal_id'] or ['0'],
+            entry['maternal_id'] or ['0'],
         ):
             ped_lines.append(
                 '\t'.join(

--- a/reanalysis/clinvar_runner.py
+++ b/reanalysis/clinvar_runner.py
@@ -182,7 +182,7 @@ def main(date: str | None = None, folder: str | None = None):
 
     dependency = None
 
-    # generate a new round of clinva decisions
+    # generate a new round of clinvar decisions
     if not all(output.exists() for output in [clinvar_table_path, snv_vcf]):
         dependency = generate_clinvar_table(clinvar_table_path, folder, snv_vcf, date)
 

--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -548,12 +548,13 @@ def main(
     all_decisions = sort_decisions(all_decisions)
 
     # if there's no defined config, write a local file
+    date_string = (
+        date.strftime('%Y-%m-%d') if date else datetime.now().strftime('%Y-%m-%d')
+    )
     try:
-        temp_output = output_path(
-            f'{date.strftime("%Y-%m-%d")}_clinvar_table.json', category='tmp'
-        )
+        temp_output = output_path(f'{date_string}_clinvar_table.json', category='tmp')
     except (ConfigError, KeyError):
-        temp_output = f'{date.strftime("%Y-%m-%d")}_clinvar_table.json'
+        temp_output = f'{date_string}_clinvar_table.json'
 
     logging.info(f'temp JSON location: {temp_output}')
 


### PR DESCRIPTION
# Fixes

  - Pedigree generation broken by graphQL change: participants dropped off if only one parent was present
  - ClinVar script doesn't handle no date being supplied

## Proposed Changes

  - Fixes the itertools.product() call when generating pedigree rows
  - adds a default date to the clinvar output file
  - when the CI workflow automatically generates ClinVar summary data, it excludes MCRI entries