### PR TITLE
Change HPO term storage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,39 @@
+default_language_version:
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: check-yaml
-        exclude: '\.*conda/.*'
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: '\.txt$|\.tsv$'
+        exclude: '\.txt|\.tsv$'
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: detect-private-key
       - id: debug-statements
       - id: check-added-large-files
+        exclude: '\.*.interval_list'
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
-    hooks:
-      - id: markdownlint
-        args: ["--config", ".markdownlint.json"]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
+  # - repo: https://github.com/populationgenomics/pre-commits
+  #   rev: "v0.1.3"
+  #   hooks:
+  #     - id: cpg-id-checker
 
   - repo: https://github.com/ambv/black
-    rev: 23.12.1
+    rev: 24.3.0
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.11
+    rev: v0.3.3
     hooks:
       - id: ruff
 
-  - repo: https://github.com/populationgenomics/pre-commits
-    rev: v0.1.3
-    hooks:
-      - id: cpg-id-checker
-
+  # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: "v1.9.0"
     hooks:
       - id: mypy
-        args:
-          [
-            --pretty,
-            --show-error-codes,
-            --no-strict-optional,
-            --ignore-missing-imports,
-            --install-types,
-            --non-interactive,
-          ]
+        args: [--pretty, --show-error-codes, --install-types, --non-interactive]

--- a/comparison/comparison_wrapper.py
+++ b/comparison/comparison_wrapper.py
@@ -70,9 +70,7 @@ def main(results_folder: str, seqr: str, mt: str):
 
     # need to localise the VCF + index
     run_vcf = os.path.join(results_folder, 'hail_categorised.vcf.bgz')
-    vcf_in_batch = batch.read_input_group(
-        **{'vcf.bgz': run_vcf, 'vcf.bgz.tbi': run_vcf + '.tbi'}
-    )
+    vcf_in_batch = batch.read_input_group(**{'vcf.bgz': run_vcf, 'vcf.bgz.tbi': run_vcf + '.tbi'})
     ped_in_batch = batch.read_input(os.path.join(results_folder, 'latest_pedigree.fam'))
 
     results_command = (

--- a/helpers/generate_historic_data.py
+++ b/helpers/generate_historic_data.py
@@ -30,9 +30,7 @@ def main(input_results: str):
     """
 
     input_data: ResultData = read_json_from_path(input_results, return_model=ResultData)  # type: ignore
-    generate_fresh_latest_results(
-        input_data, prefix='', dataset=get_config()['workflow']['dataset']
-    )
+    generate_fresh_latest_results(input_data, prefix='', dataset=get_config()['workflow']['dataset'])
 
 
 if __name__ == '__main__':

--- a/helpers/process_seqr_metadata.py
+++ b/helpers/process_seqr_metadata.py
@@ -34,8 +34,7 @@ def get_seqr_details(seqr_meta: str) -> dict[str, dict[str, str]]:
 
     # map CPG ID to individual GUID
     return {
-        sample['sampleId']: sample['familyGuid']
-        for seqr_sample_id, sample in details_dict['samplesByGuid'].items()
+        sample['sampleId']: sample['familyGuid'] for seqr_sample_id, sample in details_dict['samplesByGuid'].items()
     }
 
 

--- a/helpers/report_hunter.py
+++ b/helpers/report_hunter.py
@@ -31,7 +31,7 @@ PROJECT_QUERY = gql(
             dataset
         }
     }
-    """
+    """,
 )
 REPORT_QUERY = gql(
     """
@@ -44,7 +44,7 @@ REPORT_QUERY = gql(
             }
         }
     }
-    """
+    """,
 )
 
 
@@ -82,9 +82,7 @@ def get_project_analyses(project: str) -> list[dict]:
         project (str): project to query for
     """
 
-    response: dict[str, Any] = wrapped_gql_query(
-        REPORT_QUERY, variables={'project': project}
-    )
+    response: dict[str, Any] = wrapped_gql_query(REPORT_QUERY, variables={'project': project})
     return response['project']['analyses']
 
 
@@ -145,9 +143,7 @@ def main(latest: bool = False):
     template_context = {'reports': list(all_cohorts.values())}
 
     # build some HTML
-    env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(JINJA_TEMPLATE_DIR),
-    )
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(JINJA_TEMPLATE_DIR), autoescape=True)
     template = env.get_template('index.html.jinja')
     content = template.render(**template_context)
 
@@ -157,7 +153,7 @@ def main(latest: bool = False):
             get_config()['storage']['common']['test']['web'],
             'reanalysis',
             'latest_aip_index.html' if latest else 'aip_index.html',
-        )
+        ),
     ).write_text('\n'.join(line for line in content.split('\n') if line.strip()))
 
 

--- a/helpers/stratify_solved_cases.py
+++ b/helpers/stratify_solved_cases.py
@@ -21,7 +21,7 @@ PROJECT_QUERY = gql(
             dataset
         }
     }
-    """
+    """,
 )
 ID_QUERY = gql(
     """
@@ -37,7 +37,7 @@ ID_QUERY = gql(
           }
         }
       }
-    }"""
+    }""",
 )
 
 
@@ -60,9 +60,7 @@ def get_affected_per_family(pedigree: list[dict]):
 
 
 # find all my projects
-all_projects_of_interest = {
-    dataset['dataset'] for dataset in query(PROJECT_QUERY)['myProjects']
-}
+all_projects_of_interest = {dataset['dataset'] for dataset in query(PROJECT_QUERY)['myProjects']}
 
 project_dict = dict()
 solved_fams = open(argv[1]).readlines()
@@ -75,10 +73,7 @@ for project in all_projects_of_interest:
     aff_dict = get_affected_per_family(response['project']['pedigree'])
 
     # create a mapping of sample ID to participant ID
-    sample_map = {
-        sg['sample']['participant']['externalId']: sg['id']
-        for sg in response['project']['sequencingGroups']
-    }
+    sample_map = {sg['sample']['participant']['externalId']: sg['id'] for sg in response['project']['sequencingGroups']}
 
     solves_project_ids = []
 
@@ -88,9 +83,7 @@ for project in all_projects_of_interest:
                 if ext_id in sample_map:
                     solves_project_ids.append(sample_map[ext_id])
                 elif ext_id.replace('_proband', '') in sample_map:
-                    solves_project_ids.append(
-                        sample_map[ext_id.replace('_proband', '')]
-                    )
+                    solves_project_ids.append(sample_map[ext_id.replace('_proband', '')])
 
     # write this to a dict
     project_dict[project] = solves_project_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,53 @@
 [tool.black]
-line-length = 88
+line-length = 120
 skip-string-normalization = true
+exclude = '''
+/(
+  seqr-loading-pipelines
+  | gnomad_methods
+  | venv
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
 
-[tool.isort]
-py_version = 311
-profile = "black"
-line_length = 88
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "HAIL", "CPG", "FIRSTPARTY", "LOCALFOLDER"]
-known_hail = [
-    "hail",
-    "hailtop",
-]
-# Adjust these for each repository, e.g., removing those that should be
-# local rather than CPG. Also fill in extend_skip below if there are any
-# subdirectories that should be ignored.
-known_cpg = [
-    "analysis_runner",
-    "cpg_infra",
-    "cpg_utils",
-    "cpg_workflows",
-    "gnomad",
-    "hail_scripts",
-    "metamist",
-]
-# extend_skip = ["list", "submodules", "etc", here"]
+[tool.mypy]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+pythonpath = ['gnomad_methods', 'seqr-loading-pipelines']
+testpaths = ['test']
+
 
 [tool.ruff]
-line-length = 88
-extend-select = ["T201"]
+line-length = 120
+
+extend-exclude = [
+    "gnomad_methods",
+    "seqr-loading-pipelines",
+    "venv",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "build",
+    "dist",
+]
+
+[tool.ruff.lint]
+# ignore pydocstyle, flake8-boolean-trap (FBT)
+select = ["A", "B", "C", "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+
 ignore = [
     "ANN101", # Missing type annotation for self in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
     "ANN201", # Missing return type annotation for public function
+    "ANN204", # Missing type annotation for special method `__init__`
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
     "E501", # Line length too long
     "E731", # Do not assign a lambda expression, use a def
     "E741", # Ambiguous variable name
@@ -43,5 +60,146 @@ ignore = [
     "PT018", # Assertion should be broken down into multiple parts
     "Q000", # Single quotes found but double quotes preferred
     "S101", # Use of assert detected
-    "I001", # Import block is un-sorted (we use isort directly as ruff sort isn't fully supported)
+    "SLF001", # Private member accessed: `_preemptible`
+
+    "ARG001", # Unused function argument
+    "ARG002", # Unused method argument
+
+    "PLR2004", # Magic value used
+
+    "ANN001",
+    "ANN202",
+    "C408",
+    "TID252",
+    "RET504",
+    "ERA001",
+    "UP032",
+    "RUF100",
+    "ISC001",
+    "PIE804",
+    "F401",
+    "C901",
+    "W605",
+    "RET505",
+    "ANN003",
+    "RUF013",
+    "UP031",
+    "RUF010",
+    "B006",
+    "ANN002",
+    "B023",
+    "EXE001",
+    "G001",
+    "SIM108",
+    "RUF005",
+    "G002",
+    "PD901",
+    "N999",
+    "SIM118",
+    "SIM102",
+    "PLW2901",
+    "S603",
+    "ARG005",
+    "PGH003",
+    "B904",
+    "N802",
+    "ISC003",
+    "ANN205",
+    "S607",
+    "RUF015",
+    "E701",
+    "N818",
+    "PIE790",
+    "N803",
+    "A002",
+    "RUF012",
+    "W291",
+    "S113",
+    "S311",
+    "N806",
+    "PLR5501",
+    "F403",
+    "SIM115",
+    "B007",
+    "F841",
+    "C405",
+    "C419",
+    "SIM300",
+    "PD011",
+    "UP015",
+    "S602",
+    "Q002",
+    "ISC002",
+    "COM819",
+    "C416",
+    "DTZ005",
+    "G003",
+    "S608",
+    "PIE808",
+    "B008",
+    "S108",
+    "E402",
+    "S605",
+    "F821",
+    "RET507",
+    "RET503",
+    "UP030",
+    "UP026",
+    "PLR1714",
+    "C403",
+    "PLR1711",
+    "PIE810",
+    "DTZ011",
+    "S105",
+    "BLE001",
+    "C401",
+    "C400",
+    "PLR0402",
+    "SIM201",
+    "RET506",
+    "C417",
+    "PD010",
+    "PLW1510",
+    "A001",
+    "W292",
+    "PYI024",
+    "Q003",
+    "S301",
+    "RET501",
+    "PD003",
+    "SIM117",
+    "RUF002",
+    "UP027",
+    "SIM105",
+    "E713",
+    "S324",
+    "S310",
+    "Q001",
+    "UP020",
+    "S506",
+    "N805",
+    "E712",
+    "E401",
+    "SIM212",
+    "DTZ002",
+]
+
+[tool.ruff.lint.isort]
+
+section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
+
+[tool.ruff.lint.isort.sections]
+hail = [
+    "hail",
+    "hailtop",
+]
+
+cpg = [
+    "analysis_runner",
+    "cpg_infra",
+    "cpg_utils",
+    "cpg_workflows",
+    "gnomad",
+    "hail_scripts",
+    "metamist",
 ]

--- a/reanalysis/clinvar_by_codon.py
+++ b/reanalysis/clinvar_by_codon.py
@@ -36,18 +36,14 @@ def protein_indexed_clinvar(mt_path: str, write_path: str):
 
     # 1. retain only relevant annotations
     vep_clinvar = vep_clinvar.rows()
-    vep_clinvar = vep_clinvar.select(
-        tx_csq=vep_clinvar.vep.transcript_consequences, info=vep_clinvar.info
-    )
+    vep_clinvar = vep_clinvar.select(tx_csq=vep_clinvar.vep.transcript_consequences, info=vep_clinvar.info)
 
     # 2. split rows out to separate transcript consequences
     vep_clinvar = vep_clinvar.explode(vep_clinvar.tx_csq)
 
     # 3. filter down to missense
     # a reasonable filter here would also include MANE transcripts
-    vep_clinvar = vep_clinvar.filter(
-        vep_clinvar.tx_csq.consequence_terms.contains('missense_variant')
-    )
+    vep_clinvar = vep_clinvar.filter(vep_clinvar.tx_csq.consequence_terms.contains('missense_variant'))
 
     # 4. squash the clinvar and protein content into single strings
     vep_clinvar = vep_clinvar.annotate(
@@ -55,13 +51,13 @@ def protein_indexed_clinvar(mt_path: str, write_path: str):
             [
                 hl.str(vep_clinvar.info.allele_id),
                 hl.str(vep_clinvar.info.gold_stars),
-            ]
+            ],
         ),
         newkey=hl.str('::').join(
             [
                 vep_clinvar.tx_csq.protein_id,
                 hl.str(vep_clinvar.tx_csq.protein_start),
-            ]
+            ],
         ),
     )
 
@@ -73,9 +69,7 @@ def protein_indexed_clinvar(mt_path: str, write_path: str):
 
     # 7. squash the multiple clinvar entries back to a single string
     vep_clinvar = vep_clinvar.transmute(
-        clinvar_alleles=hl.str('+').join(
-            hl.set(hl.map(lambda x: x.clinvar_entry, vep_clinvar.values))
-        )
+        clinvar_alleles=hl.str('+').join(hl.set(hl.map(lambda x: x.clinvar_entry, vep_clinvar.values))),
     )
 
     # 8. write the table of all ENSP:residue#: Clinvar[+Clinvar,]

--- a/reanalysis/hail_audit.py
+++ b/reanalysis/hail_audit.py
@@ -4,7 +4,6 @@ mostly just to reduce the line count
 partially to make this available in other places
 """
 
-
 import logging
 
 import hail as hl  # type: ignore
@@ -98,9 +97,7 @@ USELESS_FIELDS = [
 ]
 
 
-def fields_audit(
-    mt: hl.MatrixTable, base_fields: list[tuple], nested_fields: dict
-) -> bool:
+def fields_audit(mt: hl.MatrixTable, base_fields: list[tuple], nested_fields: dict) -> bool:
     """
     checks that the required fields are all present before continuing
     """
@@ -120,11 +117,7 @@ def fields_audit(
             for annotation, datatype in group_types:
                 if annotation in mt[field_group]:
                     if not isinstance(mt[field_group][annotation], datatype):
-                        problems.append(
-                            f'{annotation}:'
-                            f'{datatype}/'
-                            f'{type(mt[field_group][annotation])}'
-                        )
+                        problems.append(f'{annotation}:' f'{datatype}/' f'{type(mt[field_group][annotation])}')
                 else:
                     problems.append(f'{annotation}:missing')
     for problem in problems:
@@ -132,9 +125,7 @@ def fields_audit(
     return len(problems) == 0
 
 
-def vep_audit(
-    mt: hl.MatrixTable, expected_fields: list[tuple[str, hl.Expression]]
-) -> bool:
+def vep_audit(mt: hl.MatrixTable, expected_fields: list[tuple[str, hl.Expression]]) -> bool:
     """
     check that the required VEP annotations are present
     True if the 'audit' passes (all required fields present)
@@ -151,9 +142,7 @@ def vep_audit(
         for field, field_type in expected_fields:
             if field in fields_and_types:
                 if not isinstance(fields_and_types[field], field_type):
-                    problems.append(
-                        f'{field}:{field_type}/{type(fields_and_types[field])}'
-                    )
+                    problems.append(f'{field}:{field_type}/{type(fields_and_types[field])}')
             else:
                 problems.append(f'{field}:missing')
 

--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -120,7 +120,7 @@ def get_participant_hpos(dataset: str) -> tuple[PhenotypeMatchedPanels, set[str]
             **{
                 'external_id': sg['sample']['participant']['externalId'],
                 'family_id': fam_id,
-                'hpo_terms': hpos,
+                'hpo_terms': {hpo: '' for hpo in hpos},
                 'panels': {137},
             },
         )
@@ -276,7 +276,7 @@ def update_hpo_with_description(
 
     """
     for party_data in hpo_dict.samples.values():
-        party_data.hpo_terms = {f"{hpo} - {hpo_to_text[hpo]}" for hpo in party_data.hpo_terms}
+        party_data.hpo_terms = {hpo: hpo_to_text[hpo] for hpo in party_data.hpo_terms}
     return hpo_dict
 
 

--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -253,11 +253,11 @@ def match_participants_to_panels(participant_hpos: PhenotypeMatchedPanels, hpo_p
 
     for party_data in participant_hpos.samples.values():
         for hpo_term in party_data.hpo_terms:
-            if hpo_term in hpo_panels:
+            if panel_list := hpo_panels.get(hpo_term['id']):
                 # add relevant panels for this participant
-                party_data.panels.update(hpo_panels[hpo_term])
+                party_data.panels.update(panel_list)
                 # and add to the collection of all panels
-                participant_hpos.all_panels.update(hpo_panels[hpo_term])
+                participant_hpos.all_panels.update(panel_list)
 
 
 def update_hpo_with_description(
@@ -265,18 +265,16 @@ def update_hpo_with_description(
     hpo_to_text: dict[str, str],
 ) -> PhenotypeMatchedPanels:
     """
-    update the HPO terms attached to the participants to be
-    human-readable: "HPO:Description"
+    Add the plaintext meaning of the HPO term to the entity
 
     Args:
         hpo_dict: all participants and their HPO terms
         hpo_to_text (dict): a lookup to find descriptions per HPO term
-
-    Returns:
-
     """
     for party_data in hpo_dict.samples.values():
-        party_data.hpo_terms = {hpo: hpo_to_text[hpo] for hpo in party_data.hpo_terms}
+        for term in party_data.hpo_terms:
+            term['label'] = hpo_to_text[term['id']]
+
     return hpo_dict
 
 

--- a/reanalysis/minimise_output_for_seqr.py
+++ b/reanalysis/minimise_output_for_seqr.py
@@ -34,9 +34,7 @@ def coord_to_string(coord: dict) -> str:
     return f"{coord['chrom']}-{coord['pos']}-{coord['ref']}-{coord['alt']}"
 
 
-def main(
-    input_file: str, output: str, ext_map: str | None = None, pheno_match: bool = False
-):
+def main(input_file: str, output: str, ext_map: str | None = None, pheno_match: bool = False):
     """
     reads in the input file, shrinks it, and writes the output file
 
@@ -57,7 +55,7 @@ def main(
     lil_data = MiniForSeqr(
         **{
             'metadata': {'categories': data.metadata.categories},
-        }
+        },
     )
     ext_map_dict = None
     if ext_map:
@@ -75,7 +73,8 @@ def main(
             if pheno_match and not variant.panels.matched:
                 continue
             lil_data.results[individual][var_data.info['seqr_link']] = MiniVariant(
-                categories=variant.categories, support_vars=variant.support_vars
+                categories=variant.categories,
+                support_vars=variant.support_vars,
             )
 
     if not any(lil_data.results.values()):
@@ -92,9 +91,7 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('input_file', help='the input file to process')
     parser.add_argument('output_file', help='the output file to write to')
-    parser.add_argument(
-        'pheno_file', help='the output file for phenotype-matched data', default=None
-    )
+    parser.add_argument('pheno_file', help='the output file for phenotype-matched data', default=None)
     parser.add_argument(
         '--external_map',
         help='mapping of internal to external IDs for seqr',

--- a/reanalysis/model_go_brrr.py
+++ b/reanalysis/model_go_brrr.py
@@ -64,9 +64,7 @@ t = TXFields(
 clinvar = Clinvar(allele_id=1234, clinical_significance='Pathogenic', gold_stars=1)
 splice = Splice(delta_score=0.02)
 
-v3 = VepVariant(
-    BaseFields('chr1:123457', ['A', 'CC']), [t], clinvar=clinvar, splice=splice
-)
+v3 = VepVariant(BaseFields('chr1:123457', ['A', 'CC']), [t], clinvar=clinvar, splice=splice)
 sn3 = SneakyTable([v3], '.')
 ht = sn3.to_hail(hail_table=True)
 ht.describe()

--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -315,7 +315,7 @@ class ReportVariant(BaseModel):
     independent: bool = Field(default=False)
     labels: set[str] = Field(default_factory=set)
     panels: ReportPanel = Field(default_factory=ReportPanel)
-    phenotypes: set[str] = Field(default_factory=set)
+    phenotypes: dict[str, str] = Field(default_factory=set)
     reasons: set[str] = Field(default_factory=set)
     support_vars: set[str] = Field(default_factory=set)
 
@@ -427,7 +427,7 @@ class ParticipantMeta(BaseModel):
     ext_id: str
     family_id: str
     members: dict[str, FamilyMembers] = Field(default_factory=dict)
-    phenotypes: list[str] = Field(default_factory=list)
+    phenotypes: dict[str, str] = Field(default_factory=dict)
     panel_ids: list[int] = Field(default_factory=list)
     panel_names: list[str] = Field(default_factory=list)
     solved: bool = Field(default=False)
@@ -460,7 +460,7 @@ class ModelVariant(BaseModel):
 class ParticipantHPOPanels(BaseModel):
     external_id: str = Field(default_factory=str)
     family_id: str = Field(default_factory=str)
-    hpo_terms: set[str] = Field(default_factory=set)
+    hpo_terms: dict[str, str] = Field(default_factory=dict)
     panels: set[int] = Field(default_factory=set)
 
 

--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -315,7 +315,7 @@ class ReportVariant(BaseModel):
     independent: bool = Field(default=False)
     labels: set[str] = Field(default_factory=set)
     panels: ReportPanel = Field(default_factory=ReportPanel)
-    phenotypes: dict[str, str] = Field(default_factory=set)
+    phenotypes: list[dict[str, str]] = Field(default_factory=list)
     reasons: set[str] = Field(default_factory=set)
     support_vars: set[str] = Field(default_factory=set)
 
@@ -427,7 +427,7 @@ class ParticipantMeta(BaseModel):
     ext_id: str
     family_id: str
     members: dict[str, FamilyMembers] = Field(default_factory=dict)
-    phenotypes: dict[str, str] = Field(default_factory=dict)
+    phenotypes: list[dict[str, str]] = Field(default_factory=list)
     panel_ids: list[int] = Field(default_factory=list)
     panel_names: list[str] = Field(default_factory=list)
     solved: bool = Field(default=False)
@@ -460,7 +460,7 @@ class ModelVariant(BaseModel):
 class ParticipantHPOPanels(BaseModel):
     external_id: str = Field(default_factory=str)
     family_id: str = Field(default_factory=str)
-    hpo_terms: dict[str, str] = Field(default_factory=dict)
+    hpo_terms: list[dict[str, str]] = Field(default_factory=list)
     panels: set[int] = Field(default_factory=set)
 
 

--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -1,6 +1,7 @@
 """
 A home for all data models used in AIP
 """
+
 from enum import Enum
 
 import toml
@@ -67,9 +68,7 @@ class VariantCommon(BaseModel):
     """
 
     coordinates: Coordinates = Field(repr=True)
-    info: dict[
-        str, str | int | float | list[str] | list[float] | dict[str, str] | bool
-    ] = Field(default_factory=dict)
+    info: dict[str, str | int | float | list[str] | list[float] | dict[str, str] | bool] = Field(default_factory=dict)
     het_samples: set[str] = Field(default_factory=set, exclude=True)
     hom_samples: set[str] = Field(default_factory=set, exclude=True)
     boolean_categories: list[str] = Field(default_factory=list, exclude=True)
@@ -144,9 +143,7 @@ class VariantCommon(BaseModel):
         Returns:
             True if support only
         """
-        return self.has_support and not (
-            self.category_non_support or self.sample_categorised_check(sample_id)
-        )
+        return self.has_support and not (self.category_non_support or self.sample_categorised_check(sample_id))
 
     def category_values(self, sample: str) -> set[str]:
         """
@@ -167,11 +164,7 @@ class VariantCommon(BaseModel):
             if sample in self.info[category]  # type: ignore
         }
         categories.update(
-            {
-                bool_cat.replace('categoryboolean', '')
-                for bool_cat in self.boolean_categories
-                if self.info[bool_cat]
-            }
+            {bool_cat.replace('categoryboolean', '') for bool_cat in self.boolean_categories if self.info[bool_cat]},
         )
 
         if self.has_support:
@@ -209,9 +202,7 @@ class VariantCommon(BaseModel):
         Returns:
             True if the variant is categorised for this sample
         """
-        big_cat = self.has_boolean_categories or self.sample_categorised_check(
-            sample_id
-        )
+        big_cat = self.has_boolean_categories or self.sample_categorised_check(sample_id)
         if allow_support:
             return big_cat or self.has_support
         return big_cat
@@ -255,9 +246,7 @@ class SmallVariant(VariantCommon):
         """
         return self.check_ab_ratio(sample) | self.check_read_depth(sample)
 
-    def check_read_depth(
-        self, sample: str, threshold: int = 10, var_is_cat_1: bool = False
-    ) -> set[str]:
+    def check_read_depth(self, sample: str, threshold: int = 10, var_is_cat_1: bool = False) -> set[str]:
         """
         flag low read depth for this sample
 
@@ -286,11 +275,7 @@ class SmallVariant(VariantCommon):
         het = sample in self.het_samples
         hom = sample in self.hom_samples
         variant_ab = self.ab_ratios.get(sample, 0.0)
-        if (
-            (variant_ab <= 0.15)
-            or (het and not 0.25 <= variant_ab <= 0.75)
-            or (hom and variant_ab <= 0.85)
-        ):
+        if (variant_ab <= 0.15) or (het and not 0.25 <= variant_ab <= 0.75) or (hom and variant_ab <= 0.85):
             return {'AB Ratio'}
         return set()
 
@@ -340,10 +325,7 @@ class ReportVariant(BaseModel):
         """
         # self_supvar = set(self.support_vars)
         # other_supvar = set(other.support_vars)
-        return (
-            self.sample == other.sample
-            and self.var_data.coordinates == other.var_data.coordinates
-        )
+        return self.sample == other.sample and self.var_data.coordinates == other.var_data.coordinates
 
     def __lt__(self, other):
         return self.var_data.coordinates < other.var_data.coordinates
@@ -473,8 +455,6 @@ class ModelVariant(BaseModel):
     """
     might be required for the VCF generator
     """
-
-    ...
 
 
 class ParticipantHPOPanels(BaseModel):

--- a/reanalysis/moi_tests.py
+++ b/reanalysis/moi_tests.py
@@ -5,6 +5,7 @@ One class (MoiRunner) to run all the appropriate MOIs on a variant
 Reduce the PanelApp plain text MOI description into a few categories
 We then run a permissive MOI match for the variant
 """
+
 # mypy: ignore-errors
 from abc import abstractmethod
 
@@ -72,9 +73,7 @@ def check_for_second_hit(
 
     partners = comp_hets[sample].get(first_variant, [])
     if require_non_support:
-        return [
-            partner for partner in partners if not partner.sample_support_only(sample)
-        ]
+        return [partner for partner in partners if not partner.sample_support_only(sample)]
     else:
         return partners
 
@@ -150,11 +149,7 @@ class MOIRunner:
 
         moi_matched = []
         for model in self.filter_list:
-            moi_matched.extend(
-                model.run(
-                    principal=principal_var, comp_het=comp_het, partial_pen=partial_pen
-                )
-            )
+            moi_matched.extend(model.run(principal=principal_var, comp_het=comp_het, partial_pen=partial_pen))
         return moi_matched
 
 
@@ -184,9 +179,7 @@ class BaseMoi:
         run all applicable inheritance patterns and finds good fits
         """
 
-    def check_affected_category_depths(
-        self, variant: VARIANT_MODELS, sample_id: str
-    ) -> bool:
+    def check_affected_category_depths(self, variant: VARIANT_MODELS, sample_id: str) -> bool:
         """
 
         Args:
@@ -209,9 +202,7 @@ class BaseMoi:
             return True
         return False
 
-    def check_familial_inheritance(
-        self, sample_id: str, called_variants: set[str], partial_pen: bool = False
-    ) -> bool:
+    def check_familial_inheritance(self, sample_id: str, called_variants: set[str], partial_pen: bool = False) -> bool:
         """
         check for single variant inheritance
         - find the family ID from this sample
@@ -237,21 +228,14 @@ class BaseMoi:
             # complete & incomplete penetrance - affected samples must have the variant
             # complete pen. requires participants to be affected if they have the var
             # if any of these combinations occur, fail the family
-            if (
-                member.affected == PEDDY_AFFECTED
-                and member.sample_id not in called_variants
-            ) or (
-                member.sample_id in called_variants
-                and not partial_pen
-                and not member.affected == PEDDY_AFFECTED
+            if (member.affected == PEDDY_AFFECTED and member.sample_id not in called_variants) or (
+                member.sample_id in called_variants and not partial_pen and not member.affected == PEDDY_AFFECTED
             ):
                 return False
 
         return True
 
-    def get_family_genotypes(
-        self, variant: VARIANT_MODELS, sample_id: str
-    ) -> dict[str, str]:
+    def get_family_genotypes(self, variant: VARIANT_MODELS, sample_id: str) -> dict[str, str]:
         """
 
         Args:
@@ -274,9 +258,7 @@ class BaseMoi:
             """
 
             if variant.coordinates.chrom in X_CHROMOSOME:
-                if sex == 'male' and (
-                    member_id in variant.het_samples or member_id in variant.hom_samples
-                ):
+                if sex == 'male' and (member_id in variant.het_samples or member_id in variant.hom_samples):
                     return 'Hemi'
 
                 if member_id in variant.het_samples:
@@ -294,9 +276,7 @@ class BaseMoi:
         sample_ped_entry = self.pedigree[sample_id]
         family = self.pedigree.families[sample_ped_entry.family_id]
         return {
-            member.sample_id: get_sample_genotype(
-                member_id=member.sample_id, sex=member.sex
-            )
+            member.sample_id: get_sample_genotype(member_id=member.sample_id, sex=member.sex)
             for member in family.samples
         }
 
@@ -347,8 +327,7 @@ class BaseMoi:
                 continue
 
             if (
-                (parent.sample_id in variant_1.het_samples)
-                and (parent.sample_id in variant_2.het_samples)
+                (parent.sample_id in variant_1.het_samples) and (parent.sample_id in variant_2.het_samples)
             ) or parent.affected == PEDDY_AFFECTED:
                 return False
         return True
@@ -407,9 +386,7 @@ class DominantAutosomal(BaseMoi):
 
         # reject support for dominant MOI, apply checks based on var type
         if principal.support_only or not (
-            self.check_frequency_passes(
-                principal.info, self.freq_tests[principal.__class__.__name__]
-            )
+            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
         ):
             return classifications
 
@@ -447,12 +424,10 @@ class DominantAutosomal(BaseMoi):
                     var_data=principal,
                     categories=principal.category_values(sample_id),
                     reasons={self.applied_moi},
-                    genotypes=self.get_family_genotypes(
-                        variant=principal, sample_id=sample_id
-                    ),
+                    genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                     flags=principal.get_sample_flags(sample_id),
                     independent=True,
-                )
+                ),
             )
 
         return classifications
@@ -503,9 +478,7 @@ class RecessiveAutosomalCH(BaseMoi):
 
         # remove if too many homs are present in population databases
         if not (
-            self.check_frequency_passes(
-                principal.info, self.freq_tests[principal.__class__.__name__]
-            )
+            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
             or principal.info.get('categoryboolean1')
         ):
             return classifications
@@ -554,9 +527,7 @@ class RecessiveAutosomalCH(BaseMoi):
                 #     continue
 
                 # check if this is a candidate for comp-het inheritance
-                if not self.check_comp_het(
-                    sample_id=sample_id, variant_1=principal, variant_2=partner_variant
-                ):
+                if not self.check_comp_het(sample_id=sample_id, variant_1=principal, variant_2=partner_variant):
                     continue
 
                 classifications.append(
@@ -567,12 +538,9 @@ class RecessiveAutosomalCH(BaseMoi):
                         var_data=principal,
                         categories=principal.category_values(sample_id),
                         reasons={self.applied_moi},
-                        genotypes=self.get_family_genotypes(
-                            variant=principal, sample_id=sample_id
-                        ),
+                        genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                         support_vars={partner_variant.info['seqr_link']},
-                        flags=principal.get_sample_flags(sample_id)
-                        | partner_variant.get_sample_flags(sample_id),
+                        flags=principal.get_sample_flags(sample_id) | partner_variant.get_sample_flags(sample_id),
                         independent=False,
                     ),
                 )
@@ -621,9 +589,7 @@ class RecessiveAutosomalHomo(BaseMoi):
 
         # remove if too many homs are present in population databases
         if principal.support_only or not (
-            self.check_frequency_passes(
-                principal.info, self.freq_tests[principal.__class__.__name__]
-            )
+            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
             or principal.info.get('categoryboolean1')
         ):
             return classifications
@@ -637,9 +603,7 @@ class RecessiveAutosomalHomo(BaseMoi):
                     self.pedigree[sample_id].affected == PEDDY_AFFECTED
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(
-                sample_id, self.minimum_depth, principal.info.get('categoryboolean1')
-            ):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -657,13 +621,11 @@ class RecessiveAutosomalHomo(BaseMoi):
                     gene=principal.info.get('gene_id'),
                     var_data=principal,
                     categories=principal.category_values(sample_id),
-                    genotypes=self.get_family_genotypes(
-                        variant=principal, sample_id=sample_id
-                    ),
+                    genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                     reasons={self.applied_moi},
                     flags=principal.get_sample_flags(sample_id),
                     independent=True,
-                )
+                ),
             )
 
         return classifications
@@ -726,9 +688,7 @@ class XDominant(BaseMoi):
 
         # never apply dominant MOI to support variants
         # more stringent Pop.Freq checks for dominant - hemi restriction
-        if not self.check_frequency_passes(
-            principal.info, self.freq_tests[principal.__class__.__name__]
-        ):
+        if not self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__]):
             return classifications
 
         # all samples which have a variant call
@@ -743,9 +703,7 @@ class XDominant(BaseMoi):
                     principal.sample_category_check(sample_id, allow_support=False)
                     and self.pedigree[sample_id].affected == PEDDY_AFFECTED
                 )
-            ) or principal.check_read_depth(
-                sample_id, self.minimum_depth, principal.info.get('categoryboolean1')
-            ):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
                 continue
 
             # check if this is a candidate for dominant inheritance
@@ -764,12 +722,10 @@ class XDominant(BaseMoi):
                     var_data=principal,
                     categories=principal.category_values(sample_id),
                     reasons={self.applied_moi},
-                    genotypes=self.get_family_genotypes(
-                        variant=principal, sample_id=sample_id
-                    ),
+                    genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                     flags=principal.get_sample_flags(sample_id),
                     independent=True,
-                )
+                ),
             )
         return classifications
 
@@ -821,19 +777,13 @@ class XRecessiveMale(BaseMoi):
         classifications = []
 
         # remove from analysis if too many homs are present in population databases
-        if not self.check_frequency_passes(
-            principal.info, self.freq_tests[principal.__class__.__name__]
-        ):
+        if not self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__]):
             return classifications
 
         # combine het and hom here, we don't trust the variant callers
         # if hemi count is too high, don't consider males
         # never consider support variants on X for males
-        males = {
-            sam
-            for sam in principal.het_samples.union(principal.hom_samples)
-            if self.pedigree[sam].sex == 'male'
-        }
+        males = {sam for sam in principal.het_samples.union(principal.hom_samples) if self.pedigree[sam].sex == 'male'}
 
         for sample_id in males:
             # specific affected sample category check, never consider support on X for males
@@ -842,9 +792,7 @@ class XRecessiveMale(BaseMoi):
                     self.pedigree[sample_id].affected == PEDDY_AFFECTED
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(
-                sample_id, self.minimum_depth, principal.info.get('categoryboolean1')
-            ):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -862,13 +810,11 @@ class XRecessiveMale(BaseMoi):
                     gene=principal.info.get('gene_id'),
                     var_data=principal,
                     categories=principal.category_values(sample_id),
-                    genotypes=self.get_family_genotypes(
-                        variant=principal, sample_id=sample_id
-                    ),
+                    genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                     reasons={self.applied_moi},
                     flags=principal.get_sample_flags(sample_id),
                     independent=True,
-                )
+                ),
             )
         return classifications
 
@@ -894,9 +840,7 @@ class XRecessiveFemaleHom(BaseMoi):
         self.hom_rec_threshold = get_config()['moi_tests'][GNOMAD_REC_HOM_THRESHOLD]
         self.freq_tests = {
             SmallVariant.__name__: {key: self.hom_rec_threshold for key in INFO_HOMS},
-            StructuralVariant.__name__: {
-                key: self.hom_rec_threshold for key in SV_HOMS
-            },
+            StructuralVariant.__name__: {key: self.hom_rec_threshold for key in SV_HOMS},
         }
         super().__init__(pedigree=pedigree, applied_moi=applied_moi)
 
@@ -918,17 +862,13 @@ class XRecessiveFemaleHom(BaseMoi):
 
         # remove from analysis if too many homs are present in population databases
         if principal.support_only or not (
-            self.check_frequency_passes(
-                principal.info, self.freq_tests[principal.__class__.__name__]
-            )
+            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
             or principal.info.get('categoryboolean1')
         ):
             return classifications
 
         # never consider support homs
-        samples_to_check = {
-            sam for sam in principal.hom_samples if self.pedigree[sam].sex == 'female'
-        }
+        samples_to_check = {sam for sam in principal.hom_samples if self.pedigree[sam].sex == 'female'}
 
         for sample_id in samples_to_check:
             # specific affected sample category check
@@ -937,9 +877,7 @@ class XRecessiveFemaleHom(BaseMoi):
                     self.pedigree[sample_id].affected == PEDDY_AFFECTED
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(
-                sample_id, self.minimum_depth, principal.info.get('categoryboolean1')
-            ):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -957,13 +895,11 @@ class XRecessiveFemaleHom(BaseMoi):
                     gene=principal.info.get('gene_id'),
                     var_data=principal,
                     categories=principal.category_values(sample_id),
-                    genotypes=self.get_family_genotypes(
-                        variant=principal, sample_id=sample_id
-                    ),
+                    genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                     reasons={self.applied_moi},
                     flags=principal.get_sample_flags(sample_id),
                     independent=True,
-                )
+                ),
             )
         return classifications
 
@@ -989,9 +925,7 @@ class XRecessiveFemaleCH(BaseMoi):
         self.hom_rec_threshold = get_config()['moi_tests'][GNOMAD_REC_HOM_THRESHOLD]
         self.freq_tests = {
             SmallVariant.__name__: {key: self.hom_rec_threshold for key in INFO_HOMS},
-            StructuralVariant.__name__: {
-                key: self.hom_rec_threshold for key in SV_HOMS
-            },
+            StructuralVariant.__name__: {key: self.hom_rec_threshold for key in SV_HOMS},
         }
         super().__init__(pedigree=pedigree, applied_moi=applied_moi)
 
@@ -1015,15 +949,11 @@ class XRecessiveFemaleCH(BaseMoi):
 
         # remove from analysis if too many homs are present in population databases
         if not (
-            self.check_frequency_passes(
-                principal.info, self.freq_tests[principal.__class__.__name__]
-            )
+            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
             or principal.info.get('categoryboolean1')
         ):
             return classifications
-        het_females = {
-            sam for sam in principal.het_samples if self.pedigree[sam].sex == 'female'
-        }
+        het_females = {sam for sam in principal.het_samples if self.pedigree[sam].sex == 'female'}
 
         # if het females are present, try and find support
         for sample_id in het_females:
@@ -1034,9 +964,7 @@ class XRecessiveFemaleCH(BaseMoi):
                     self.pedigree[sample_id].affected == PEDDY_AFFECTED
                     and principal.sample_category_check(sample_id, allow_support=True)
                 )
-            ) or principal.check_read_depth(
-                sample_id, self.minimum_depth, principal.info.get('categoryboolean1')
-            ):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
                 continue
 
             for partner in check_for_second_hit(
@@ -1046,25 +974,17 @@ class XRecessiveFemaleCH(BaseMoi):
                 require_non_support=principal.sample_support_only(sample_id),
             ):
                 # allow for de novo check - also screen out high-AF partners
-                if not partner.sample_category_check(
-                    sample_id, allow_support=True
-                ) or not (
-                    self.check_frequency_passes(
-                        partner.info, self.freq_tests[partner.__class__.__name__]
-                    )
+                if not partner.sample_category_check(sample_id, allow_support=True) or not (
+                    self.check_frequency_passes(partner.info, self.freq_tests[partner.__class__.__name__])
                     or partner.info.get('categoryboolean1')
                 ):
                     continue
 
                 # check for minimum depth in partner
-                if partner.check_read_depth(
-                    sample_id, self.minimum_depth, partner.info.get('categoryboolean1')
-                ):
+                if partner.check_read_depth(sample_id, self.minimum_depth, partner.info.get('categoryboolean1')):
                     continue
 
-                if not self.check_comp_het(
-                    sample_id=sample_id, variant_1=principal, variant_2=partner
-                ):
+                if not self.check_comp_het(sample_id=sample_id, variant_1=principal, variant_2=partner):
                     continue
 
                 classifications.append(
@@ -1075,15 +995,12 @@ class XRecessiveFemaleCH(BaseMoi):
                         var_data=principal,
                         categories=principal.category_values(sample_id),
                         reasons={self.applied_moi},
-                        genotypes=self.get_family_genotypes(
-                            variant=principal, sample_id=sample_id
-                        ),
+                        genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                         # needs to comply with Seqr
                         support_vars={partner.info['seqr_link']},
-                        flags=principal.get_sample_flags(sample_id)
-                        | partner.get_sample_flags(sample_id),
+                        flags=principal.get_sample_flags(sample_id) | partner.get_sample_flags(sample_id),
                         independent=False,
-                    )
+                    ),
                 )
 
         return classifications

--- a/reanalysis/seqr_loader.py
+++ b/reanalysis/seqr_loader.py
@@ -10,9 +10,7 @@ import hail as hl
 from cpg_utils.hail_batch import genome_build, reference_path
 
 
-def annotate_cohort(
-    vcf_path, out_mt_path, vep_ht_path, checkpoint_prefix=None, vep_only: bool = False
-):
+def annotate_cohort(vcf_path, out_mt_path, vep_ht_path, checkpoint_prefix=None, vep_only: bool = False):
     """
     Convert VCF to matrix table, annotate for Seqr Loader, add VEP
 
@@ -77,9 +75,7 @@ def annotate_cohort(
         else:
             logger.info('Adding AC/AF/AN attributes from variant_qc')
             mt = hl.variant_qc(mt)
-            mt = mt.annotate_rows(
-                AN=mt.variant_qc.AN, AF=mt.variant_qc.AF[1], AC=mt.variant_qc.AC[1]
-            )
+            mt = mt.annotate_rows(AN=mt.variant_qc.AN, AF=mt.variant_qc.AF[1], AC=mt.variant_qc.AC[1])
             mt = mt.drop('variant_qc')
 
     # don't fail if the AC/AF attributes are an inappropriate type
@@ -101,7 +97,7 @@ def annotate_cohort(
                 'allele_id': mt.clinvar_data.info.ALLELEID,
                 'clinical_significance': hl.delimit(mt.clinvar_data.info.CLNSIG),
                 'gold_stars': mt.clinvar_data.gold_stars,
-            }
+            },
         ),
     )
 

--- a/reanalysis/static_values.py
+++ b/reanalysis/static_values.py
@@ -1,6 +1,7 @@
 """
 This is a placeholder, completely base class to prevent circular imports
 """
+
 import logging
 import sys
 from datetime import datetime
@@ -28,9 +29,7 @@ def get_granular_date():
     return _GRANULAR_DATE
 
 
-def get_logger(
-    logger_name: str = 'AIP-logger', log_level: int = logging.INFO
-) -> logging.Logger:
+def get_logger(logger_name: str = 'AIP-logger', log_level: int = logging.INFO) -> logging.Logger:
     """
     creates a logger instance (so as not to use the root logger)
 
@@ -55,9 +54,7 @@ def get_logger(
         stream_handler.setLevel(log_level)
 
         # create format string for messages
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s %(lineno)d - %(levelname)s - %(message)s'
-        )
+        formatter = logging.Formatter('%(asctime)s - %(name)s %(lineno)d - %(levelname)s - %(message)s')
         stream_handler.setFormatter(formatter)
 
         # set the logger to use this handler

--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -384,6 +384,8 @@ def acmg_filter_submissions(subs: list[Submission]) -> list[Submission]:
     """
 
     # apply the date threshold to all submissions
+    print(ACMG_THRESHOLD.tzinfo)
+    print([sub.date.tzinfo for sub in subs])
     date_filt_subs = [sub for sub in subs if sub.date >= ACMG_THRESHOLD or sub.review_status in STRONG_REVIEWS]
 
     # if this contains results, return only those

--- a/reanalysis/templates/variant_table_child_row.html.jinja
+++ b/reanalysis/templates/variant_table_child_row.html.jinja
@@ -172,8 +172,8 @@
                                 Phenotypes:
                             </dt>
                             <dd class="col-sm-9">
-                            {% for phenotype, description in sample.phenotypes %}
-                                {{ phenotype }} - {{ description }}<br>
+                            {% for phenotype in sample.phenotypes %}
+                                {{ phenotype['id'] }} - {{ phenotype['description'] }}<br>
                             {% endfor %}
                             </dd>
 

--- a/reanalysis/templates/variant_table_child_row.html.jinja
+++ b/reanalysis/templates/variant_table_child_row.html.jinja
@@ -172,8 +172,8 @@
                                 Phenotypes:
                             </dt>
                             <dd class="col-sm-9">
-                            {% for phenotype in sample.phenotypes %}
-                                {{ phenotype }}<br>
+                            {% for phenotype, description in sample.phenotypes %}
+                                {{ phenotype }} - {{ description }}<br>
                             {% endfor %}
                             </dd>
 

--- a/reanalysis/utils.py
+++ b/reanalysis/utils.py
@@ -70,12 +70,8 @@ COHORT_CONFIG: dict | None = None
 COHORT_SEQ_CONFIG: dict | None = None
 
 
-@backoff.on_exception(
-    wait_gen=expo, exception=(TransportQueryError, TransportServerError), max_time=20
-)
-def wrapped_gql_query(
-    query_node: DocumentNode, variables: dict[str, Any] | None = None
-) -> dict[str, Any]:
+@backoff.on_exception(wait_gen=expo, exception=(TransportQueryError, TransportServerError), max_time=20)
+def wrapped_gql_query(query_node: DocumentNode, variables: dict[str, Any] | None = None) -> dict[str, Any]:
     """
     wrapped gql query method, with retries
     uses an exponential backoff retry timer to space out attempts
@@ -155,9 +151,7 @@ def identify_file_type(file_path: str) -> FileTypes | Exception:
     raise TypeError(f'File cannot be definitively typed: {str(extensions)}')
 
 
-@backoff.on_exception(
-    wait_gen=expo, exception=(requests.RequestException, TimeoutError), max_time=20
-)
+@backoff.on_exception(wait_gen=expo, exception=(requests.RequestException, TimeoutError), max_time=20)
 def get_json_response(url):
     """
     takes a request URL, checks for healthy response, returns the JSON
@@ -246,11 +240,7 @@ def get_new_gene_map(
     ]
 
     # collect all genes new in at least one panel
-    new_genes: dict[str, set[int]] = {
-        ensg: content.new
-        for ensg, content in panelapp_data.genes.items()
-        if content.new
-    }
+    new_genes: dict[str, set[int]] = {ensg: content.new for ensg, content in panelapp_data.genes.items() if content.new}
 
     # if there's no panel matching, new applies to everyone
     if pheno_panels is None:
@@ -301,9 +291,7 @@ def get_phase_data(samples, var) -> dict[str, dict[int, str]]:
     # but are un-phased variants
 
     try:
-        for sample, phase, genotype in zip(
-            samples, map(int, var.format('PS')), var.genotypes
-        ):
+        for sample, phase, genotype in zip(samples, map(int, var.format('PS')), var.genotypes):
             # cyvcf2.Variant holds two ints, and a bool
             allele_1, allele_2, phased = genotype
             if not phased:
@@ -316,9 +304,7 @@ def get_phase_data(samples, var) -> dict[str, dict[int, str]]:
         get_logger().info('failed to find PS phase attributes')
         try:
             # retry using PGT & PID
-            for sample, phase_gt, phase_id in zip(
-                samples, var.format('PGT'), var.format('PID')
-            ):
+            for sample, phase_gt, phase_id in zip(samples, var.format('PGT'), var.format('PID')):
                 if phase_gt != '.' and phase_id != '.':
                     phased_dict[sample][phase_id] = phase_gt
         except KeyError:
@@ -395,13 +381,9 @@ def create_small_variant(
         as_singletons ():
         new_genes ():
     """
-    coordinates = Coordinates(
-        chrom=var.CHROM.replace('chr', ''), pos=var.POS, ref=var.REF, alt=var.ALT[0]
-    )
+    coordinates = Coordinates(chrom=var.CHROM.replace('chr', ''), pos=var.POS, ref=var.REF, alt=var.ALT[0])
     depths: dict[str, int] = dict(zip(samples, map(int, var.gt_depths)))
-    info: dict[str, Any] = {x.lower(): y for x, y in var.INFO} | {
-        'seqr_link': coordinates.string_format
-    }
+    info: dict[str, Any] = {x.lower(): y for x, y in var.INFO} | {'seqr_link': coordinates.string_format}
 
     # optionally - ignore some categories from this analysis
     if ignore_cats := get_config()['workflow'].get('ignore_categories'):
@@ -426,13 +408,9 @@ def create_small_variant(
     info = organise_pm5(info)
 
     # set the class attributes
-    boolean_categories = [
-        key for key in info.keys() if key.startswith('categoryboolean')
-    ]
+    boolean_categories = [key for key in info.keys() if key.startswith('categoryboolean')]
     sample_categories = [key for key in info.keys() if key.startswith('categorysample')]
-    support_categories = [
-        key for key in info.keys() if key.startswith('categorysupport')
-    ]
+    support_categories = [key for key in info.keys() if key.startswith('categorysupport')]
 
     # overwrite with true booleans
     for cat in support_categories + boolean_categories:
@@ -446,9 +424,7 @@ def create_small_variant(
         if as_singletons and sam_cat in REMOVE_IN_SINGLETONS:
             info[sam_cat] = set()
         elif isinstance(info[sam_cat], str):
-            info[sam_cat] = (
-                info[sam_cat].split(',') if info[sam_cat] != 'missing' else set()
-            )
+            info[sam_cat] = info[sam_cat].split(',') if info[sam_cat] != 'missing' else set()
         elif isinstance(info[sam_cat], list):
             info[sam_cat] = set(info[sam_cat])
 
@@ -500,9 +476,7 @@ def create_structural_variant(var: cyvcf2.Variant, samples: list[str]):
     het_samples, hom_samples = get_non_ref_samples(variant=var, samples=samples)
 
     # set the class attributes
-    boolean_categories = [
-        key for key in info.keys() if key.startswith('categoryboolean')
-    ]
+    boolean_categories = [key for key in info.keys() if key.startswith('categoryboolean')]
 
     # overwrite with true booleans
     for cat in boolean_categories:
@@ -547,7 +521,7 @@ def gather_gene_dict_from_contig(
     variant_source,
     new_gene_map: dict[str, set[str]],
     singletons: bool = False,
-    sv_source=None,
+    sv_sources: list | None = None,
 ) -> GeneDict:
     """
     takes a cyvcf2.VCFReader instance, and a specified chromosome
@@ -558,9 +532,9 @@ def gather_gene_dict_from_contig(
     Args:
         contig (): contig name from VCF header
         variant_source (): the VCF reader instance
+        sv_sources (): an optional list of SV VCFs
         new_gene_map ():
         singletons ():
-        sv_source (): an optional second VCF (SV)
 
     Returns:
         A lookup in the form
@@ -570,6 +544,8 @@ def gather_gene_dict_from_contig(
             ...
         }
     """
+    if sv_sources is None:
+        sv_sources = []
 
     if 'blacklist' in get_config()['filter']:
         blacklist = read_json_from_path(get_config()['filter']['blacklist'])
@@ -593,9 +569,7 @@ def gather_gene_dict_from_contig(
         )
 
         if small_variant.coordinates.string_format in blacklist:
-            get_logger().info(
-                f'Skipping blacklisted variant: {small_variant.coordinates.string_format}'
-            )
+            get_logger().info(f'Skipping blacklisted variant: {small_variant.coordinates.string_format}')
             continue
 
         # if unclassified, skip the whole variant
@@ -608,21 +582,17 @@ def gather_gene_dict_from_contig(
         # update the gene index dictionary
         contig_dict[small_variant.info.get('gene_id')].append(small_variant)
 
-    if sv_source:
+    for sv_source in sv_sources:
         structural_variants = 0
         for variant in sv_source(contig):
             # create an abstract SV variant
-            structural_variant = create_structural_variant(
-                var=variant, samples=sv_source.samples
-            )
+            structural_variant = create_structural_variant(var=variant, samples=sv_source.samples)
 
             # update the variant count
             structural_variants += 1
 
             # update the gene index dictionary
-            contig_dict[structural_variant.info.get('gene_id')].append(
-                structural_variant
-            )
+            contig_dict[structural_variant.info.get('gene_id')].append(structural_variant)
 
         get_logger().info(f'Contig {contig} contained {structural_variants} SVs')
 
@@ -635,21 +605,8 @@ def gather_gene_dict_from_contig(
 def read_json_from_path(
     bucket_path: str | CPGPathType | None,
     default: Any = None,
-    return_model: HistoricVariants
-    | HistoricPanels
-    | ResultData
-    | PanelApp
-    | PhenotypeMatchedPanels
-    | None = None,
-) -> (
-    list
-    | None
-    | HistoricVariants
-    | HistoricPanels
-    | ResultData
-    | PanelApp
-    | PhenotypeMatchedPanels
-):
+    return_model: HistoricVariants | HistoricPanels | ResultData | PanelApp | PhenotypeMatchedPanels | None = None,
+) -> list | None | HistoricVariants | HistoricPanels | ResultData | PanelApp | PhenotypeMatchedPanels:
     """
     take a path to a JSON file, read into an object
     if the path doesn't exist - return the default object
@@ -764,10 +721,7 @@ def extract_csq(csq_contents: str) -> list[dict]:
     csq_categories = get_config()['csq']['csq_string']
 
     # iterate over all consequences, and make each into a dict
-    txc_dict = [
-        dict(zip(csq_categories, each_csq.split('|')))
-        for each_csq in csq_contents.split(',')
-    ]
+    txc_dict = [dict(zip(csq_categories, each_csq.split('|'))) for each_csq in csq_contents.split(',')]
 
     # update this String to be either a float, or missing
     for each_dict in txc_dict:
@@ -803,9 +757,7 @@ def find_comp_hets(var_list: list[VARIANT_MODELS], pedigree: peddy.Ped) -> CompH
     for var_1, var_2 in combinations_with_replacement(var_list, 2):
         assert var_1.coordinates.chrom == var_2.coordinates.chrom
 
-        if (
-            var_1.coordinates == var_2.coordinates
-        ) or var_1.coordinates.chrom in NON_HOM_CHROM:
+        if (var_1.coordinates == var_2.coordinates) or var_1.coordinates.chrom in NON_HOM_CHROM:
             continue
 
         # iterate over any samples with a het overlap
@@ -820,30 +772,17 @@ def find_comp_hets(var_list: list[VARIANT_MODELS], pedigree: peddy.Ped) -> CompH
             # check for both variants being in the same phase set
             if sample in var_1.phased and sample in var_2.phased:
                 # check for presence of the same phase set
-                for phase_set in [
-                    ps
-                    for ps in var_1.phased[sample].keys()
-                    if ps in var_2.phased[sample].keys()
-                ]:
-                    if (
-                        var_1.phased[sample][phase_set]
-                        == var_2.phased[sample][phase_set]
-                    ):
+                for phase_set in [ps for ps in var_1.phased[sample].keys() if ps in var_2.phased[sample].keys()]:
+                    if var_1.phased[sample][phase_set] == var_2.phased[sample][phase_set]:
                         phased = True
             if not phased:
-                comp_het_results[sample].setdefault(
-                    var_1.coordinates.string_format, []
-                ).append(var_2)
-                comp_het_results[sample].setdefault(
-                    var_2.coordinates.string_format, []
-                ).append(var_1)
+                comp_het_results[sample].setdefault(var_1.coordinates.string_format, []).append(var_2)
+                comp_het_results[sample].setdefault(var_2.coordinates.string_format, []).append(var_1)
 
     return comp_het_results
 
 
-def generate_fresh_latest_results(
-    current_results: ResultData, dataset: str, prefix: str = ''
-):
+def generate_fresh_latest_results(current_results: ResultData, dataset: str, prefix: str = ''):
     """
     This will be called if a cohort has no latest results, but has
     indicated a place to save them.
@@ -853,14 +792,10 @@ def generate_fresh_latest_results(
         prefix (str): optional prefix for the filename
     """
 
-    new_history = HistoricVariants(
-        metadata=CategoryMeta(categories=get_config().get('categories', {}))
-    )
+    new_history = HistoricVariants(metadata=CategoryMeta(categories=get_config().get('categories', {})))
     for sample, content in current_results.results.items():
         for var in content.variants:
-            new_history.results.setdefault(sample, {})[
-                var.var_data.coordinates.string_format
-            ] = HistoricSampleVariant(
+            new_history.results.setdefault(sample, {})[var.var_data.coordinates.string_format] = HistoricSampleVariant(
                 categories={cat: var.first_seen for cat in var.categories},
                 support_vars=list(var.support_vars),
                 independent=var.independent,
@@ -902,14 +837,10 @@ def filter_results(results: ResultData, singletons: bool, dataset: str):
 
     # get latest results as a HistoricVariants object, or fail - on fail, return
     if (
-        latest_results := read_json_from_path(
-            latest_results_path, return_model=HistoricVariants  # type: ignore
-        )
+        latest_results := read_json_from_path(latest_results_path, return_model=HistoricVariants)  # type: ignore
     ) is None:
         # generate and write some new latest data
-        generate_fresh_latest_results(
-            current_results=results, prefix=prefix, dataset=dataset
-        )
+        generate_fresh_latest_results(current_results=results, prefix=prefix, dataset=dataset)
         return
 
     assert isinstance(latest_results, HistoricVariants)
@@ -918,9 +849,7 @@ def filter_results(results: ResultData, singletons: bool, dataset: str):
     save_new_historic(results=latest_results, prefix=prefix, dataset=dataset)
 
 
-def save_new_historic(
-    results: HistoricVariants | HistoricPanels, dataset: str, prefix: str = ''
-):
+def save_new_historic(results: HistoricVariants | HistoricPanels, dataset: str, prefix: str = ''):
     """
     save the new results in the historic results dir
 
@@ -942,9 +871,7 @@ def save_new_historic(
     get_logger().info(f'Wrote new data to {new_file}')
 
 
-def find_latest_file(
-    dataset: str, results_folder: str | None = None, start: str = '', ext: str = 'json'
-) -> str | None:
+def find_latest_file(dataset: str, results_folder: str | None = None, start: str = '', ext: str = 'json') -> str | None:
     """
     takes a directory of files, and finds the latest
     Args:
@@ -1020,9 +947,7 @@ def date_annotate_results(current: ResultData, historic: HistoricVariants):
                         hist.categories[cat] = get_granular_date()
 
                 # same categories, new support
-                elif new_sups := [
-                    sup for sup in var.support_vars if sup not in hist.support_vars
-                ]:
+                elif new_sups := [sup for sup in var.support_vars if sup not in hist.support_vars]:
                     hist.support_vars.extend(new_sups)
 
                 # otherwise alter the first_seen date

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -14,9 +14,9 @@ for each variant in each participant, check MOI in affected
 participants relative to the MOI described in PanelApp
 """
 
+from argparse import ArgumentParser
 from collections import defaultdict
 
-import click
 from cyvcf2 import VCFReader
 from peddy.peddy import Ped
 
@@ -158,9 +158,7 @@ def apply_moi_to_variants(
             # Flag! If this is a Category 1 (ClinVar) variant, and we are
             # interpreting under a lenient MOI, add flag for analysts
             # control this in just one place
-            if panel_gene_data.moi == 'Mono_And_Biallelic' and variant.info.get(
-                'categoryboolean1', False
-            ):
+            if panel_gene_data.moi == 'Mono_And_Biallelic' and variant.info.get('categoryboolean1', False):
                 # consider each variant in turn
                 for each_result in variant_results:
                     # never tag if this variant/sample is de novo
@@ -210,17 +208,13 @@ def clean_and_filter(
     # for these categories, require a phenotype-gene match
     cats_require_pheno_match = get_config()['category_rules'].get('phenotype_match', [])
 
-    panel_meta: dict[int, str] = {
-        content.id: content.name for content in panelapp_data.metadata
-    }
+    panel_meta: dict[int, str] = {content.id: content.name for content in panelapp_data.metadata}
 
     gene_details: dict[str, set[int]] = {}
 
     for each_event in result_list:
         # shouldn't be possible, here as a precaution
-        assert (
-            each_event.categories
-        ), f'No categories for {each_event.var_data.coordinates.string_format}'
+        assert each_event.categories, f'No categories for {each_event.var_data.coordinates.string_format}'
 
         # find all panels for this gene
         if each_event.gene in gene_details:
@@ -239,9 +233,7 @@ def clean_and_filter(
         # neither step is required if no custom panel data is supplied
         if participant_panels is not None:
             # intersection to find participant phenotype-matched panels
-            phenotype_intersection = participant_panels.samples[
-                each_event.sample
-            ].panels.intersection(all_panels)
+            phenotype_intersection = participant_panels.samples[each_event.sample].panels.intersection(all_panels)
 
             # is this gene relevant for this participant?
             # this test includes matched, cohort-level, and core panel
@@ -297,10 +289,7 @@ def clean_and_filter(
             # combine flags across variants, and remove Ambiguous marking
             # if it's no longer appropriate
             both_flags = {*prev_event.flags, *each_event.flags}
-            if (
-                prev_event.reasons != {'Autosomal Dominant'}
-                and AMBIGUOUS_FLAG in both_flags
-            ):
+            if prev_event.reasons != {'Autosomal Dominant'} and AMBIGUOUS_FLAG in both_flags:
                 both_flags.remove(AMBIGUOUS_FLAG)
             prev_event.flags = both_flags
 
@@ -411,9 +400,7 @@ def prepare_results_shell(
 
     # limit to affected samples present in both Pedigree and VCF
     for sample in [
-        sam
-        for sam in pedigree.samples()
-        if sam.affected == PEDDY_AFFECTED and sam.sample_id in vcf_samples
+        sam for sam in pedigree.samples() if sam.affected == PEDDY_AFFECTED and sam.sample_id in vcf_samples
     ]:
         sample_id = sample.sample_id
         family_id = sample.family_id
@@ -421,15 +408,11 @@ def prepare_results_shell(
         family_members = {
             member.sample_id: FamilyMembers(
                 **{
-                    'sex': str(member.sex)
-                    if str(member.sex) in {'male', 'female'}
-                    else 'unknown',
+                    'sex': str(member.sex) if str(member.sex) in {'male', 'female'} else 'unknown',
                     'affected': member.affected == PEDDY_AFFECTED,
-                    'ext_id': panel_data.samples.get(
-                        member.sample_id, ParticipantHPOPanels()
-                    ).external_id
+                    'ext_id': panel_data.samples.get(member.sample_id, ParticipantHPOPanels()).external_id
                     or member.sample_id,
-                }
+                },
             )
             for member in pedigree.families[family_id]
         }
@@ -444,39 +427,23 @@ def prepare_results_shell(
                         'members': family_members,
                         'phenotypes': sample_panel_data.hpo_terms,
                         'panel_ids': sample_panel_data.panels,
-                        'panel_names': [
-                            panel_meta[panel_id]
-                            for panel_id in sample_panel_data.panels
-                        ],
-                        'solved': bool(
-                            sample_id in solved_cases or family_id in solved_cases
-                        ),
-                    }
+                        'panel_names': [panel_meta[panel_id] for panel_id in sample_panel_data.panels],
+                        'solved': bool(sample_id in solved_cases or family_id in solved_cases),
+                    },
                 ),
-            }
+            },
         )
 
     return results_shell
 
 
-@click.command
-@click.option('--labelled_vcf', help='Category-labelled VCF')
-@click.option('--labelled_sv', help='Category-labelled SV VCF', default=None)
-@click.option('--out_json', help='Prefix to write JSON results to')
-@click.option('--panelapp', help='Path to JSON file of PanelApp data')
-@click.option('--pedigree', help='Path to joint-call PED file')
-@click.option(
-    '--input_path', help='source data', default='Not supplied', show_default=True
-)
-@click.option('--participant_panels', help='panels per participant', default=None)
-@click.option('--dataset', help='optional, dataset to use', default=None)
 def main(
     labelled_vcf: str,
     out_json: str,
     panelapp: str,
     pedigree: str,
     input_path: str,
-    labelled_sv: str | None = None,
+    labelled_sv: list[str] | None = None,
     participant_panels: str | None = None,
     dataset: str | None = None,
 ):
@@ -498,6 +465,13 @@ def main(
         dataset (str): optional, dataset to use
     """
 
+    if dataset is None:
+        dataset = get_config()['workflow']['dataset']
+    assert isinstance(dataset, str)
+
+    if labelled_sv is None:
+        labelled_sv = []
+
     out_json_path = to_path(out_json)
 
     # parse the pedigree from the file
@@ -510,7 +484,9 @@ def main(
     moi_lookup = set_up_moi_filters(panelapp_data=panelapp_data, pedigree=ped)
 
     pheno_panels: PhenotypeMatchedPanels | None = read_json_from_path(
-        participant_panels, return_model=PhenotypeMatchedPanels, default=None  # type: ignore
+        participant_panels,
+        return_model=PhenotypeMatchedPanels,  # type: ignore
+        default=None,  # type: ignore
     )
 
     # create the new gene map
@@ -518,11 +494,18 @@ def main(
 
     result_list: list[ReportVariant] = []
 
+    # collect all sample IDs from each VCF type
+    small_vcf_samples: list[str] = []
+    sv_vcf_samples: list[str] = []
+
     # open the small variant VCF using a cyvcf2 reader
     vcf_opened = VCFReader(labelled_vcf)
+    small_vcf_samples.extend(vcf_opened.samples)
 
     # optional SV behaviour
-    sv_opened = VCFReader(labelled_sv) if labelled_sv else None
+    sv_opened = [VCFReader(sv_vcf) for sv_vcf in labelled_sv]
+    for sv_vcf in sv_opened:
+        sv_vcf_samples.extend(sv_vcf.samples)
 
     # obtain a set of all contigs with variants
     for contig in canonical_contigs_from_vcf(vcf_opened):
@@ -530,7 +513,7 @@ def main(
         contig_dict = gather_gene_dict_from_contig(
             contig=contig,
             variant_source=vcf_opened,
-            sv_source=sv_opened,
+            sv_sources=sv_opened,
             new_gene_map=new_gene_map,
             singletons=bool('singleton' in pedigree),
         )
@@ -541,7 +524,7 @@ def main(
                 moi_lookup=moi_lookup,
                 panelapp_data=panelapp_data.genes,
                 pedigree=ped,
-            )
+            ),
         )
 
     # do we have seqr projects?
@@ -556,7 +539,7 @@ def main(
             'panels': panelapp_data.metadata,
             'container': get_config()['workflow']['driver_image'],
             'projects': [seqr_project] if seqr_project else [],
-        }
+        },
     )
 
     # create a shell to store results in, adds participant metadata
@@ -579,19 +562,36 @@ def main(
     )
 
     # annotate previously seen results using cumulative data file(s)
-    filter_results(
-        results_model, singletons=bool('singleton' in pedigree), dataset=dataset
-    )
+    filter_results(results_model, singletons=bool('singleton' in pedigree), dataset=dataset)
 
     # write the output to long term storage using Pydantic
     # validate the model against the schema, then write the result if successful
     with to_path(out_json_path).open('w') as out_file:
-        out_file.write(
-            ResultData.model_validate(results_model).model_dump_json(indent=4)
-        )
+        out_file.write(ResultData.model_validate(results_model).model_dump_json(indent=4))
 
 
 if __name__ == '__main__':
     get_logger(__file__).info('Starting MOI testing phase')
     get_logger().info(f'Operational Categories: {CATEGORY_DICT}')
-    main()
+
+    parser = ArgumentParser(description='Startup commands for the MOI testing phase of AIP')
+    parser.add_argument('--labelled_vcf', help='Category-labelled VCF')
+    parser.add_argument('--labelled_sv', help='Category-labelled SV VCF', default=[], nargs='+')
+    parser.add_argument('--out_json', help='Prefix to write JSON results to')
+    parser.add_argument('--panelapp', help='Path to JSON file of PanelApp data')
+    parser.add_argument('--pedigree', help='Path to joint-call PED file')
+    parser.add_argument('--input_path', help='source data', default='Not supplied', show_default=True)
+    parser.add_argument('--participant_panels', help='panels per participant', default=None)
+    parser.add_argument('--dataset', help='optional, dataset to use', default=None)
+    args = parser.parse_args()
+
+    main(
+        labelled_vcf=args.labelled_vcf,
+        out_json=args.out_json,
+        panelapp=args.panelapp,
+        pedigree=args.pedigree,
+        input_path=args.input_path,
+        labelled_sv=args.labelled_sv,
+        participant_panels=args.participant_panels,
+        dataset=args.dataset,
+    )

--- a/reanalysis/vep.py
+++ b/reanalysis/vep.py
@@ -129,11 +129,9 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
             flags:array<str>
         }>,
         variant_class:str
-    }"""
+    }""",
     )
-    ht = hl.import_table(
-        paths=vep_result_paths, no_header=True, types={'f0': json_schema}
-    )
+    ht = hl.import_table(paths=vep_result_paths, no_header=True, types={'f0': json_schema})
     ht = ht.transmute(vep=ht.f0)
 
     # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it

--- a/reanalysis/vep_jobs.py
+++ b/reanalysis/vep_jobs.py
@@ -36,9 +36,7 @@ def subset_vcf(
     j.memory('standard')
     j.cpu(2)
 
-    j.declare_resource_group(
-        output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
-    )
+    j.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
     reference = fasta_res_group(b)
     assert isinstance(j.output_vcf, hb.ResourceGroup)
 
@@ -53,7 +51,7 @@ def subset_vcf(
         command(
             cmd,
             monitor_space=True,
-        )
+        ),
     )
     return j
 
@@ -88,19 +86,14 @@ def scatter_intervals(
     """
     assert scatter_count > 0, scatter_count
     sequencing_type = get_config()['workflow']['sequencing_type']
-    source_intervals_path = source_intervals_path or reference_path(
-        f'broad/{sequencing_type}_calling_interval_lists'
-    )
+    source_intervals_path = source_intervals_path or reference_path(f'broad/{sequencing_type}_calling_interval_lists')
 
     if scatter_count == 1:
         # Special case when we don't need to split
         return None, [b.read_input(str(source_intervals_path))]
 
     if output_prefix and to_path(output_prefix / '1.interval_list').exists():
-        return None, [
-            b.read_input(str(output_prefix / f'{idx + 1}.interval_list'))
-            for idx in range(scatter_count)
-        ]
+        return None, [b.read_input(str(output_prefix / f'{idx + 1}.interval_list')) for idx in range(scatter_count)]
 
     j = b.new_job(
         f'Make {scatter_count} intervals for {sequencing_type}',
@@ -174,7 +167,7 @@ def add_vep_jobs(
         **{
             'vcf.gz': str(input_siteonly_vcf_path),
             'vcf.gz.tbi': str(input_siteonly_vcf_path) + '.tbi',
-        }
+        },
     )
 
     input_vcf_parts: list[hb.ResourceGroup] = []
@@ -250,7 +243,7 @@ def gather_vep_json_to_ht(
             [str(p) for p in vep_results_paths],
             str(out_path),
             setup_gcp=True,
-        )
+        ),
     )
     if depends_on:
         j.depends_on(*depends_on)
@@ -296,9 +289,7 @@ def vep_one(
     }
 
     # sexy new plugin - only present in 110 build
-    alpha_missense_plugin = (
-        f'--plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz '
-    )
+    alpha_missense_plugin = f'--plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz '
     j.command(
         f"""\
     FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz
@@ -317,7 +308,7 @@ def vep_one(
     --fasta $FASTA \\
     {alpha_missense_plugin} \
     --plugin LoF,{','.join(f'{k}:{v}' for k, v in loftee_conf.items())}
-    """
+    """,
     )
 
     b.write_output(j.output, str(out_path).replace('.vcf.gz', ''))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 automated installation instructions
 """
 
-
 from setuptools import find_packages, setup
 
 with open('README.md', encoding='utf-8') as handle:
@@ -20,11 +19,7 @@ def read_reqs(filename: str) -> list[str]:
         list[str]: the requirements
     """
     with open(filename, encoding='utf-8') as filehandler:
-        return [
-            line.strip()
-            for line in filehandler
-            if line.strip() and not line.startswith('#')
-        ]
+        return [line.strip() for line in filehandler if line.strip() and not line.startswith('#')]
 
 
 setup(
@@ -33,10 +28,7 @@ setup(
     long_description=readme,
     version='3.2.2',
     author='Matthew Welland, CPG',
-    author_email=(
-        'matthew.welland@populationgenomics.org.au, '
-        'cas.simons@populationgenomics.org.au'
-    ),
+    author_email=('matthew.welland@populationgenomics.org.au, ' 'cas.simons@populationgenomics.org.au'),
     package_data={'reanalysis': ['templates/*.jinja', 'reanalysis_global.toml']},
     url='https://github.com/populationgenomics/automated-interpretation-pipeline',
     license='MIT',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,9 +58,7 @@ def fixture_hail_cleanup():
     yield ''
 
     log_files = [
-        filename
-        for filename in PWD.parent.iterdir()
-        if filename.name.startswith('hail') and filename.suffix == '.log'
+        filename for filename in PWD.parent.iterdir() if filename.name.startswith('hail') and filename.suffix == '.log'
     ]
 
     # remove all hail log files
@@ -82,9 +80,7 @@ def fixture_make_a_mt(tmp_path_factory) -> hl.MatrixTable:
         [TXFields('a', 'ensga')],
         sample_data=sample_data,
     )
-    return SneakyTable(
-        [v], sample_details=sample_schema, tmp_path=str(tmp_path)
-    ).to_hail()
+    return SneakyTable([v], sample_details=sample_schema, tmp_path=str(tmp_path)).to_hail()
 
 
 @pytest.fixture(name='make_a_vcf', scope='session')

--- a/test/test_aip_comparison.py
+++ b/test/test_aip_comparison.py
@@ -100,13 +100,9 @@ def test_seqr_parser(seqr_csv_output):
     assert len(list(seqr_results.keys())) == 1
 
     sample_variants = seqr_results.get('PROBAND')
-    assert (
-        len(sample_variants) == 1
-    ), f'Should only be one retained variant: {sample_variants}'
+    assert len(sample_variants) == 1, f'Should only be one retained variant: {sample_variants}'
 
-    assert sample_variants == [
-        CommonFormatResult('17', 10697288, 'G', 'A', [Confidence.POSSIBLE])
-    ]
+    assert sample_variants == [CommonFormatResult('17', 10697288, 'G', 'A', [Confidence.POSSIBLE])]
 
 
 def test_find_missing_matched(caplog):
@@ -124,7 +120,7 @@ def test_find_missing_matched(caplog):
         'match': [
             CommonFormatResult('1', 1, 'A', 'C', [Confidence.POSSIBLE]),
             CommonFormatResult('2', 2, 'A', 'G', [Confidence.POSSIBLE]),
-        ]
+        ],
     }
 
     discrep = find_missing(fake_aip, fake_seqr)
@@ -148,7 +144,7 @@ def test_find_missing_fails(caplog):
     fake_aip = {
         'match': [
             CommonFormatResult('2', 2, 'A', 'G', [Confidence.POSSIBLE]),
-        ]
+        ],
     }
 
     discrep = find_missing(fake_aip, fake_seqr)
@@ -173,7 +169,7 @@ def test_find_missing_different_sample(caplog):
     fake_aip = {
         'mismatch': [
             CommonFormatResult('2', 2, 'A', 'G', [Confidence.POSSIBLE]),
-        ]
+        ],
     }
 
     discrep = find_missing(fake_aip, fake_seqr)
@@ -300,9 +296,7 @@ def test_check_gene_is_green(gene, rows, make_a_mt):
         (1, 100, 0, []),
     ],
 )
-def test_ac_threshold(
-    ac: int, an: int, clinvar: int, results: list[str], make_a_mt: hl.MatrixTable
-):
+def test_ac_threshold(ac: int, an: int, clinvar: int, results: list[str], make_a_mt: hl.MatrixTable):
     """
     required fields: alleles, AC, AN
     """
@@ -331,9 +325,7 @@ def test_run_quality_flag_check(
     """
     if filters is None:
         filters = hl.empty_set(t=hl.tstr)
-    anno_mt = make_a_mt.annotate_rows(
-        filters=filters, info=make_a_mt.info.annotate(clinvar_aip=clinvar)
-    )
+    anno_mt = make_a_mt.annotate_rows(filters=filters, info=make_a_mt.info.annotate(clinvar_aip=clinvar))
     assert run_quality_flag_check(anno_mt) == results
 
 

--- a/test/test_clinvar.py
+++ b/test/test_clinvar.py
@@ -2,9 +2,12 @@
 tests for clinvar manual summaries
 """
 
-
 from copy import deepcopy
 from datetime import datetime
+
+import zoneinfo
+
+TIMEZONE = zoneinfo.ZoneInfo('Australia/Brisbane')
 
 from reanalysis.summarise_clinvar_entries import (
     ACMG_THRESHOLD,
@@ -81,9 +84,9 @@ def tests_acmg_filter_neutral():
 def tests_acmg_filter_removes():
     """filter submissions against ACMG date threshold"""
     sub1 = deepcopy(BASIC_SUB)
-    sub1.date = datetime(year=1970, month=1, day=1)
+    sub1.date = datetime(year=1970, month=1, day=1, tzinfo=TIMEZONE)
     sub2 = deepcopy(BASIC_SUB)
-    sub2.date = datetime(year=2000, month=1, day=1)
+    sub2.date = datetime(year=2000, month=1, day=1, tzinfo=TIMEZONE)
     subs = [BASIC_SUB, sub1, sub2]
     assert acmg_filter_submissions(subs) == [BASIC_SUB]
 
@@ -197,7 +200,7 @@ def test_process_line():
     allele, sub = process_line(input_list)
     assert allele == 1
     assert sub.classification == Consequence.PATHOGENIC
-    assert sub.date == datetime(year=2021, month=7, day=13)
+    assert sub.date == datetime(year=2021, month=7, day=13, tzinfo=TIMEZONE)
     assert sub.submitter == 'submitter'
     assert sub.review_status == '6'
 
@@ -220,7 +223,7 @@ def test_process_line_no_date():
     allele, sub = process_line(input_list)
     assert allele == 1
     assert sub.classification == Consequence.BENIGN
-    assert sub.date == datetime(year=1970, month=1, day=1)
+    assert sub.date == datetime(year=1970, month=1, day=1, tzinfo=TIMEZONE)
     assert sub.submitter == 'submitter'
     assert sub.review_status == '6'
 
@@ -235,7 +238,7 @@ def test_get_all_decisions(sub_stub):
     allele_ids = {1, 2, 3, 4}
     results = get_all_decisions(
         sub_stub,
-        threshold_date=datetime(year=2018, day=1, month=1),
+        threshold_date=datetime(year=2018, day=1, month=1, tzinfo=TIMEZONE),
         allele_ids=allele_ids,
     )
 

--- a/test/test_clinvar.py
+++ b/test/test_clinvar.py
@@ -20,7 +20,7 @@ from reanalysis.summarise_clinvar_entries import (
     process_line,
 )
 
-CURRENT_TIME = datetime.now()
+CURRENT_TIME = datetime.now(tz=TIMEZONE)
 BASIC_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.UNKNOWN, 'review')
 BENIGN_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.BENIGN, 'review')
 PATH_SUB = Submission(CURRENT_TIME, 'submitter', Consequence.PATHOGENIC, 'review')

--- a/test/test_generate_pedigree.py
+++ b/test/test_generate_pedigree.py
@@ -20,7 +20,7 @@ DIRTY_PED = [
         'maternal_id': 'sam3',
         'sex': 1,
         'affected': 1,
-    }
+    },
 ]
 
 
@@ -63,9 +63,7 @@ def test_get_clean_pedigree():
 
     :return:
     """
-    cleaned = get_ped_with_permutations(
-        pedigree_dicts=deepcopy(DIRTY_PED), ext_lookup=SAMPLE_TO_CPG
-    )
+    cleaned = get_ped_with_permutations(pedigree_dicts=deepcopy(DIRTY_PED), ext_lookup=SAMPLE_TO_CPG)
     assert cleaned == [
         {
             'family_id': 'FAM1',
@@ -74,5 +72,5 @@ def test_get_clean_pedigree():
             'maternal_id': ['cpg3'],
             'sex': 1,
             'affected': 1,
-        }
+        },
     ]

--- a/test/test_hail_broad_filters.py
+++ b/test/test_hail_broad_filters.py
@@ -25,9 +25,7 @@ from reanalysis.hail_filter_and_label import (
         (50, 50, 1, 0.01, 1),
     ],
 )
-def test_ac_filter_no_filt(
-    ac: int, an: int, clinvar: int, threshold: float, rows: int, make_a_mt
-):
+def test_ac_filter_no_filt(ac: int, an: int, clinvar: int, threshold: float, rows: int, make_a_mt):
     """
     run tests on the ac filtering method
     check that a clinvar pathogenic overrides the AC test
@@ -54,9 +52,7 @@ def test_filter_on_quality_flags(filters, clinvar, length, make_a_mt):
     """
     # to add new alleles, we need to scrub alleles from the key fields
     anno_matrix = make_a_mt.key_rows_by('locus')
-    anno_matrix = anno_matrix.annotate_rows(
-        filters=filters, info=anno_matrix.info.annotate(clinvar_aip=clinvar)
-    )
+    anno_matrix = anno_matrix.annotate_rows(filters=filters, info=anno_matrix.info.annotate(clinvar_aip=clinvar))
 
     assert filter_on_quality_flags(anno_matrix).count_rows() == length
 

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -53,7 +53,7 @@ def test_class_1_assignment(value, classified, make_a_mt):
     anno_matrix = make_a_mt.annotate_rows(
         info=make_a_mt.info.annotate(
             clinvar_aip_strong=value,
-        )
+        ),
     )
 
     anno_matrix = annotate_category_1(anno_matrix)
@@ -71,9 +71,7 @@ def test_class_1_assignment(value, classified, make_a_mt):
         (0, 1, 'GREEN', 'synonymous', 1),
     ],
 )
-def test_cat_2_assignment(
-    clinvar_aip, c6, gene_id, consequence_terms, classified, make_a_mt
-):
+def test_cat_2_assignment(clinvar_aip, c6, gene_id, consequence_terms, classified, make_a_mt):
     """
     use some fake annotations, apply to the single fake variant
     Args:
@@ -89,9 +87,7 @@ def test_cat_2_assignment(
         geneIds=gene_id,
         info=make_a_mt.info.annotate(clinvar_aip=clinvar_aip, categoryboolean6=c6),
         vep=hl.Struct(
-            transcript_consequences=hl.array(
-                [hl.Struct(consequence_terms=hl.set([consequence_terms]))]
-            ),
+            transcript_consequences=hl.array([hl.Struct(consequence_terms=hl.set([consequence_terms]))]),
         ),
     )
 
@@ -108,9 +104,7 @@ def test_cat_2_assignment(
         (1, hl.missing(hl.tstr), 'frameshift_variant', 1),
     ],
 )
-def test_class_3_assignment(
-    clinvar_aip, loftee, consequence_terms, classified, make_a_mt
-):
+def test_class_3_assignment(clinvar_aip, loftee, consequence_terms, classified, make_a_mt):
     """
 
     Args:
@@ -131,8 +125,8 @@ def test_class_3_assignment(
                     hl.Struct(
                         consequence_terms=hl.set([consequence_terms]),
                         lof=loftee,
-                    )
-                ]
+                    ),
+                ],
             ),
         ),
     )
@@ -154,9 +148,7 @@ def test_category_5_assignment(spliceai_score: float, flag: int, make_a_mt):
         make_a_mt ():
     """
 
-    matrix = make_a_mt.annotate_rows(
-        info=make_a_mt.info.annotate(splice_ai_delta=spliceai_score)
-    )
+    matrix = make_a_mt.annotate_rows(info=make_a_mt.info.annotate(splice_ai_delta=spliceai_score))
     matrix = annotate_category_5(matrix)
     assert matrix.info.categoryboolean5.collect() == [flag]
 
@@ -259,9 +251,7 @@ def test_filter_rows_for_rare(exomes, genomes, clinvar, length, make_a_mt):
 
     """
     anno_matrix = make_a_mt.annotate_rows(
-        info=make_a_mt.info.annotate(
-            gnomad_ex_af=exomes, gnomad_af=genomes, clinvar_aip=clinvar
-        )
+        info=make_a_mt.info.annotate(gnomad_ex_af=exomes, gnomad_af=genomes, clinvar_aip=clinvar),
     )
     matrix = filter_to_population_rare(anno_matrix)
     assert matrix.count_rows() == length
@@ -290,9 +280,7 @@ def test_filter_to_green_genes_and_split(gene_ids, length, make_a_mt):
     anno_matrix = make_a_mt.annotate_rows(
         geneIds=hl.literal(gene_ids),
         vep=hl.Struct(
-            transcript_consequences=hl.array(
-                [hl.Struct(gene_id='gene', biotype='protein_coding', mane_select='')]
-            ),
+            transcript_consequences=hl.array([hl.Struct(gene_id='gene', biotype='protein_coding', mane_select='')]),
         ),
     )
     matrix = split_rows_by_gene_and_filter_to_green(anno_matrix, green_genes)
@@ -312,15 +300,11 @@ def test_filter_to_green_genes_and_split__consequence(make_a_mt):
         vep=hl.Struct(
             transcript_consequences=hl.array(
                 [
-                    hl.Struct(
-                        gene_id='green', biotype='protein_coding', mane_select=''
-                    ),
+                    hl.Struct(gene_id='green', biotype='protein_coding', mane_select=''),
                     hl.Struct(gene_id='green', biotype='batman', mane_select='NM_Bane'),
                     hl.Struct(gene_id='green', biotype='non_coding', mane_select=''),
-                    hl.Struct(
-                        gene_id='NOT_GREEN', biotype='protein_coding', mane_select=''
-                    ),
-                ]
+                    hl.Struct(gene_id='NOT_GREEN', biotype='protein_coding', mane_select=''),
+                ],
             ),
         ),
     )
@@ -360,7 +344,7 @@ def test_filter_to_classified(one, two, three, four, five, six, pm5, length, mak
             categoryboolean5=five,
             categoryboolean6=six,
             categorydetailsPM5=pm5,
-        )
+        ),
     )
     matrix = filter_to_categorised(anno_matrix)
     assert matrix.count_rows() == length
@@ -389,9 +373,7 @@ def test_aip_clinvar_default(make_a_mt):
         ('pathogenic', 1, 1, 1, 1),
     ],
 )
-def test_annotate_aip_clinvar(
-    rating, stars, rows, regular, strong, tmp_path, make_a_mt
-):
+def test_annotate_aip_clinvar(rating, stars, rows, regular, strong, tmp_path, make_a_mt):
     """
     Test intention
     - take a VCF of two variants w/default clinvar annotations
@@ -409,8 +391,8 @@ def test_annotate_aip_clinvar(
                     'clinical_significance': rating,
                     'gold_stars': stars,
                     'allele_id': 1,
-                }
-            ]
+                },
+            ],
         ),
         key=['locus', 'alleles'],
     )
@@ -427,10 +409,5 @@ def test_annotate_aip_clinvar(
 
     returned_table = annotate_aip_clinvar(make_a_mt)
     assert returned_table.count_rows() == rows
-    assert (
-        len([x for x in returned_table.info.clinvar_aip.collect() if x == 1]) == regular
-    )
-    assert (
-        len([x for x in returned_table.info.clinvar_aip_strong.collect() if x == 1])
-        == strong
-    )
+    assert len([x for x in returned_table.info.clinvar_aip.collect() if x == 1]) == regular
+    assert len([x for x in returned_table.info.clinvar_aip_strong.collect() if x == 1]) == strong

--- a/test/test_html_builder.py
+++ b/test/test_html_builder.py
@@ -1,6 +1,7 @@
 """
 tests for the HTML builder
 """
+
 from reanalysis.html_builder import check_date_filter
 from reanalysis.models import Coordinates, ResultData, SmallVariant
 
@@ -28,7 +29,7 @@ def test_check_date_filter(tmp_path):
                             'sample': 'sample1',
                             'first_seen': '2021-01-01',
                             'var_data': VAR_1,
-                        }
+                        },
                     ],
                 },
                 'sample2': {
@@ -38,11 +39,11 @@ def test_check_date_filter(tmp_path):
                             'sample': 'sample1',
                             'first_seen': '2022-02-02',
                             'var_data': VAR_2,
-                        }
+                        },
                     ],
                 },
             },
-        }
+        },
     )
     result_path = str(tmp_path / 'results.json')
     with open(result_path, 'w', encoding='utf-8') as handle:
@@ -52,12 +53,7 @@ def test_check_date_filter(tmp_path):
     assert 'sample1' in filtered_results.results
     assert 'sample2' not in filtered_results.results
     assert filtered_results.results['sample1'].variants[0].first_seen == '2021-01-01'
-    assert (
-        filtered_results.results['sample1']
-        .variants[0]
-        .var_data.coordinates.string_format
-        == '1-1-A-C'
-    )
+    assert filtered_results.results['sample1'].variants[0].var_data.coordinates.string_format == '1-1-A-C'
 
 
 def test_check_date_filter_pair(tmp_path):
@@ -94,11 +90,11 @@ def test_check_date_filter_pair(tmp_path):
                             'sample': 'sample1',
                             'first_seen': '2022-02-02',
                             'var_data': VAR_2,
-                        }
+                        },
                     ],
                 },
             },
-        }
+        },
     )
     result_path = str(tmp_path / 'results.json')
     with open(result_path, 'w', encoding='utf-8') as handle:
@@ -108,9 +104,10 @@ def test_check_date_filter_pair(tmp_path):
     assert 'sample1' in filtered_results.results
     assert 'sample2' not in filtered_results.results
     assert len(filtered_results.results['sample1'].variants) == 2
-    assert sorted(
-        var.first_seen for var in filtered_results.results['sample1'].variants
-    ) == ['2021-01-01', '2023-03-03']
+    assert sorted(var.first_seen for var in filtered_results.results['sample1'].variants) == [
+        '2021-01-01',
+        '2023-03-03',
+    ]
 
 
 def test_check_date_filter_none_pass(tmp_path):
@@ -131,7 +128,7 @@ def test_check_date_filter_none_pass(tmp_path):
                             'sample': 'sample1',
                             'first_seen': '2021-01-01',
                             'var_data': VAR_1,
-                        }
+                        },
                     ],
                 },
                 'sample2': {
@@ -141,11 +138,11 @@ def test_check_date_filter_none_pass(tmp_path):
                             'sample': 'sample2',
                             'first_seen': '2022-02-02',
                             'var_data': VAR_2,
-                        }
+                        },
                     ],
                 },
             },
-        }
+        },
     )
     result_path = str(tmp_path / 'results.json')
     with open(result_path, 'w', encoding='utf-8') as handle:
@@ -168,7 +165,7 @@ def test_check_date_filter_date_from_meta(tmp_path):
                             'sample': 'sample1',
                             'first_seen': '2021-01-01',
                             'var_data': VAR_1,
-                        }
+                        },
                     ],
                 },
                 'sample2': {
@@ -178,11 +175,11 @@ def test_check_date_filter_date_from_meta(tmp_path):
                             'sample': 'sample2',
                             'first_seen': '2022-02-02',
                             'var_data': VAR_2,
-                        }
+                        },
                     ],
                 },
             },
-        }
+        },
     )
     result_path = str(tmp_path / 'results.json')
     with open(result_path, 'w', encoding='utf-8') as handle:
@@ -192,9 +189,4 @@ def test_check_date_filter_date_from_meta(tmp_path):
     assert 'sample1' not in filtered_results.results
     assert 'sample2' in filtered_results.results
     assert filtered_results.results['sample2'].variants[0].first_seen == '2022-02-02'
-    assert (
-        filtered_results.results['sample2']
-        .variants[0]
-        .var_data.coordinates.string_format
-        == '2-2-A-C'
-    )
+    assert filtered_results.results['sample2'].variants[0].var_data.coordinates.string_format == '2-2-A-C'

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -106,13 +106,13 @@ def test_match_participants_to_panels():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {'HP:1', 'HP:2'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
                     'panels': {137},
                 },
                 'participant2': {
                     'external_id': 'participant2',
                     'family_id': 'fam2',
-                    'hpo_terms': {'HP:1', 'HP:6'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:6', 'label': ''}],
                     'panels': {137},
                 },
             },
@@ -129,7 +129,7 @@ def test_match_participants_to_panels():
         **{
             'external_id': 'participant1',
             'family_id': 'fam1',
-            'hpo_terms': {'HP:1', 'HP:2'},
+            'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
             'panels': {137, 101, 102, 2002},
         },
     )
@@ -137,7 +137,7 @@ def test_match_participants_to_panels():
         **{
             'external_id': 'participant2',
             'family_id': 'fam2',
-            'hpo_terms': {'HP:1', 'HP:6'},
+            'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:6', 'label': ''}],
             'panels': {137, 101, 102, 666},
         },
     )
@@ -153,7 +153,7 @@ def test_update_hpo_with_description():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {'HP:1', 'HP:2'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
                     'panels': {137},
                 },
             },
@@ -167,10 +167,10 @@ def test_update_hpo_with_description():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {
-                        'HP:1 - Philosopher\'s Stone',
-                        'HP:2 - Chamber of Secrets',
-                    },
+                    'hpo_terms': [
+                        {'id': 'HP:1', 'label': 'Philosopher\'s Stone'},
+                        {'id': 'HP:2', 'label': 'Chamber of Secrets'},
+                    ],
                     'panels': {137},
                 },
             },

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -2,7 +2,7 @@
 test file for metamist panel-participant matching
 """
 
-import networkx
+import networkx as nx
 import pytest
 from obonet import read_obo
 
@@ -45,12 +45,8 @@ def test_match_hpo_terms(fake_obo_path):
     """
     obo_parsed = read_obo(fake_obo_path)
     panel_map = {'HP:2': {1, 2}}
-    assert match_hpo_terms(
-        panel_map=panel_map, hpo_tree=obo_parsed, hpo_str='HP:4'
-    ) == {1, 2}
-    assert match_hpo_terms(
-        panel_map=panel_map, hpo_tree=obo_parsed, hpo_str='HP:2'
-    ) == {1, 2}
+    assert match_hpo_terms(panel_map=panel_map, hpo_tree=obo_parsed, hpo_str='HP:4') == {1, 2}
+    assert match_hpo_terms(panel_map=panel_map, hpo_tree=obo_parsed, hpo_str='HP:2') == {1, 2}
 
 
 def test_match_hpos_to_panels(fake_obo_path):
@@ -58,9 +54,7 @@ def test_match_hpos_to_panels(fake_obo_path):
     test the hpo-to-panel matching
     """
     panel_map = {'HP:2': {1, 2}, 'HP:5': {5}}
-    assert match_hpos_to_panels(
-        panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}
-    ) == (
+    assert match_hpos_to_panels(panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}) == (
         {
             'HP:4': {1, 2},
             'HP:7a': {5},
@@ -68,9 +62,7 @@ def test_match_hpos_to_panels(fake_obo_path):
         {'HP:4': 'Goblet of Fire', 'HP:7a': 'Deathly Hallows'},
     )
     # full depth from the terminal node should capture all panels
-    assert match_hpos_to_panels(
-        panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}
-    ) == (
+    assert match_hpos_to_panels(panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}) == (
         {
             'HP:4': {1, 2},
             'HP:7a': {5},
@@ -84,8 +76,8 @@ def test_read_hpo_tree(fake_obo_path):
     check that reading the obo tree works
     """
     obo_parsed = read_obo(fake_obo_path)
-    assert isinstance(obo_parsed, networkx.MultiDiGraph)
-    assert list(networkx.bfs_edges(obo_parsed, 'HP:1', reverse=True)) == [
+    assert isinstance(obo_parsed, nx.MultiDiGraph)
+    assert list(nx.bfs_edges(obo_parsed, 'HP:1', reverse=True)) == [
         ('HP:1', 'HP:2'),
         ('HP:2', 'HP:3'),
         ('HP:3', 'HP:4'),
@@ -123,8 +115,8 @@ def test_match_participants_to_panels():
                     'hpo_terms': {'HP:1', 'HP:6'},
                     'panels': {137},
                 },
-            }
-        }
+            },
+        },
     )
     hpo_to_panels = {
         'HP:1': {101, 102},
@@ -139,7 +131,7 @@ def test_match_participants_to_panels():
             'family_id': 'fam1',
             'hpo_terms': {'HP:1', 'HP:2'},
             'panels': {137, 101, 102, 2002},
-        }
+        },
     )
     assert party_hpo.samples['participant2'] == ParticipantHPOPanels(
         **{
@@ -147,7 +139,7 @@ def test_match_participants_to_panels():
             'family_id': 'fam2',
             'hpo_terms': {'HP:1', 'HP:6'},
             'panels': {137, 101, 102, 666},
-        }
+        },
     )
 
 
@@ -163,9 +155,9 @@ def test_update_hpo_with_description():
                     'family_id': 'fam1',
                     'hpo_terms': {'HP:1', 'HP:2'},
                     'panels': {137},
-                }
-            }
-        }
+                },
+            },
+        },
     )
     hpo_to_desc = {'HP:1': 'Philosopher\'s Stone', 'HP:2': 'Chamber of Secrets'}
     hpo_dict = update_hpo_with_description(hpo_dict, hpo_to_desc)
@@ -180,7 +172,7 @@ def test_update_hpo_with_description():
                         'HP:2 - Chamber of Secrets',
                     },
                     'panels': {137},
-                }
-            }
-        }
+                },
+            },
+        },
     )

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -56,10 +56,7 @@ def test_check_second_hit(first, comp_hets, sample, values):
     :return:
     """
 
-    assert (
-        check_for_second_hit(first_variant=first, comp_hets=comp_hets, sample=sample)
-        == values
-    )
+    assert check_for_second_hit(first_variant=first, comp_hets=comp_hets, sample=sample) == values
 
 
 @pytest.mark.parametrize(
@@ -115,7 +112,7 @@ def test_dominant_autosomal_fails_on_depth(peddy_ped):
         depths={'male': 1},
         transcript_consequences=[],
     )
-    results = dom.run(principal=shallow_variant)  # noqa
+    results = dom.run(principal=shallow_variant)
     assert len(results) == 0
 
 
@@ -396,9 +393,7 @@ def test_recessive_autosomal_comp_het_fails_no_paired_call(peddy_ped):
     )
 
 
-@pytest.mark.parametrize(
-    'info', [{'gnomad_hom': 3, 'gene_id': 'TEST1'}]
-)  # threshold is 2
+@pytest.mark.parametrize('info', [{'gnomad_hom': 3, 'gene_id': 'TEST1'}])  # threshold is 2
 def test_recessive_autosomal_hom_fails(info, peddy_ped):
     """
     check that when the info values are failures
@@ -434,7 +429,7 @@ def test_x_dominant_female_and_male_het_passes(peddy_ped):
 
     assert len(results) == 2
     reasons = {result.reasons.pop() for result in results}
-    assert reasons == {'X_Dominant', 'X_Dominant'}
+    assert reasons == {'X_Dominant'}
 
 
 def test_x_dominant_female_hom_passes(peddy_ped):
@@ -708,9 +703,7 @@ def test_check_familial_inheritance_simple(peddy_ped):
 
     base_moi = BaseMoi(pedigree=peddy_ped, applied_moi='applied')
 
-    result = base_moi.check_familial_inheritance(
-        sample_id='male', called_variants={'male'}
-    )
+    result = base_moi.check_familial_inheritance(sample_id='male', called_variants={'male'})
     assert result
 
 
@@ -722,9 +715,7 @@ def test_check_familial_inheritance_mother_fail(peddy_ped):
 
     base_moi = BaseMoi(pedigree=peddy_ped, applied_moi='applied')
 
-    result = base_moi.check_familial_inheritance(
-        sample_id='male', called_variants={'male', 'mother_1'}
-    )
+    result = base_moi.check_familial_inheritance(sample_id='male', called_variants={'male', 'mother_1'})
     assert not result
 
 
@@ -753,9 +744,7 @@ def test_check_familial_inheritance_father_fail(peddy_ped):
 
     base_moi = BaseMoi(pedigree=peddy_ped, applied_moi='applied')
 
-    result = base_moi.check_familial_inheritance(
-        sample_id='male', called_variants={'male', 'father_1'}
-    )
+    result = base_moi.check_familial_inheritance(sample_id='male', called_variants={'male', 'father_1'})
     assert not result
 
 

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -133,7 +133,7 @@ def test_panel_query_addition(fake_panelapp):
                     'panels': [123, 137],
                 },
             },
-        }
+        },
     )
 
     # should query for and integrate the incidentalome content
@@ -168,11 +168,7 @@ def test_get_best_moi_mono():
     check that the MOI summary works
     """
 
-    d = {
-        'ensg1': PanelDetail(
-            **{'all_moi': {'monoallelic'}, 'chrom': '1', 'symbol': 'ensg1'}
-        )
-    }
+    d = {'ensg1': PanelDetail(**{'all_moi': {'monoallelic'}, 'chrom': '1', 'symbol': 'ensg1'})}
     get_best_moi(d)
     assert d['ensg1'].moi == 'Monoallelic'
 
@@ -182,11 +178,7 @@ def test_get_best_moi_mono_and_biallelic():
     check that the MOI summary works
     """
 
-    d = {
-        'ensg1': PanelDetail(
-            **{'all_moi': {'monoallelic', 'biallelic'}, 'chrom': '1', 'symbol': 'ensg1'}
-        )
-    }
+    d = {'ensg1': PanelDetail(**{'all_moi': {'monoallelic', 'biallelic'}, 'chrom': '1', 'symbol': 'ensg1'})}
     get_best_moi(d)
     assert d['ensg1'].moi == 'Mono_And_Biallelic'
 
@@ -202,8 +194,8 @@ def test_get_best_moi_1():
                 'all_moi': {'Monoallelic', 'Biallelic', 'both'},
                 'chrom': '1',
                 'symbol': 'ensg1',
-            }
-        )
+            },
+        ),
     }
     get_best_moi(d)
     assert d['ensg1'].moi == 'Mono_And_Biallelic'
@@ -220,8 +212,8 @@ def test_get_best_moi_x():
                 'all_moi': {'x-linked biallelic', 'x-linked'},
                 'chrom': 'X',
                 'symbol': 'ensgX',
-            }
-        )
+            },
+        ),
     }
     get_best_moi(d)
     assert d['ensg1'].moi == 'Hemi_Mono_In_Female'

--- a/test/test_results_comparison.py
+++ b/test/test_results_comparison.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from os.path import join
 from time import sleep
 
+import zoneinfo
+
 from reanalysis.models import (
     Coordinates,
     HistoricSampleVariant,
@@ -21,22 +23,16 @@ from reanalysis.utils import date_annotate_results, find_latest_file
 COORD_1 = Coordinates(chrom='1', pos=1, ref='A', alt='G')
 COORD_2 = Coordinates(chrom='2', pos=2, ref='A', alt='G')
 
+TIMEZONE = zoneinfo.ZoneInfo('Australia/Brisbane')
+
 VAR_1 = SmallVariant(coordinates=COORD_1, info={}, transcript_consequences=[])
 VAR_2 = SmallVariant(coordinates=COORD_2, info={}, transcript_consequences=[])
-REP_SAM1_1 = ReportVariant(
-    sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1'
-)
-REP_SAM1_1_Independent = ReportVariant(
-    sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1', independent=True
-)
-REP_SAM2_2 = ReportVariant(
-    sample='sam2', var_data=VAR_2, categories={'2'}, gene='ENSG2', independent=True
-)
-REP_SAM2_12 = ReportVariant(
-    sample='sam2', var_data=VAR_2, categories={'1', '2'}, gene='ENSG2'
-)
+REP_SAM1_1 = ReportVariant(sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1')
+REP_SAM1_1_Independent = ReportVariant(sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1', independent=True)
+REP_SAM2_2 = ReportVariant(sample='sam2', var_data=VAR_2, categories={'2'}, gene='ENSG2', independent=True)
+REP_SAM2_12 = ReportVariant(sample='sam2', var_data=VAR_2, categories={'1', '2'}, gene='ENSG2')
 
-OLD_DATE = datetime(year=2000, month=1, day=1).strftime('%Y-%m-%d')
+OLD_DATE = datetime(year=2000, month=1, day=1, tzinfo=TIMEZONE).strftime('%Y-%m-%d')
 
 
 def test_date_annotate_one():
@@ -49,9 +45,9 @@ def test_date_annotate_one():
                 'sam1': {
                     'variants': [deepcopy(REP_SAM1_1)],
                     'metadata': {'ext_id': 'jeff', 'family_id': 'jeff'},
-                }
-            }
-        }
+                },
+            },
+        },
     )
     historic = HistoricVariants(
         **{
@@ -60,10 +56,10 @@ def test_date_annotate_one():
                     VAR_1.coordinates.string_format: {
                         'categories': {'1': OLD_DATE},
                         'independent': False,
-                    }
-                }
-            }
-        }
+                    },
+                },
+            },
+        },
     )
     date_annotate_results(results, historic)
     assert results.results['sam1'].variants[0].first_seen == OLD_DATE
@@ -79,9 +75,9 @@ def test_date_annotate_two():
                 'sam2': {
                     'metadata': {'ext_id': 'sam2', 'family_id': '2'},
                     'variants': [deepcopy(REP_SAM2_12)],
-                }
-            }
-        }
+                },
+            },
+        },
     )
     prior_results = deepcopy(results)
     historic = HistoricVariants(
@@ -91,18 +87,15 @@ def test_date_annotate_two():
                     COORD_2.string_format: {
                         'categories': {'1': OLD_DATE},
                         'independent': False,
-                    }
-                }
-            }
-        }
+                    },
+                },
+            },
+        },
     )
     date_annotate_results(results, historic)
     assert len(historic.results['sam2'][COORD_2.string_format].categories) == 2
     assert historic.results['sam2'][COORD_2.string_format].categories['1'] == OLD_DATE
-    assert (
-        historic.results['sam2'][COORD_2.string_format].categories['2']
-        == get_granular_date()
-    )
+    assert historic.results['sam2'][COORD_2.string_format].categories['2'] == get_granular_date()
     assert results == prior_results
 
 
@@ -116,9 +109,9 @@ def test_date_annotate_three():
                 'sam1': {
                     'metadata': {'ext_id': 'sam1', 'family_id': '1'},
                     'variants': [deepcopy(REP_SAM1_1_Independent)],
-                }
-            }
-        }
+                },
+            },
+        },
     )
     historic = HistoricVariants(
         **{
@@ -128,10 +121,10 @@ def test_date_annotate_three():
                         'categories': {'1': OLD_DATE},
                         'support_vars': ['flipflop'],
                         'independent': False,
-                    }
-                }
-            }
-        }
+                    },
+                },
+            },
+        },
     )
     date_annotate_results(results, historic)
     assert historic.results['sam1'][COORD_1.string_format] == HistoricSampleVariant(
@@ -139,7 +132,7 @@ def test_date_annotate_three():
             'categories': {'1': get_granular_date()},
             'support_vars': ['flipflop'],
             'independent': True,
-        }
+        },
     )
 
 
@@ -158,8 +151,8 @@ def test_date_annotate_four():
                     'metadata': {'ext_id': 'sam2', 'family_id': '2'},
                     'variants': [deepcopy(REP_SAM2_2)],
                 },
-            }
-        }
+            },
+        },
     )
     historic = HistoricVariants(
         **{
@@ -167,23 +160,17 @@ def test_date_annotate_four():
                 'sam1': {COORD_1.string_format: {'categories': {'2': OLD_DATE}}},
                 'sam3': {},
             },
-        }
+        },
     )
     date_annotate_results(results, historic)
     assert historic == HistoricVariants(
         **{
             'results': {
-                'sam1': {
-                    COORD_1.string_format: {
-                        'categories': {'1': get_granular_date(), '2': OLD_DATE}
-                    }
-                },
-                'sam2': {
-                    COORD_2.string_format: {'categories': {'2': get_granular_date()}}
-                },
+                'sam1': {COORD_1.string_format: {'categories': {'1': get_granular_date(), '2': OLD_DATE}}},
+                'sam2': {COORD_2.string_format: {'categories': {'2': get_granular_date()}}},
                 'sam3': {},
             },
-        }
+        },
     )
 
 
@@ -217,9 +204,7 @@ def test_find_latest_singletons(tmp_path):
     touch(join(tmp_str, 'file2.json'))
     sleep(0.2)
     touch(join(tmp_str, 'file3.json'))
-    assert 'singletons_file1.json' in find_latest_file(
-        results_folder=tmp_str, start='singletons', dataset='cohort'
-    )
+    assert 'singletons_file1.json' in find_latest_file(results_folder=tmp_str, start='singletons', dataset='cohort')
 
 
 def test_find_latest_with_ext(tmp_path):
@@ -232,6 +217,4 @@ def test_find_latest_with_ext(tmp_path):
     touch(join(tmp_str, 'file2.txt'))
     sleep(0.2)
     touch(join(tmp_str, 'file3.json'))
-    assert 'file2.txt' in find_latest_file(
-        results_folder=tmp_str, ext='txt', dataset='cohort'
-    )
+    assert 'file2.txt' in find_latest_file(results_folder=tmp_str, ext='txt', dataset='cohort')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -46,7 +46,6 @@ def test_abs_var_sorting(two_trio_abs_variants: list[SmallVariant]):
 
     var1, var2 = two_trio_abs_variants
     assert var1 < var2
-    assert var1 == var1
     assert sorted([var2, var1]) == [var1, var2]
     # not sure if I should be able to just override the chrom...
     var1.coordinates.chrom = 'HLA1234'
@@ -176,9 +175,7 @@ def test_gene_dict(two_trio_variants_vcf):
     """
     reader = VCFReader(two_trio_variants_vcf)
     contig = 'chr20'
-    var_dict = gather_gene_dict_from_contig(
-        contig=contig, variant_source=reader, new_gene_map={}
-    )
+    var_dict = gather_gene_dict_from_contig(contig=contig, variant_source=reader, new_gene_map={})
     assert len(var_dict) == 1
     assert 'ENSG00000075043' in var_dict
     assert len(var_dict['ENSG00000075043']) == 2
@@ -198,10 +195,11 @@ def test_comp_hets(two_trio_abs_variants: list[SmallVariant], peddy_ped):
     ch_dict = find_comp_hets(two_trio_abs_variants, pedigree=peddy_ped)
     assert 'male' in ch_dict
     results = ch_dict.get('male')
+    assert isinstance(results, dict)
     assert len(results) == 2
     key_1, key_2 = list(results.keys())
-    assert results[key_1][0].coordinates.string_format == key_2
-    assert results[key_2][0].coordinates.string_format == key_1
+    assert results[key_1][0].coordinates.string_format == key_2  # type: ignore
+    assert results[key_2][0].coordinates.string_format == key_1  # type: ignore
 
 
 def test_phased_dict(phased_vcf_path):
@@ -210,7 +208,9 @@ def test_phased_dict(phased_vcf_path):
     """
     reader = VCFReader(phased_vcf_path)
     var_dict = gather_gene_dict_from_contig(
-        contig='chr20', variant_source=reader, new_gene_map={'ENSG00000075043': {'all'}}
+        contig='chr20',
+        variant_source=reader,
+        new_gene_map={'ENSG00000075043': {'all'}},
     )
     assert len(var_dict) == 1
     assert 'ENSG00000075043' in var_dict
@@ -296,12 +296,10 @@ def test_new_gene_map_complex():
                 'ENSG2': {'new': {137}, 'symbol': 'ensg2'},
                 'ENSG3': {'new': {4}, 'symbol': 'ensg3'},
                 'ENSG4': {'new': {2}, 'symbol': 'ensg4'},
-            }
-        }
+            },
+        },
     )
-    personal_panels = PhenotypeMatchedPanels(
-        **{'samples': {'sam': {'panels': {1, 2}}, 'sam2': {'panels': {4, 2}}}}
-    )
+    personal_panels = PhenotypeMatchedPanels(**{'samples': {'sam': {'panels': {1, 2}}, 'sam2': {'panels': {4, 2}}}})
     result = get_new_gene_map(panel_data, personal_panels)
     assert result == {
         'ENSG1': {'sam'},

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -2,7 +2,6 @@
 script testing methods within reanalysis/validate_categories.py
 """
 
-
 from reanalysis.models import (  # ReportPanel,
     Coordinates,
     PanelApp,
@@ -22,15 +21,9 @@ TEST_COORDS = Coordinates(chrom='1', pos=1, ref='A', alt='C')
 TEST_COORDS_2 = Coordinates(chrom='2', pos=2, ref='G', alt='T')
 VAR_1 = SmallVariant(coordinates=TEST_COORDS, info={}, transcript_consequences=[])
 VAR_2 = SmallVariant(coordinates=TEST_COORDS_2, info={}, transcript_consequences=[])
-REP_SAM1_1 = ReportVariant(
-    sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1'
-)
-REP_SAM3_1 = ReportVariant(
-    sample='sam3', var_data=VAR_1, categories={'1'}, gene='ENSG4'
-)
-REP_SAM3_2 = ReportVariant(
-    sample='sam3', var_data=VAR_2, categories={'2'}, gene='ENSG5'
-)
+REP_SAM1_1 = ReportVariant(sample='sam1', var_data=VAR_1, categories={'1'}, gene='ENSG1')
+REP_SAM3_1 = ReportVariant(sample='sam3', var_data=VAR_1, categories={'1'}, gene='ENSG4')
+REP_SAM3_2 = ReportVariant(sample='sam3', var_data=VAR_2, categories={'2'}, gene='ENSG5')
 
 
 dirty_data = [REP_SAM1_1, REP_SAM3_1, REP_SAM3_2]
@@ -50,7 +43,7 @@ panel_genes = PanelApp(
             'ENSG4': {'panels': {3}, 'new': [3], 'symbol': 'G4'},
             'ENSG5': {'panels': {4}, 'symbol': 'G5'},
         },
-    }
+    },
 )
 
 
@@ -76,7 +69,7 @@ def test_results_shell(peddy_ped):
                 },
             },
             'all_panels': {1, 2, 3},
-        }
+        },
     )
     panelapp = PanelApp(
         **{
@@ -86,7 +79,7 @@ def test_results_shell(peddy_ped):
                 {'id': 3, 'name': 'etc'},
             ],
             'genes': {'ENSG1': {'symbol': 'G1'}},
-        }
+        },
     )
     result_meta = ResultMeta(input_file='', cohort='cohort')
     shell = prepare_results_shell(
@@ -155,8 +148,8 @@ def test_results_shell(peddy_ped):
                         'solved': True,
                     },
                 },
-            }
-        }
+            },
+        },
     )
 
     assert shell.results == expected.results
@@ -173,8 +166,8 @@ def test_gene_clean_results_no_personal():
                 'sam1': {'metadata': {'ext_id': 'sam1', 'family_id': 'family_1'}},
                 'sam2': {'metadata': {'ext_id': 'sam2', 'family_id': 'family_2'}},
                 'sam3': {'metadata': {'ext_id': 'sam3', 'family_id': 'family_3'}},
-            }
-        }
+            },
+        },
     )
 
     clean = clean_and_filter(
@@ -216,8 +209,8 @@ def test_gene_clean_results_personal():
                         'panel_ids': {1},
                     },
                 },
-            }
-        }
+            },
+        },
     )
     personal_panels = PhenotypeMatchedPanels(
         **{
@@ -225,8 +218,8 @@ def test_gene_clean_results_personal():
                 'sam1': {'panels': {1}, 'hpo_terms': {'HP1'}},
                 'sam2': {'hpo_terms': {'HP2'}},
                 'sam3': {'panels': {3, 4}, 'hpo_terms': {'HP3'}},
-            }
-        }
+            },
+        },
     )
 
     clean = clean_and_filter(

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -60,12 +60,12 @@ def test_results_shell(peddy_ped):
                 'male': {
                     'panels': {1, 3},
                     'external_id': 'MALE!',
-                    'hpo_terms': {'Boneitis'},
+                    'hpo_terms': [{'id': 'HBP', 'label': 'Boneitis'}],
                 },
                 'female': {
                     'panels': {1, 2},
                     'external_id': 'FEMALE!',
-                    'hpo_terms': {'HPfemale'},
+                    'hpo_terms': [{'id': 'HBF', 'label': 'Female'}],
                 },
             },
             'all_panels': {1, 2, 3},
@@ -116,7 +116,7 @@ def test_results_shell(peddy_ped):
                                 'ext_id': 'mother_1',
                             },
                         },
-                        'phenotypes': ['Boneitis'],
+                        'phenotypes': [{'id': 'HBP', 'label': 'Boneitis'}],
                         'panel_ids': [1, 3],
                         'panel_names': ['lorem', 'etc'],
                     },
@@ -142,7 +142,7 @@ def test_results_shell(peddy_ped):
                                 'ext_id': 'mother_2',
                             },
                         },
-                        'phenotypes': ['HPfemale'],
+                        'phenotypes': [{'id': 'HBF', 'label': 'Female'}],
                         'panel_ids': [1, 2],
                         'panel_names': ['lorem', 'ipsum'],
                         'solved': True,
@@ -215,9 +215,9 @@ def test_gene_clean_results_personal():
     personal_panels = PhenotypeMatchedPanels(
         **{
             'samples': {
-                'sam1': {'panels': {1}, 'hpo_terms': {'HP1'}},
-                'sam2': {'hpo_terms': {'HP2'}},
-                'sam3': {'panels': {3, 4}, 'hpo_terms': {'HP3'}},
+                'sam1': {'panels': {1}, 'hpo_terms': [{'id': 'HP1', 'label': 'hp1_description'}]},
+                'sam2': {'hpo_terms': [{'id': 'HP2', 'label': 'hp2_description'}]},
+                'sam3': {'panels': {3, 4}, 'hpo_terms': [{'id': 'HP3', 'label': 'hp3_description'}]},
             },
         },
     )


### PR DESCRIPTION
# Fixes

  - Not sure if this is required, setting as a draft
  - I used to store HPO terms as a list of Strings. Recently this changed to `HPO - Text Description`. That packaging is going to make it harder to pull out just the HPO terms 

## Proposed Changes

  - Takes the list of compound Strings and changes it to a dictionary of `{'HPO': 'Description'}`
  - Later it should be pretty easy to pull out just the HPO terms if required for phenotype matching

## Checklist

- [x] Linting checks pass