### PR TITLE
update to use new analysis types

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -85,7 +85,7 @@ class HTMLBuilder:
         self.seqr = {}
 
         if seqr_path:
-            self.seqr = read_json_from_path(seqr_path)
+            self.seqr = read_json_from_path(seqr_path, default=self.seqr)
 
             # Force user to correct config file if seqr URL/project are missing
             for seqr_key in ['seqr_instance', 'seqr_project']:

--- a/reanalysis/metamist_registration.py
+++ b/reanalysis/metamist_registration.py
@@ -36,14 +36,14 @@ def register_html(file_path: str, samples: list[str]):
 
     # add HTML-specific elements
     if file_path.endswith('html'):
-        analysis_type = 'web'
+        analysis_type = 'aip-report'
         report_meta['display_url'] = join(
             get_config()['storage']['default']['web_url'],
             get_config()['workflow']['output_prefix'],
             Path(file_path).name,
         )
     else:
-        analysis_type = 'custom'
+        analysis_type = 'aip-results'
 
     AnalysisApi().create_analysis(
         project=get_config()['workflow']['dataset'],


### PR DESCRIPTION
# Fixes

- Production-pipelines now writes report/result entries as metamist analysis type 'aip-report' and 'aip-results'
- This change is not compatible withe current index builder script

## Proposed Changes

  - metamist analysis reporter now writes new entries using those analysis types
  - report finder now detects those analysis types
  - unrelated - seqr lookup dict can be empty/absent without causing failures