### PR TITLE
show_default fix

### DIFF
--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -577,7 +577,7 @@ if __name__ == '__main__':
     parser.add_argument('--out_json', help='Prefix to write JSON results to')
     parser.add_argument('--panelapp', help='Path to JSON file of PanelApp data')
     parser.add_argument('--pedigree', help='Path to joint-call PED file')
-    parser.add_argument('--input_path', help='source data', default='Not supplied', show_default=True)
+    parser.add_argument('--input_path', help='source data', default='Not supplied')
     parser.add_argument('--participant_panels', help='panels per participant', default=None)
     parser.add_argument('--dataset', help='optional, dataset to use', default=None)
     args = parser.parse_args()


### PR DESCRIPTION
# Fixes

  - `show_default` is not a valid argument to argparse - CoPilot led me astray. Looks like `show_default` is a valid argument for the Lua version of the library, but not for Python, so this was causing startup failures.
  - A while back I removed some checkpoints from the Hail process - the recent runtimes are WAY higher than I would expect, so reinstating some checkpoints to see if that alleviates the issue.

## Proposed Changes

  - Remove bad argument from argparse
  - adds checkpoints back in to match a previous state ([here](https://github.com/populationgenomics/automated-interpretation-pipeline/blob/2fbb058d728bf12d82c6c4b14c7c118a64ab8dd4/reanalysis/hail_filter_and_label.py))

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
