### PR TITLE
Allow for no categorised variants

### DIFF
--- a/reanalysis/html_builder.py
+++ b/reanalysis/html_builder.py
@@ -1,7 +1,7 @@
 """
 Methods for taking the final output and generating static report content
 """
-
+import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass
 from itertools import chain
@@ -226,6 +226,11 @@ class HTMLBuilder:
             for key in ordered_categories
             if category_count[key]
         ]
+
+        # this can fail if there are no categorised variants... at all
+        if summary_dicts == []:
+            get_logger().info('No categorised variants found')
+            sys.exit(0)
 
         df: pd.DataFrame = pd.DataFrame(summary_dicts)
         df['Mean/sample'] = df['Mean/sample'].round(3)


### PR DESCRIPTION
# Fixes

  - This is the real reason for #354
  - Since moving to a model where 2 reports are generated - one for all variants, and one for 'new variants today', we've occasionally hit an issue where we fail to reference a column within a dataframe. The reason: if no variants are found at all, the list of dictionaries passed to the DataFrame builder is an empty list, so the result has no columns. This typically happens when filtering to latest, but could potentially happen if no variants are found at all.

## Proposed Changes

  - If the list builder contains no data, gracefully exit

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
