### PR TITLE
Improve HPO presentation in reports

### DIFF
--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -207,7 +207,7 @@ def match_hpo_terms(
 
 def match_hpos_to_panels(
     hpo_to_panel_map: dict, hpo_file: str, all_hpos: set[str]
-) -> dict[str, set[int]]:
+) -> tuple[dict[str, set[int]], dict[str, str]]:
     """
     take the HPO terms from the participant metadata, and match to panels
     Args:
@@ -217,8 +217,19 @@ def match_hpos_to_panels(
 
     Returns:
         a dictionary linking all HPO terms to a corresponding set of Panel IDs
+        a second dictionary linking all HPO terms to their plaintext names
     """
+
+    hpo_to_text: dict[str, str] = {}
     hpo_graph = read_obo(hpo_file, ignore_obsolete=False)
+
+    # create a dictionary of HPO terms to their text
+    for hpo in all_hpos:
+        if not hpo_graph.has_node(hpo):
+            logging.error(f'HPO term was absent from the tree: {hpo}')
+            hpo_to_text[hpo] = 'Unknown'
+        else:
+            hpo_to_text[hpo] = hpo_graph.nodes[hpo]['name']
 
     hpo_to_panels = {}
     for hpo in all_hpos:
@@ -227,7 +238,7 @@ def match_hpos_to_panels(
         )
         hpo_to_panels[hpo] = panel_ids
 
-    return hpo_to_panels
+    return hpo_to_panels, hpo_to_text
 
 
 def match_participants_to_panels(
@@ -254,6 +265,27 @@ def match_participants_to_panels(
                 participant_hpos.all_panels.update(hpo_panels[hpo_term])
 
 
+def make_hpo_great_again(
+    hpo_dict: PhenotypeMatchedPanels, hpo_to_text: dict[str, str]
+) -> PhenotypeMatchedPanels:
+    """
+    update the HPO terms attached to the participants to be
+    human-readable: "HPO:Description"
+
+    Args:
+        hpo_dict ():
+        hpo_to_text ():
+
+    Returns:
+
+    """
+    for party_data in hpo_dict.samples.values():
+        party_data.hpo_terms = {
+            f"{hpo}:{hpo_to_text[hpo]}" for hpo in party_data.hpo_terms
+        }
+    return hpo_dict
+
+
 def main(dataset: str, hpo_file: str, panel_out: str | None) -> PhenotypeMatchedPanels:
     """
     main method to do the fun things
@@ -266,10 +298,14 @@ def main(dataset: str, hpo_file: str, panel_out: str | None) -> PhenotypeMatched
     # PhenotypeMatchedPanels
     panels_by_hpo = get_panels()
     hpo_dict, all_hpo = get_participant_hpos(dataset=dataset)
-    hpo_to_panels = match_hpos_to_panels(
+    hpo_to_panels, hpo_to_text = match_hpos_to_panels(
         hpo_to_panel_map=panels_by_hpo, hpo_file=hpo_file, all_hpos=all_hpo
     )
     match_participants_to_panels(hpo_dict, hpo_to_panels)
+
+    # update the HPO terms attached to the participants to be
+    # human-readable: "HPO:Description"
+    hpo_dict = make_hpo_great_again(hpo_dict, hpo_to_text)
 
     # validate the object
     valid_pheno_dict = PhenotypeMatchedPanels.model_validate(hpo_dict)

--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -265,7 +265,7 @@ def match_participants_to_panels(
                 participant_hpos.all_panels.update(hpo_panels[hpo_term])
 
 
-def make_hpo_great_again(
+def update_hpo_with_description(
     hpo_dict: PhenotypeMatchedPanels, hpo_to_text: dict[str, str]
 ) -> PhenotypeMatchedPanels:
     """
@@ -273,15 +273,15 @@ def make_hpo_great_again(
     human-readable: "HPO:Description"
 
     Args:
-        hpo_dict ():
-        hpo_to_text ():
+        hpo_dict: all participants and their HPO terms
+        hpo_to_text (dict): a lookup to find descriptions per HPO term
 
     Returns:
 
     """
     for party_data in hpo_dict.samples.values():
         party_data.hpo_terms = {
-            f"{hpo}:{hpo_to_text[hpo]}" for hpo in party_data.hpo_terms
+            f"{hpo} - {hpo_to_text[hpo]}" for hpo in party_data.hpo_terms
         }
     return hpo_dict
 
@@ -305,7 +305,7 @@ def main(dataset: str, hpo_file: str, panel_out: str | None) -> PhenotypeMatched
 
     # update the HPO terms attached to the participants to be
     # human-readable: "HPO:Description"
-    hpo_dict = make_hpo_great_again(hpo_dict, hpo_to_text)
+    hpo_dict = update_hpo_with_description(hpo_dict, hpo_to_text)
 
     # validate the object
     valid_pheno_dict = PhenotypeMatchedPanels.model_validate(hpo_dict)

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -11,6 +11,7 @@ from reanalysis.hpo_panel_match import (
     match_hpo_terms,
     match_hpos_to_panels,
     match_participants_to_panels,
+    update_hpo_with_description,
 )
 from reanalysis.models import ParticipantHPOPanels, PhenotypeMatchedPanels
 
@@ -146,5 +147,40 @@ def test_match_participants_to_panels():
             'family_id': 'fam2',
             'hpo_terms': {'HP:1', 'HP:6'},
             'panels': {137, 101, 102, 666},
+        }
+    )
+
+
+def test_update_hpo_with_description():
+    """
+    test that the description is added to the hpo
+    """
+    hpo_dict = PhenotypeMatchedPanels(
+        **{
+            'samples': {
+                'luke_skywalker': {
+                    'external_id': 'participant1',
+                    'family_id': 'fam1',
+                    'hpo_terms': {'HP:1', 'HP:2'},
+                    'panels': {137},
+                }
+            }
+        }
+    )
+    hpo_to_desc = {'HP:1': 'Philosopher\'s Stone', 'HP:2': 'Chamber of Secrets'}
+    hpo_dict = update_hpo_with_description(hpo_dict, hpo_to_desc)
+    assert hpo_dict == PhenotypeMatchedPanels(
+        **{
+            'samples': {
+                'luke_skywalker': {
+                    'external_id': 'participant1',
+                    'family_id': 'fam1',
+                    'hpo_terms': {
+                        'HP:1 - Philosopher\'s Stone',
+                        'HP:2 - Chamber of Secrets',
+                    },
+                    'panels': {137},
+                }
+            }
         }
     )

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -59,17 +59,23 @@ def test_match_hpos_to_panels(fake_obo_path):
     panel_map = {'HP:2': {1, 2}, 'HP:5': {5}}
     assert match_hpos_to_panels(
         panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}
-    ) == {
-        'HP:4': {1, 2},
-        'HP:7a': {5},
-    }
+    ) == (
+        {
+            'HP:4': {1, 2},
+            'HP:7a': {5},
+        },
+        {'HP:4': 'Goblet of Fire', 'HP:7a': 'Deathly Hallows'},
+    )
     # full depth from the terminal node should capture all panels
     assert match_hpos_to_panels(
         panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}
-    ) == {
-        'HP:4': {1, 2},
-        'HP:7a': {5},
-    }
+    ) == (
+        {
+            'HP:4': {1, 2},
+            'HP:7a': {5},
+        },
+        {'HP:4': 'Goblet of Fire', 'HP:7a': 'Deathly Hallows'},
+    )
 
 
 def test_read_hpo_tree(fake_obo_path):


### PR DESCRIPTION
# Fixes

  - HPO terms in the reports are naked (HPO:NNNN only)
  - Closes #356

## Proposed Changes

  - After matching HPO terms to relevant panels, they are enhanced by appending their plain text short description
  - This will then be added in the final report, to make reading easier, removing the need to find a separate lookup
  -

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
