### PR TITLE
Update Seqr minimiser script

### DIFF
--- a/helpers/minimise_output_for_seqr.py
+++ b/helpers/minimise_output_for_seqr.py
@@ -64,9 +64,7 @@ def main(input_file: str, output: str, ext_map: str | None = None):
         lil_data.results[individual] = {}
         for variant in details.variants:
             var_data = variant.var_data
-            lil_data.results[individual][
-                var_data.coordinates.string_format
-            ] = MiniVariant(
+            lil_data.results[individual][var_data.info['seqr_link']] = MiniVariant(
                 **{
                     'categories': variant.categories,
                     'support_vars': variant.support_vars

--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -491,7 +491,6 @@ class PhenotypeMatchedPanels(BaseModel):
 class MiniVariant(BaseModel):
     categories: set[str] = Field(default_factory=set)
     support_vars: set[str] = Field(default_factory=set)
-    independent: bool = Field(default=True)
 
 
 class MiniForSeqr(BaseModel):


### PR DESCRIPTION
# Fixes

  - Script which takes AIP results and minimises for Seqr doesn't 100% fit the expected API
  - Based on this [test data](https://github.com/populationgenomics/seqr/blob/staging/ui/pages/SummaryData/SummaryData.jsx#L48) which doesn't include 'independent' as an entity, and maps on Individual ID

## Proposed Changes

  - Requires a Seqr mapping dictionary to convert CPG IDs to External Participant IDs
  - Removes the Independent attribute from models

This is on hold pending the successful ingestion of the data generated by the script in its current form

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
