### PR TITLE
Fix Cat 4 logic, reorganise methods

### DIFF
--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -956,7 +956,7 @@ def write_matrix_to_vcf(mt: hl.MatrixTable, vcf_out: str, dataset: str):
 
 
 def green_and_new_from_panelapp(
-    panel_genes: dict[str, dict[str, str]]
+    panel_genes: dict[str, dict[str, str | list[int]]]
 ) -> tuple[hl.SetExpression, hl.SetExpression | None]:
     """
     Pull all ENSGs from PanelApp data relating to Green Genes

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -629,12 +629,10 @@ def filter_by_consequence(mt: hl.MatrixTable) -> hl.MatrixTable:
     """
     - reduce the per-row transcript CSQ to a limited group
     - reduce the rows to ones where there are remaining tx consequences
+    - alternatively except rows with spliceAI delta above threshold
 
     Args:
         mt ():
-
-    Returns:
-
     """
 
     # at time of writing this is VEP HIGH + missense_variant
@@ -657,8 +655,9 @@ def filter_by_consequence(mt: hl.MatrixTable) -> hl.MatrixTable:
 
     # filter out rows with no tx consequences left, and no splice cat. assignment
     return filtered_mt.filter_rows(
-        (hl.len(filtered_mt.vep.transcript_consequences) > 0)
-        & (filtered_mt.info.categoryboolean5 == 0)
+        (hl.len(filtered_mt.vep.transcript_consequences) == 0)
+        | (filtered_mt.info.categoryboolean5 == 0),
+        keep=False,
     )
 
 

--- a/reanalysis/hail_filter_and_label.py
+++ b/reanalysis/hail_filter_and_label.py
@@ -1102,7 +1102,11 @@ def main(
     get_logger().info(f'Reading config dict from {os.getenv("CPG_CONFIG_PATH")}')
 
     # get temp suffix from the config (can be None or missing)
-    checkpoint_root = output_path('hail_matrix.mt', 'tmp', dataset=dataset)
+    # make this checkpoint sequencing-type specific to prevent crossover
+    sequencing_type = get_config().get('sequencing_type', 'unknown')
+    checkpoint_root = output_path(
+        f'{sequencing_type}_hail_matrix.mt', 'tmp', dataset=dataset
+    )
 
     # read the parsed panelapp data
     get_logger().info(f'Reading PanelApp data from {panelapp_path!r}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click>=8.1.7
 cloudpathlib[all]>=0.16.0
 cpg-utils>=4.18.2
-cyvcf2==0.30.18
+cyvcf2>=0.30.18
 dill>=0.3.7
 hail>=0.2.120
 Jinja2==3.0.3

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -454,7 +454,7 @@ def test_aip_clinvar_default(make_a_mt):
 @pytest.mark.parametrize(
     'rating,stars,rows,regular,strong',
     [
-        ('benign', 0, 1, 0, 0),  # with private data, any benign is removed
+        ('benign', 0, 1, 0, 0),
         ('benign', 1, 0, 0, 0),
         ('other', 7, 1, 0, 0),
         ('pathogenic', 0, 1, 1, 0),

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -454,7 +454,7 @@ def test_aip_clinvar_default(make_a_mt):
 @pytest.mark.parametrize(
     'rating,stars,rows,regular,strong',
     [
-        ('benign', 0, 0, 0, 0),  # with private data, any benign is removed
+        ('benign', 0, 1, 0, 0),  # with private data, any benign is removed
         ('benign', 1, 0, 0, 0),
         ('other', 7, 1, 0, 0),
         ('pathogenic', 0, 1, 1, 0),


### PR DESCRIPTION
# Fixes
  
  - Closes #353 - was caused by exomes and genomes writing to (and potentially resuming from) the same checkpoint path
  - There may have been a bug in Cat. 4 (de novo) [here](https://github.com/populationgenomics/automated-interpretation-pipeline/blob/main/reanalysis/hail_filter_and_label.py#L511-L533)
  - The intention of this logic is 
    1. get all relevant consequences (VEP critical + missense)
    2. filter transcripts to the ones which have those relevant consequence annotations
    3. the final clause is supposed to be "filter variants to ones where there is either at least one transcript with a relevant consequence annotation, OR the variant has a substantial SpliceAI score"
    4. the final clause instead filters for variants which have a consequential transcript annotation AND NO SpliceAI score
 - Not sure how often we'll expect variants with consequential transcript annotations AND spliceAI scores, but it's not impossible. With the current code we'll have been removing those from consideration as de novos

## Proposed Changes

  - This does a lot of housekeeping, mostly moving the methods around to be in the chronological order in which they are called
  - Also changes the logger to stop using the root logger, not important
  - This clause in Cat4 assignment is corrected
  - We filter out Benign variants only where the number of ClinVar stars is >= 1. This ties into as-yet unreleased tweaks to the https://github.com/populationgenomics/ClinvArbitration codebase, so that we will now generate 0-star clinvar entries in the raw data, even if we don't intend to use them. Currently all our private ClinVar data is 1 star or greater, so this doesn't impact us.

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
