### PR TITLE
Re-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
+FROM hailgenetics/hail:0.2.127-py3.11
 
 COPY requirements.txt .
 COPY requirements-dev.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,38 @@
-FROM hailgenetics/hail:0.2.127-py3.11
+FROM python:3.10-bullseye
 
-COPY requirements.txt .
-COPY requirements-dev.txt .
-RUN pip install -r requirements.txt
-COPY README.md .
-COPY setup.py .
-COPY helpers helpers/
-COPY reanalysis reanalysis/
+ARG HAIL_SHA=${HAIL_SHA:-8f6797b033d2e102575c40166cf0c977e91f834e}
+
+RUN apt update && apt install -y \
+        apt-transport-https \
+        bash \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        curl \
+        g++ \
+        gcc \
+        git \
+        gnupg \
+        liblapack3 \
+        libopenblas-base \
+        make \
+        openjdk-11-jdk-headless \
+        rsync \
+        software-properties-common \
+        wget \
+        zip && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/*
+
+# Install Hail from the CPG fork.
+RUN git clone https://github.com/populationgenomics/hail.git && \
+    cd hail && \
+    git checkout $HAIL_SHA && \
+    cd hail && \
+    # Install locally, avoiding the need for a pip package.
+    make install && \
+    cd ../.. && \
+    rm -rf hail
+
+COPY . /
 RUN pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ cpg-utils>=4.18.2
 cyvcf2>=0.30.18
 dill>=0.3.7
 gql
-hail>=0.2.120
+# hail version can't exceed the CPG version
+# or QoB will fail to find JAR files
+hail==0.2.127
 Jinja2>=3.1.3
 metamist>=6.5.0
 networkx>=3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dill>=0.3.7
 gql
 # hail version can't exceed the CPG version
 # or QoB will fail to find JAR files
-hail==0.2.127
+hail>=0.2.126
 Jinja2>=3.1.3
 metamist>=6.5.0
 networkx>=3


### PR DESCRIPTION
# Fixes

  - This attempts to build off a lighter docker image than the CPG driver
  - Previous attempt at this used a global Hail dockerfile as a base image - that's not valid, as QoB within our infrastructure requires us to use a specific version of Hail which has been deployed within our infra
  - The benefits from this optimisation are limited by the fact that within CPG infra we have to use a CPG-built version of Hail

## Proposed Changes

  - Pins the Hail hash to the version build from our hail fork
  - uses a similar build plan to the driver image, minus a lot of irrelevant weight

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
