### PR TITLE
Added AlphaMissense Cat6 class

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -638,7 +638,7 @@ def annotate_category_6(mt: hl.MatrixTable) -> hl.MatrixTable:
 
     # focus on the auto-annotated AlphaMissense class
     # allow for the field to be missing
-    if 'am_class' in list(mt.vep.transcript_consequences[0].keys()):
+    if 'am_class' not in list(mt.vep.transcript_consequences[0].keys()):
         logging.warning('AlphaMissense class not found, skipping annotation')
         return mt.annotate_rows(info=mt.info.annotate(categoryboolean6=MISSING_INT))
 

--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -114,9 +114,14 @@ def get_participant_hpos(dataset: str) -> tuple[dict, set[str]]:
             HPO_RE.findall(sg['sample']['participant']['phenotypes'].get(HPO_KEY, ''))
         )
         all_hpo.update(hpos)
+        fam_id = (
+            sg['sample']['participant']['families'][0]['externalId']
+            if sg['sample']['participant']['families']
+            else 'MISSING'
+        )
         hpo_dict[sg['id']] = {
             'external_id': sg['sample']['participant']['externalId'],
-            'family_id': sg['sample']['participant']['families'][0]['externalId'],
+            'family_id': fam_id,
             'hpo_terms': hpos,
             'panels': {137},
         }

--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -77,7 +77,7 @@ class HTMLBuilder:
             pedigree (str): path to the PED file
             dataset (str): dataset to run for
         """
-        self.panelapp: dict = read_json_from_path(panelapp_path)  # type: ignore
+        self.panelapp: dict = read_json_from_path(panelapp_path, {})  # type: ignore
         assert isinstance(self.panelapp, dict)
 
         self.pedigree = Ped(pedigree)

--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -57,6 +57,7 @@ spliceai = 0.5
 3 = 'High Impact Variant'
 4 = 'de Novo'
 5 = 'High SpliceAI Score'
+6 = 'AlphaMissense P/LP'
 pm5 = 'ACMG PM5 - missense in same residue as known pathogenic'
 support = 'High in Silico Scores'
 

--- a/reanalysis/templates/variant_table_child_row.html.jinja
+++ b/reanalysis/templates/variant_table_child_row.html.jinja
@@ -42,6 +42,9 @@
                                 {% if variant.var_data.info.mutationtaster != 'missing' %}
                                 MutationTaster: {{variant.var_data.info.mutationtaster}}
                                 {% endif %}
+                                {% if variant.var_data.info.am_class != 'missing' %}
+                                AlphaMissense: {{variant.var_data.info.am_class}} ({{variant.var_data.info.am_pathogenicity}})
+                                {% endif %}
                             </dd>
 
                             <dt class="col-sm-3">Links</dt>

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -393,6 +393,9 @@ class AbstractVariant:
         # overwrite the non-standard cyvcf2 representation
         self.info: dict[str, Any] = {x.lower(): y for x, y in var.INFO}
 
+        # temp so we permit alphamissense missing
+        self.info['am_class'] = self.info.get('am_class', 'missing')
+
         # hot-swap cat 2 from a boolean to a sample list - if appropriate
         if self.info.get('categoryboolean2', 0):
             new_gene_samples = new_genes.get(self.info.get('gene_id'), '')

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -550,7 +550,7 @@ def main(
         'results': analysis_results,
         'metadata': {
             'input_file': input_path,
-            'cohort': get_config()['workflow']['dataset'],
+            'cohort': dataset,
             'run_datetime': get_granular_date(),
             'family_breakdown': count_families(
                 pedigree_digest, samples=vcf_opened.samples

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -16,6 +16,7 @@ from reanalysis.hail_filter_and_label import (
     annotate_category_2,
     annotate_category_3,
     annotate_category_5,
+    annotate_category_6,
     annotate_category_support,
     green_and_new_from_panelapp,
     filter_to_population_rare,
@@ -173,6 +174,53 @@ def test_category_5_assignment(spliceai_score: float, flag: int, make_a_mt):
     )
     matrix = annotate_category_5(matrix)
     assert matrix.info.categoryboolean5.collect() == [flag]
+
+
+@pytest.mark.parametrize(
+    'am_class,classified',
+    [
+        ('likely_pathogenic', 1),
+        ('not_pathogenic', 0),
+        ('', 0),
+        (hl.missing('tstr'), 0),
+    ],
+)
+def test_class_6_assignment(am_class, classified, make_a_mt):
+    """
+
+    Args:
+        am_class ():
+        classified ():
+        make_a_mt ():
+    """
+
+    anno_matrix = make_a_mt.annotate_rows(
+        vep=hl.Struct(
+            transcript_consequences=hl.array([hl.Struct(am_class=am_class)]),
+        ),
+    )
+
+    anno_matrix = annotate_category_6(anno_matrix)
+    anno_matrix.rows().show()
+    assert anno_matrix.info.categoryboolean6.collect() == [classified]
+
+
+def annotate_c6_missing(make_a_mt, caplog):
+    """
+    test what happens if the am_class attribute is missing
+
+    Args:
+        make_a_mt ():
+    """
+    anno_matrix = make_a_mt.annotate_rows(
+        vep=hl.Struct(
+            transcript_consequences=hl.array([hl.Struct(not_am='a value')]),
+        ),
+    )
+
+    anno_matrix = annotate_category_6(anno_matrix)
+    assert anno_matrix.info.categoryboolean6.collect() == [0]
+    assert 'AlphaMissense class not found, skipping annotation' in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Fixes

  - AlphaMissense scores aren't recognised as a category

## Proposed Changes

  - Adds categoryboolean6 - binary classification based on AM's default thresholds
  - Should be compatible with MTs where `vep.transcript_consequences.am_class` is absent
  - Test added for am_class classification & missing AM scores
  - Correction to Project label in metadata
  - AM scores added to drop-down drawer (unless it's missing)

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
