### PR TITLE
"jvm jobs cannot be on lowmem machines"

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -1092,7 +1092,7 @@ def main(
     dataset = dataset or get_config()['workflow']['dataset']
 
     # initiate Hail with defined driver spec.
-    init_batch(driver_cores=8, driver_memory='highmem')
+    init_batch(driver_cores=2, driver_memory='standard')
 
     # checkpoints should be kept independent
     checkpoint_number = 0

--- a/reanalysis/hail_filter_sv.py
+++ b/reanalysis/hail_filter_sv.py
@@ -153,7 +153,7 @@ def main(
     get_logger().info(f'Starting Hail with reference genome {genome_build()}')
     # un-comment this to play locally
     # hl.init(default_reference=genome_build())
-    init_batch(driver_cores=1, driver_memory='lowmem')
+    init_batch(driver_cores=2, driver_memory='standard')
 
     # if we already generated the annotated output, load instead
     if not to_path(mt_path.rstrip('/') + '/').exists():

--- a/reanalysis/interpretation_runner.py
+++ b/reanalysis/interpretation_runner.py
@@ -164,7 +164,7 @@ def handle_hail_sv_filtering(
     """
 
     labelling_job = get_batch().new_job(name='Hail SV labelling')
-    set_job_resources(labelling_job, prior_job=prior_job, memory='lowmem')
+    set_job_resources(labelling_job, prior_job=prior_job)
     labelling_command = (
         f'python3 {hail_filter_sv.__file__} '
         f'--mt {ANNOTATED_MT} '
@@ -192,7 +192,7 @@ def handle_hail_filtering(pedigree: str, prior_job: Job | None = None) -> BashJo
     """
 
     labelling_job = get_batch().new_job(name='Hail small-variant labelling')
-    set_job_resources(labelling_job, prior_job=prior_job, memory='lowemem')
+    set_job_resources(labelling_job, prior_job=prior_job)
     labelling_command = (
         f'python3 {hail_filter_and_label.__file__} '
         f'--mt {ANNOTATED_MT} '


### PR DESCRIPTION
# Fixes

  - "jvm jobs cannot be on lowmem machines" - this Hail filtering process is very lightweight, and can be run from a laptop, but there appears to be a hard restriction on machine type when running a Hail Query batch
  - https://batch.hail.populationgenomics.org.au/batches/430115/jobs/3

## Proposed Changes

  - updates the `init_batch` call to use standard instead of lowmem machines