### PR TITLE
Fix Comp-Het test

### DIFF
--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -498,6 +498,7 @@ class RecessiveAutosomalCH(BaseMoi):
                     sample_id=sample_id, variant_1=principal, variant_2=partner_variant
                 ):
                     continue
+
                 classifications.append(
                     ReportedVariant(
                         sample=sample_id,


### PR DESCRIPTION
# Fixes

  - Failed to call an expected Comp-Het in a production run
  - Both variants in the comp-het were assigned Support and Cat6 (and maybe a couple of other categories)

## Proposed Changes

  - I'm confused - this seems like quite a core bug that should have cropped up before, but the code here hasn't been touched in a year. It definitely appears to be a bug, and suggests we've been under-reporting Comp-Hets in various cohorts


In AIP variant representation there are 3 types of category which can be assigned to a variant:
- support
- boolean (applies to all samples)
- sample (applies to subset of samples, e.g. de novo)

When testing that 2 variants can form a Comp-Het, we screen out cases where both variants are only supporting. The logic in this test was:

```
if var1 is support ONLY and var2 is support ONLY: fail
```

The method testing whether a variant is Support ONLY checked:

```
if variant.has_support and not variant.has_sample_category
```

missing out the boolean category case. The behaviour this has lead to is unintentional:

``` 
The only way to form a Comp-Het in AIP is when a variant with the Support category combines with a variant without the Support category, or where neither variant has the support category assigned.
```

This is an unintended consequence of the logic being too convoluted. This is a patch for the comp-het test, and I'll schedule a more detailed look into this.

## Checklist

- [x] Linting checks pass
