### PR TITLE
Avoid broken hail version during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
+FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:a15ed15c0ca0b7304e0ceca1b873d734720c5d7a-hail-abaf45c99b32250dfc55a1b26a6a0635760e0a99
+# this pinned image is a temporary workaround for production-pipelines/issues/477
 
 COPY requirements.txt .
 COPY requirements-dev.txt .

--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -112,17 +112,18 @@ def main(latest: bool = False):
                 if 'latest' not in analysis['output']:
                     continue
                 date = analysis['output'].rstrip('.html').split('_')[-1]
-                cohort = f'{cohort}_{date}'
+                cohort_key = f'{cohort}_{date}'
             else:
                 if 'latest' in analysis['output']:
                     continue
+                cohort_key = cohort
 
             # pull the exome/singleton flags
             exome_output = analysis['meta'].get('is_exome', False)
             singleton_output = analysis['meta'].get('is_singleton', False)
             try:
                 # incorporate that into a key when gathering
-                all_cohorts[f'{cohort}_{exome_output}_{singleton_output}'] = Report(
+                all_cohorts[f'{cohort_key}_{exome_output}_{singleton_output}'] = Report(
                     dataset=cohort,
                     address=analysis['meta']['display_url'],
                     genome_or_exome='Exome' if exome_output else 'Genome',

--- a/reanalysis/templates/index.html.jinja
+++ b/reanalysis/templates/index.html.jinja
@@ -77,37 +77,37 @@
               <p>All samples have reportable variants.</p>
             {% endif %}
           </div>
-        </div>
+          <div>
+              <h3>Unused external labels</h3>
+              {% if unused_ext_labels %}
+                <ul>
+                  {% for label in unused_ext_labels %}
+                    <li>
+                      <a href="{{seqr_url}}/variant_search/variant/{{label['variant']}}/family/{{label['sample_ext']}}" target="_blank">
+                          {{ label ['sample'] }} ({{ label['sample_ext'] }}) -- {{ label['variant'] }} {{ label['labels'] }}
+                      </a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p>All external labels displayed in variants table.</p>
+              {% endif %}
+          </div>
 
-        <div>
-          <h3>Unused external labels</h3>
-          {% if unused_ext_labels %}
-            <ul>
-              {% for label in unused_ext_labels %}
-                <li>
-                  <a href="{{seqr_url}}/variant_search/variant/{{label['variant']}}/family/{{label['sample_ext']}}" target="_blank">
-                      {{ label ['sample'] }} ({{ label['sample_ext'] }}) -- {{ label['variant'] }} {{ label['labels'] }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p>All external labels displayed in variants table.</p>
-          {% endif %}
-        </div>
-        <div>
-          <h3>Solved Cases</h3>
-          {% if solved %}
-            <ul>
-              {% for sample in solved %}
-                <li>
-                    {{sample}}
-                </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p>No Solved cases removed</p>
-          {% endif %}
+          <div>
+              <h3>Solved Cases</h3>
+              {% if solved %}
+                <ul>
+                  {% for sample in solved %}
+                    <li>
+                        {{sample}}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p>No Solved cases removed</p>
+              {% endif %}
+          </div>
         </div>
 
         {# Run Metadata #}

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -398,11 +398,13 @@ def prepare_results_shell(
     panel_meta = {content['id']: content['name'] for content in panelapp['metadata']}
 
     for sample in [
-        sam.sample_id
+        sam
         for sam in pedigree.samples()
         if sam.affected == PEDDY_AFFECTED and sam.sample_id in vcf_samples
     ]:
-        family = pedigree.families[pedigree[sample].family_id]
+        sample_id = sample.sample_id
+        family_id = sample.family_id
+        family = pedigree.families[family_id]
 
         family_members = {
             member.sample_id: {
@@ -414,19 +416,19 @@ def prepare_results_shell(
             }
             for member in family
         }
-        sample_dict[sample] = {
+        sample_dict[sample_id] = {
             'variants': [],
             'metadata': {
-                'ext_id': external_map.get(sample, sample),
-                'family_id': pedigree[sample].family_id,
+                'ext_id': external_map.get(sample_id, sample_id),
+                'family_id': pedigree[sample_id].family_id,
                 'members': family_members,
-                'phenotypes': panel_data.get(sample, {}).get('hpo_terms', []),
-                'panel_ids': panel_data.get(sample, {}).get('panels', []),
+                'phenotypes': panel_data.get(sample_id, {}).get('hpo_terms', []),
+                'panel_ids': panel_data.get(sample_id, {}).get('panels', []),
                 'panel_names': [
                     panel_meta[panel_id]
-                    for panel_id in panel_data.get(sample, {}).get('panels', [])
+                    for panel_id in panel_data.get(sample_id, {}).get('panels', [])
                 ],
-                'solved': bool(sample in solved_cases or family in solved_cases),
+                'solved': bool(sample_id in solved_cases or family_id in solved_cases),
             },
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cpg-utils>=4.15.0
 cpg_workflows>=1.12.6
 cyvcf2==0.30.18
 dill>=0.3.5.1
-hail==0.2.118
+hail!=0.2.120
 Jinja2==3.0.3
 metamist>=6.0.2
 networkx>=2.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cpg-utils>=4.15.0
 cpg_workflows>=1.12.6
 cyvcf2==0.30.18
 dill>=0.3.5.1
-hail>=0.2.105
+hail==0.2.118
 Jinja2==3.0.3
 metamist>=6.0.2
 networkx>=2.8.3


### PR DESCRIPTION
# Fixes

  - Builds on a driver image containing a version of hail without workflow generation issues
  - Tweaks how samples/IDs are handled, so that we can correctly mark cases as solved on the basis of family ID or individual 
  - Report fix (IDs in wrong div) 
  - Report Hunter script (was appending date with each analysis entry, instead of finding only the latest for each time point)

