### PR TITLE
Model correction

### DIFF
--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -343,7 +343,7 @@ def main(panels: str | None, out_path: str, dataset: str | None = None):
 
     # store the list of genes currently on the core panel
     if twelve_months:
-        twelve_months = set(gene_dict['genes'])
+        twelve_months = set(gene_dict.genes)
 
     # if participant panels were provided, add each of those to the gene data
     panel_list = set()

--- a/reanalysis/query_panelapp.py
+++ b/reanalysis/query_panelapp.py
@@ -273,9 +273,7 @@ def overwrite_new_status(gene_dict: PanelApp, new_genes: set[str]):
 
     for gene, gene_data in gene_dict.genes.items():
         if gene in new_genes:
-            gene_data.new = [panel_id]
-        else:
-            gene_data.new = []
+            gene_data.new = {panel_id}
 
 
 @click.command()
@@ -394,6 +392,7 @@ def main(panels: str | None, out_path: str, dataset: str | None = None):
     with to_path(out_path).open('w') as out_file:
         out_file.write(PanelApp.model_validate(gene_dict).model_dump_json(indent=4))
 
+    # Only save here if we have a historic location in config
     save_new_historic(old_data, dataset=dataset, prefix='panel_')
 
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -886,6 +886,9 @@ def save_new_historic(
     """
 
     directory = get_cohort_seq_type_conf(dataset).get('historic_results')
+    if directory is None:
+        get_logger().info('No historic data folder, no saving')
+        return
 
     new_file = to_path(directory) / f'{prefix}{TODAY}.json'
     with new_file.open('w') as handle:


### PR DESCRIPTION
# Fixes

  - A couple more changes relating to THE COHORT THAT MUST NOT BE NAMED
  - That project's lack of a `-test` bucket means no prior data of any form, which has resulted in exercising a few config paths that weren't exposed before

## Proposed Changes

  - When running a (now vs. 12 months ago) assessment for new genes, correct the expected data type for the relevant model
  - If there's no historic data location, don't try to save any (tries to open the GCP path `None/<file>`

## Checklist
- [x] Linting checks pass
