### PR TITLE
Solved case source of truth from config

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -125,7 +125,11 @@ class HTMLBuilder:
 
         # Process samples and variants
         self.samples = []
+        self.solved = []
         for sample, content in results_dict['results'].items():
+            if content['metadata'].get('solved', False):
+                self.solved.append(sample)
+                continue
             self.samples.append(
                 Sample(
                     name=sample,
@@ -272,6 +276,7 @@ class HTMLBuilder:
             'unused_ext_labels': unused_ext_labels,
             'summary_table': None,
             'report_title': report_title,
+            'solved': self.solved,
         }
 
         for title, meta_table in self.read_metadata().items():

--- a/reanalysis/templates/index.html.jinja
+++ b/reanalysis/templates/index.html.jinja
@@ -95,6 +95,20 @@
             <p>All external labels displayed in variants table.</p>
           {% endif %}
         </div>
+        <div>
+          <h3>Solved Cases</h3>
+          {% if solved %}
+            <ul>
+              {% for sample in solved %}
+                <li>
+                    {{sample}}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p>No Solved cases removed</p>
+          {% endif %}
+        </div>
 
         {# Run Metadata #}
         <div class="tab-pane fade" id="metadata-tab-pane" role="tabpanel" aria-labelledby="contact-tab" tabindex="0">

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -390,6 +390,9 @@ def prepare_results_shell(
     # create an empty dict for all the samples
     sample_dict = {}
 
+    # find the solved cases in this project
+    solved_cases = get_config().get('dataset_specific', {}).get('solved_cases', [])
+
     ext_conf_path = get_config().get('dataset_specific', {}).get('external_lookup')
     external_map = read_json_from_path(ext_conf_path, default={})
     panel_meta = {content['id']: content['name'] for content in panelapp['metadata']}
@@ -423,6 +426,7 @@ def prepare_results_shell(
                     panel_meta[panel_id]
                     for panel_id in panel_data.get(sample, {}).get('panels', [])
                 ],
+                'solved': bool(sample in solved_cases or family in solved_cases),
             },
         }
 

--- a/test/input/reanalysis_cohort.toml
+++ b/test/input/reanalysis_cohort.toml
@@ -4,6 +4,7 @@ seqr_lookup = "e.g. gs://cpg-acute-care-test/reanalysis/parsed_seqr.json"
 external_lookup = "e.g. gs://cpg-acute-care-test/reanalysis/cpg_to_external_id.json"
 seqr_instance = "e.g. https://seqr.populationgenomics.org.au"
 seqr_project = "R0011_acute_care"
+solved_cases = ['female']
 
 [workflow]
 dataset = "cohort"

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -121,6 +121,7 @@ def test_results_shell(peddy_ped):
                 'phenotypes': ['Boneitis'],
                 'panel_ids': [1, 3],
                 'panel_names': ['lorem', 'etc'],
+                'solved': False,
             },
         },
         'female': {
@@ -144,6 +145,7 @@ def test_results_shell(peddy_ped):
                 'phenotypes': ['HPfemale'],
                 'panel_ids': [1, 2],
                 'panel_names': ['lorem', 'ipsum'],
+                'solved': True,
             },
         },
     }


### PR DESCRIPTION
# Fixes

  - Closes #316 

## Proposed Changes

  - Adds a `solved` param in config, specific to the dataset/project. This can be family IDs (any format) or individual IDs (CPGAAAA)
  - Cases marked as solved are flagged as `solved: True` in the output JSON
  - In the HTML generation step, these solved cases are removed from the presentation table, and added to the Statistics tab
  - Solved cases are not recorded in the history file, so this can be easily reversed

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
