### PR TITLE
Fix report hunter

### DIFF
--- a/.github/workflows/clinvar_runner.yaml
+++ b/.github/workflows/clinvar_runner.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/847315747340/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github@cpg-talos.iam.gserviceaccount.com"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@main
 
     - name: gcloud auth
-      uses: 'google-github-actions/auth@v0'
+      uses: 'google-github-actions/auth@v1'
       with:
         credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,5 @@
 name: Docker
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -20,15 +19,15 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
       BASE_IMAGE: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
 
     - name: gcloud auth
-      uses: 'google-github-actions/auth@v1'
+      uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
 
     - name: set up gcloud sdk
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v1
       with:
         project_id: cpg-common
 
@@ -40,7 +39,6 @@ jobs:
         docker build . -f Dockerfile --tag $BASE_IMAGE:$VERSION
 
     - name: push latest
-      if: ${{ github.event_name != 'pull_request' }}
       run: |
         docker tag $BASE_IMAGE:$VERSION $BASE_IMAGE:latest
         docker push $BASE_IMAGE:$VERSION

--- a/.github/workflows/index_page_builder.yaml
+++ b/.github/workflows/index_page_builder.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/847315747340/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github@cpg-talos.iam.gserviceaccount.com"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -16,17 +16,17 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      BASE_IMAGE: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_aip
+      BASE_IMAGE: australia-southeast1-docker.pkg.dev/cpg-common/image-dev/cpg_aip
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
 
     - name: gcloud auth
-      uses: 'google-github-actions/auth@v1'
+      uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
 
     - name: set up gcloud sdk
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v1
       with:
         project_id: cpg-common
     - name: gcloud docker auth

--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@main
 
     - name: gcloud auth
-      uses: 'google-github-actions/auth@v0'
+      uses: 'google-github-actions/auth@v1'
       with:
         credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
 

--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -115,10 +115,9 @@ def main(latest: bool = False):
             exome_output = 'Exome' if 'exome' in output_path else 'Familial'
             singleton_output = 'Singleton' if 'singleton' in output_path else 'Familial'
             try:
-                # pipeline runs don't have display_url
                 report_address = analysis['output'].replace(
-                    get_config()['storage']['default']['web'],
-                    get_config()['storage']['default']['web_url'],
+                    get_config()['storage'][cohort]['web'],
+                    get_config()['storage'][cohort]['web_url'],
                 )
                 all_cohorts[f'{cohort_key}_{exome_output}_{singleton_output}'] = Report(
                     dataset=cohort,


### PR DESCRIPTION
# Fixes

  - The index page (http://popgen.rocks/aip_index) was being published with invalid hyperlinks
  - Reason - the string replacement of `gs://cpg-PROJECT-main-web` with `https://main-web.populationgenomics.org.au/PROJECT` was being done using the `default` project
  - This script runs under the automated account ID `talos`, so the replacement was trying to string replace `gs://cpg-talos-main-web` each time, which was not present in any of the output strings
  - Also tidies up the use of `logging`, so we're not barfing all the metamist results into the hail log every time

## Proposed Changes

  - corrects this so that each analysis object runs a string replacement based on the correct project
  - updates all the CI action versions

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
- [x]  I've gotten really lazy with these checklist actions
