### PR TITLE
Remove solved cases

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -125,7 +125,13 @@ class HTMLBuilder:
 
         # Process samples and variants
         self.samples = []
+        self.solves = []
         for sample, content in results_dict['results'].items():
+            # remove solved cases
+            if solve_date := content['metadata'].get('solved'):
+                self.solves.append({'sample': sample, 'solve_date': solve_date})
+                continue
+
             self.samples.append(
                 Sample(
                     name=sample,
@@ -264,6 +270,7 @@ class HTMLBuilder:
         template_context = {
             'metadata': self.metadata,
             'samples': self.samples,
+            'solved': self.solves,
             'seqr_url': get_config()['dataset_specific'].get('seqr_instance'),
             'seqr_project': get_config()['dataset_specific'].get('seqr_project'),
             'meta_tables': {},

--- a/reanalysis/templates/index.html.jinja
+++ b/reanalysis/templates/index.html.jinja
@@ -96,6 +96,21 @@
           {% endif %}
         </div>
 
+        <div>
+          <h3>Solved Cases</h3>
+          {% if solved %}
+            <ul>
+              {% for row in solved %}
+                <li>
+                    {{row["sample"}} - {{row["solve_date"]}}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p>No Solved cases removed</p>
+          {% endif %}
+        </div>
+
         {# Run Metadata #}
         <div class="tab-pane fade" id="metadata-tab-pane" role="tabpanel" aria-labelledby="contact-tab" tabindex="0">
           <div>

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -432,8 +432,8 @@ def main(
     panelapp: str,
     pedigree: str,
     input_path: str,
+    solved: list[str],
     panel_file: str | None = None,
-    solved: list[str] = None,
 ):
     """
     VCFs used here should be small
@@ -448,8 +448,8 @@ def main(
         panelapp (str): location of PanelApp data JSON
         pedigree (str): location of PED file
         input_path (str): VCF/MT used as input
-        panel_file (str): json of panels per participant
         solved (list): list of solved case IDs
+        panel_file (str): json of panels per participant
     """
 
     out_json = to_path(out_json)

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -56,11 +56,11 @@ def test_date_annotate_one():
     """
     checks we can add one entry to a None historic
     """
-    results = {'sample': {'variants': [GENERIC_REPORT]}}
+    results = {'sample': {'variants': [GENERIC_REPORT], 'metadata': {}}}
     new_results, cumulative = date_annotate_results(results)
     assert results == new_results
     assert cumulative == {
-        'metadata': {'categories': CATEGORY_META},
+        'metadata': {'categories': CATEGORY_META, 'solved': {}},
         'results': {
             'sample': {
                 COORD_1.string_format: {
@@ -105,7 +105,7 @@ def test_date_annotate_three():
     """
     if there's a new category, don't update dates
     """
-    results = {'sample': {'variants': [deepcopy(GENERIC_REPORT_12)]}}
+    results = {'sample': {'variants': [deepcopy(GENERIC_REPORT_12)], 'metadata': {}}}
     historic = {
         'sample': {
             COORD_1.string_format: {
@@ -118,7 +118,7 @@ def test_date_annotate_three():
     }
     new_results, cumulative = date_annotate_results(results, historic)
     assert cumulative == {
-        'metadata': {'categories': CATEGORY_META},
+        'metadata': {'categories': CATEGORY_META, 'solved': {}},
         'results': {
             'sample': {
                 COORD_1.string_format: {
@@ -137,7 +137,7 @@ def test_date_annotate_four():
     """
     if there's a new category, don't update dates
     """
-    results = {'sample': {'variants': [deepcopy(GENERIC_REPORT)]}}
+    results = {'sample': {'variants': [deepcopy(GENERIC_REPORT)], 'metadata': {}}}
     historic = {
         'sample': {
             COORD_1.string_format: {
@@ -150,7 +150,7 @@ def test_date_annotate_four():
     }
     new_results, historic = date_annotate_results(results, historic)
     assert historic == {
-        'metadata': {'categories': CATEGORY_META},
+        'metadata': {'categories': CATEGORY_META, 'solved': {}},
         'results': {
             'sample': {
                 COORD_1.string_format: {
@@ -174,7 +174,7 @@ def test_date_annotate_five():
         'sample2': {'variants': [deepcopy(GENERIC_REPORT_2)]},
     }
     historic = {
-        'metadata': {'categories': CATEGORY_META},
+        'metadata': {'categories': CATEGORY_META, 'solved': {}},
         'results': {
             'sample': {
                 COORD_1.string_format: {
@@ -188,7 +188,7 @@ def test_date_annotate_five():
     }
     results, historic = date_annotate_results(results, historic)
     assert historic == {
-        'metadata': {'categories': CATEGORY_META},
+        'metadata': {'categories': CATEGORY_META, 'solved': {}},
         'results': {
             'sample': {
                 COORD_1.string_format: {
@@ -223,6 +223,137 @@ def test_date_annotate_five():
                     first_seen=get_granular_date(),
                 )
             ]
+        },
+    }
+
+
+def test_date_annotate_solved():
+    """
+    if there's a new category, don't update dates
+    """
+    results = {
+        'sample': {'variants': [deepcopy(GENERIC_REPORT)], 'metadata': {}},
+        'sample2': {'variants': [deepcopy(GENERIC_REPORT_2)], 'metadata': {}},
+    }
+    historic = {
+        'metadata': {'categories': CATEGORY_META, 'solved': {'sample': '12-34-56'}},
+        'results': {
+            'sample': {
+                COORD_1.string_format: {
+                    'categories': {'2': OLD_DATE},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample3': {},
+        },
+    }
+    results, historic = date_annotate_results(results, historic)
+    assert historic == {
+        'metadata': {'categories': CATEGORY_META, 'solved': {'sample': '12-34-56'}},
+        'results': {
+            'sample': {
+                COORD_1.string_format: {
+                    'categories': {'1': get_granular_date(), '2': OLD_DATE},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample2': {
+                COORD_2.string_format: {
+                    'categories': {'2': get_granular_date()},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample3': {},
+        },
+    }
+    assert results == {
+        'sample': {
+            'variants': [
+                MiniReport(
+                    MiniVariant(categories=['1'], coords=COORD_1),
+                    first_seen=get_granular_date(),
+                )
+            ],
+            'metadata': {'solved': '12-34-56'},
+        },
+        'sample2': {
+            'variants': [
+                MiniReport(
+                    MiniVariant(categories=['2'], coords=COORD_2),
+                    first_seen=get_granular_date(),
+                )
+            ],
+            'metadata': {},
+        },
+    }
+
+
+def test_date_annotate_solved_2():
+    """
+    if there's a new category, don't update dates
+    """
+    results = {
+        'sample': {'variants': [deepcopy(GENERIC_REPORT)], 'metadata': {}},
+        'sample2': {'variants': [deepcopy(GENERIC_REPORT_2)], 'metadata': {}},
+    }
+    historic = {
+        'metadata': {'categories': CATEGORY_META, 'solved': {'sample': '12-34-56'}},
+        'results': {
+            'sample': {
+                COORD_1.string_format: {
+                    'categories': {'2': OLD_DATE},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample3': {},
+        },
+    }
+    results, historic = date_annotate_results(results, historic, solved=['sample2'])
+    assert historic == {
+        'metadata': {
+            'categories': CATEGORY_META,
+            'solved': {'sample': '12-34-56', 'sample2': get_granular_date()},
+        },
+        'results': {
+            'sample': {
+                COORD_1.string_format: {
+                    'categories': {'1': get_granular_date(), '2': OLD_DATE},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample2': {
+                COORD_2.string_format: {
+                    'categories': {'2': get_granular_date()},
+                    'support_vars': [],
+                    'independent': False,
+                }
+            },
+            'sample3': {},
+        },
+    }
+    assert results == {
+        'sample': {
+            'variants': [
+                MiniReport(
+                    MiniVariant(categories=['1'], coords=COORD_1),
+                    first_seen=get_granular_date(),
+                )
+            ],
+            'metadata': {'solved': '12-34-56'},
+        },
+        'sample2': {
+            'variants': [
+                MiniReport(
+                    MiniVariant(categories=['2'], coords=COORD_2),
+                    first_seen=get_granular_date(),
+                )
+            ],
+            'metadata': {'solved': get_granular_date()},
         },
     }
 


### PR DESCRIPTION
# Fixes

  - Closes #316 

## Proposed Changes

  - Adds an optional argument `--solved` to pass through a list of participant IDs
  - These IDs are passed through to the MOI testing process, where they are marked `solved: DATE` in the results JSON (results are processed and retained throughout)
  - In the HTML generation step, these solved cases are removed from the presentation table, and added to the Statistics tab with `ID: DATE`
  - The solved cases are recorded in the history/state file for the project, so that adding a participant as `solved` will result in them being hidden in all future analyses

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
