### PR TITLE
Allow ignoring of specific categories via config

### DIFF
--- a/reanalysis/reanalysis_global.toml
+++ b/reanalysis/reanalysis_global.toml
@@ -14,6 +14,11 @@ status_reporter = 'metamist'
 #clinvar_decisions = "HailTable path to private ClinVar"
 #clinvar_pm5 = "HailTable path to ClinVar PM5"
 
+## optionally, ignore some categories
+#ignore_categories = [
+#    'categoryboolean6'
+#]
+
 [panels]
 default_panel = 137
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -396,7 +396,7 @@ def create_small_variant(
     }
 
     # optionally - ignore some categories from this analysis
-    if ignore_cats := get_config()['workflow']['ignore_categories']:
+    if ignore_cats := get_config()['workflow'].get('ignore_categories'):
         info = {key: val for key, val in info.items() if key not in ignore_cats}
 
     het_samples, hom_samples = get_non_ref_samples(variant=var, samples=samples)

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -133,58 +133,6 @@ def identify_file_type(file_path: str) -> FileTypes | Exception:
     raise TypeError(f'File cannot be definitively typed: {str(extensions)}')
 
 
-#
-# @dataclass
-# class Coordinates:
-#     """
-#     a home for the positional variant attributes
-#     """
-#
-#     chrom: str
-#     pos: int
-#     ref: str
-#     alt: str
-#
-#     @property
-#     def string_format(self) -> str:
-#         """
-#         forms a string representation: chr-pos-ref-alt
-#         """
-#         return f'{self.chrom}-{self.pos}-{self.ref}-{self.alt}'
-#
-#     def __lt__(self, other) -> bool:
-#         """
-#         enables positional sorting
-#         """
-#         # this will return False for same chrom and position
-#         if self.chrom == other.chrom:
-#             return self.pos < other.pos
-#         # otherwise take the relative index from sorted chromosomes list
-#         if self.chrom in CHROM_ORDER and other.chrom in CHROM_ORDER:
-#             return CHROM_ORDER.index(self.chrom) < CHROM_ORDER.index(other.chrom)
-#         # if self is on a canonical chromosome, sort before HLA/Decoy etc.
-#         if self.chrom in CHROM_ORDER:
-#             return True
-#         return False
-#
-#     def __eq__(self, other) -> bool:
-#         """
-#         equivalence check
-#         Args:
-#             other (Coordinates):
-#
-#         Returns:
-#             true if self == other
-#
-#         """
-#         return (
-#             self.chrom == other.chrom
-#             and self.pos == other.pos
-#             and self.ref == other.ref
-#             and self.alt == other.alt
-#         )
-
-
 def get_json_response(url, max_retries=4, base_delay=1, max_delay=32):
     """
     takes a request URL, checks for healthy response, returns the JSON
@@ -446,6 +394,11 @@ def create_small_variant(
     info: dict[str, Any] = {x.lower(): y for x, y in var.INFO} | {
         'seqr_link': coordinates.string_format
     }
+
+    # optionally - ignore some categories from this analysis
+    if ignore_cats := get_config()['workflow']['ignore_categories']:
+        info = {key: val for key, val in info.items() if key not in ignore_cats}
+
     het_samples, hom_samples = get_non_ref_samples(variant=var, samples=samples)
 
     # hot-swap cat 2 from a boolean to a sample list - if appropriate

--- a/test/input/reanalysis_global.toml
+++ b/test/input/reanalysis_global.toml
@@ -5,6 +5,11 @@ scatter_count = 50
 vcf_size_in_gb = 300  # if the input is a VCF, specify enough storage to fit it
 sequencing_type = 'genome'
 
+### optionally, ignore some categories
+#ignore_categories = [
+#    'categoryboolean3'
+#]
+
 [panels]
 default_panel = 137
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'


### PR DESCRIPTION
# Fixes

  - closes #349 

## Proposed Changes

  - In some situations we may want to run AIP with specific categories removed (e.g. because a label which provides value in trios may generate too much noise in singletons)
  - Instead of tweaking parameters in config, this allows us to completely remove categories from consideration
  - This removal is applied after the Hail/labelling stage, so that blocking/unblocking categories in config is reversible without having to re-run the labelling stage (longest, most expensive part)


## Checklist

- [x] Related Issue created
- [ ] Tests covering new change* (this is tricky in CI, as the whole run uses a single config. I've tested manually, running `test_utils.py` - [this](https://github.com/populationgenomics/automated-interpretation-pipeline/blob/main/test/test_utils.py#L150) method expects to find a range of labels attached to a variant. When the config entry is amended to remove one of the categories, these asserts break as expected)
- [x] Linting checks pass
