### PR TITLE
Clarify dataset in in-module use of output_path

### DIFF
--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -153,7 +153,7 @@ def handle_hail_filtering(pedigree: str, prior_job: Job | None = None) -> BashJo
     """
 
     labelling_job = get_batch().new_job(name='hail filtering')
-    set_job_resources(labelling_job, prior_job=prior_job, memory='32Gi')
+    set_job_resources(labelling_job, prior_job=prior_job, memory='6Gi')
     out_vcf = output_path('hail_categorised.vcf.bgz', 'analysis')
     labelling_command = (
         f'python3 {hail_filter_and_label.__file__} '


### PR DESCRIPTION
# Fixes

  - When multiple datasets are run concurrently in the pipeline, they are all checkpointing to the same tmp location in `cpg-seqr-main-tmp` due to this use of `output_path`
  - This is the only use of output_path I can find (other than in `interpretation_runner.py`, which is a completely different entrypoint, unused by prod-pipes

## Proposed Changes

  - pass this specific dataset name into the hail labelling stage (optional, defaults to workflow.dataset)
  - writes temp files and checkpoints to a dataset-specific path