### PR TITLE
Bases build on a smaller Hail image, instead of the driver image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
+FROM hailgenetics/hail:0.2.127-py3.11
 
 COPY requirements.txt .
 COPY requirements-dev.txt .

--- a/reanalysis/metamist_registration.py
+++ b/reanalysis/metamist_registration.py
@@ -47,7 +47,7 @@ def register_html(file_path: str, samples: list[str]):
     AnalysisApi().create_analysis(
         project=get_config()['workflow']['dataset'],
         analysis=Analysis(
-            sample_ids=samples,
+            sequencing_group_ids=samples,
             type=analysis_type,
             status=AnalysisStatus('completed'),
             output=file_path,


### PR DESCRIPTION
# Fixes

  - Closes #219

## Proposed Changes

  - Swaps out the driver image as a base, replaces with a light(er)-weight Hail image
  - Size 5.7GB -> 2.1GB
  - Needs testing