### PR TITLE
Dependabot instigated req. bump, timeout increase

### DIFF
--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -63,7 +63,7 @@ support = 'High in Silico Scores'
 
 [hail]
 cancel_after_n_failures = 1
-default_timeout = 6000
+default_timeout = 12000
 default_memory = 'highmem'
 
 [images]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 bump2version>=1.0.1
-pytest>=7.2.1
+pytest>=7.4.3
 pytest-cov>=3.0.0
 pytest-xdist>=2.5.0
 requests_mock>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click>=8.1.3
+click>=8.1.7
 cloudpathlib[all]>=0.16.0
 cpg-utils>=4.17.0
 cpg_workflows>=1.17.1
@@ -6,11 +6,11 @@ cyvcf2==0.30.18
 dill>=0.3.7
 hail>=0.2.120
 Jinja2==3.0.3
-metamist>=6.4.0
+metamist>=6.5.0
 networkx>=3
 obonet>=1
 pandas>=2
 peddy>=0.4.8
-requests>=2.25.1,<2.30.0 # vulnerability in 2.30.0
+requests>=2.31.0
 seqr-loader>=1.2.5
 tabulate>=0.8.9


### PR DESCRIPTION
# Fixes

  - Requests vulnerability was identified, patched version available

## Proposed Changes

  - updates a couple of package requirements
  - bumps the standard job timeout (VEP was failing for some large fragments)

## Checklist

- [x] Linting checks pass