### PR TITLE
Allow for interchromosomal split variants

### DIFF
--- a/reanalysis/minimise_output_for_seqr.py
+++ b/reanalysis/minimise_output_for_seqr.py
@@ -15,10 +15,10 @@ Also produce a second version of the same, limited to phenotype-matches
 """
 
 import json
-import logging
 from argparse import ArgumentParser
 
 from reanalysis.models import MiniForSeqr, MiniVariant, ResultData
+from reanalysis.utils import get_logger
 
 
 def coord_to_string(coord: dict) -> str:
@@ -72,25 +72,23 @@ def main(
             if pheno_match and not variant.panels.matched:
                 continue
             lil_data.results[individual][var_data.info['seqr_link']] = MiniVariant(
-                **{
-                    'categories': variant.categories,
-                    'support_vars': variant.support_vars,
-                }
+                categories=variant.categories, support_vars=variant.support_vars
             )
 
     if pheno_match:
-        additional_string = 'phenotype-matched'
+        additional_string = 'phenotype-matched '
         output = output.replace('.json', '_pheno.json')
     else:
         additional_string = ''
 
     if not any(lil_data.results.values()):
-        logging.info(f'No {additional_string} results found')
-        return
+        get_logger().info(f'No {additional_string}results found')
+
+    # write anyway, so as not to break the pipeline
     with open(output, 'w', encoding='utf-8') as f:
         f.write(MiniForSeqr.model_validate(lil_data).model_dump_json(indent=4))
 
-    logging.info(f'Wrote {additional_string} output to {output}')
+    get_logger().info(f'Wrote {additional_string}output to {output}')
 
 
 if __name__ == '__main__':

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -483,6 +483,10 @@ def create_structural_variant(var: cyvcf2.Variant, samples: list[str]):
 
     info: dict[str, Any] = {x.lower(): y for x, y in var.INFO}
 
+    # valid processing of inter-chromosomal SVs
+    if all(attribute in info for attribute in ('chr2', 'end2')):
+        info['svlen'] = f'{info["chr2"]}:{info["end2"]}'
+
     # this is the right ID for Seqr
     info['seqr_link'] = info['variantid']
 


### PR DESCRIPTION
# Fixes

  - #366 

## Proposed Changes

  - Inter-chromosomal variants don't have a length. Instead, we set the 'SVLEN' to be 'chrX:12345' (the other side of the breakpoint)

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
