### PR TITLE
ClinVar Re-processing Updates

### DIFF
--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -48,7 +48,6 @@ PATH_SIGS = {
 UNCERTAIN_SIGS = {'Uncertain significance', 'Uncertain risk allele'}
 
 NO_STAR_RATINGS: set[str] = {'no assertion criteria provided'}
-USELESS_RATINGS: set[str] = set()
 
 MAJORITY_RATIO: float = 0.6
 MINORITY_RATIO: float = 0.2
@@ -342,7 +341,6 @@ def get_all_decisions(submission_file: str, allele_ids: set[int]) -> dict[int, l
         if (
             (a_id not in allele_ids)
             or (line_sub.submitter in blacklist)
-            or (line_sub.review_status in USELESS_RATINGS)
             or (line_sub.classification == Consequence.UNKNOWN)
         ):
             continue

--- a/reanalysis/summarise_clinvar_entries.py
+++ b/reanalysis/summarise_clinvar_entries.py
@@ -31,6 +31,7 @@ import zoneinfo
 
 import hail as hl
 
+from cpg_utils import to_path
 from cpg_utils.hail_batch import init_batch
 
 from reanalysis.static_values import get_logger
@@ -561,12 +562,12 @@ def main(subs: str, variants: str, output_root: str):
     complete_decisions_sorted = sort_decisions(complete_decisions)
 
     # write out the JSON version of these results
-    json_output = 'local.json'
+    json_output = f'{output_root}.json'
     get_logger().info(f'temp JSON location: {json_output}')
 
     # open this temp path and write the json contents, line by line
     # the HT generation will take the file path, not a list of dictionaries
-    with open(json_output, 'w', encoding='utf-8') as handle:
+    with to_path(json_output).open('w') as handle:
         for each_dict in complete_decisions_sorted:
             handle.write(f'{json.dumps(each_dict)}\n')
 

--- a/test/test_clinvar.py
+++ b/test/test_clinvar.py
@@ -70,8 +70,8 @@ def test_check_stars_none():
 
     """
     sub1 = deepcopy(BASIC_SUB)
-    sub1.review_status = 'smithsonian'
-    subs = [BASIC_SUB, sub1, BASIC_SUB]
+    sub1.review_status = 'no assertion criteria provided'
+    subs = [sub1]
     assert check_stars(subs) == 0
 
 
@@ -236,16 +236,15 @@ def test_get_all_decisions(sub_stub):
     4 has one uncertain significance
     """
     allele_ids = {1, 2, 3, 4}
-    results = get_all_decisions(
-        sub_stub,
-        threshold_date=datetime(year=2018, day=1, month=1, tzinfo=TIMEZONE),
-        allele_ids=allele_ids,
-    )
+    results = get_all_decisions(sub_stub, allele_ids=allele_ids)
 
-    assert set(results.keys()) == {2, 4}
+    assert set(results.keys()) == {2, 3, 4}
     assert len(results.get(2)) == 2
+    assert len(results.get(3)) == 1
     assert len(results.get(4)) == 1
     for each in results[2]:
+        assert each.classification == Consequence.PATHOGENIC
+    for each in results[3]:
         assert each.classification == Consequence.PATHOGENIC
     for each in results[4]:
         assert each.classification == Consequence.UNCERTAIN


### PR DESCRIPTION
# Fixes

  - There is a bug [here](https://github.com/populationgenomics/automated-interpretation-pipeline/blob/4aa541f/reanalysis/summarise_clinvar_entries.py#L345) - if no filtering date is specified, this removes undated submissions. The correct action would be to only remove un-dated if a date filter is being applied
  - The current version of the submission generation removes all entries with 'no assertion criteria provided', but in the AIP category logic we accommodate 0-star reviews. The current format cannot create 0-star clinvar ratings.
  - The ClinvArbitration version was already patched to deal with ClinVar's weird approach to PAR regions - X and Y versions of the same variant share a single ID. This results in us dropping some chrX variants.

## Proposed Changes

  - Takes the latest version from https://github.com/populationgenomics/ClinvArbitration (with some CPG/cloud changes - that version is intended to work offline)
  - Removes the date threshold argument completely, it's extra complication we don't intend to use in production
  - Removes 'useless ratings' in favour of 'no star ratings'
  - Clanges the clinvar_runner script to match latest changes

I'm going to smash this through in test to make sure it makes sense: https://batch.hail.populationgenomics.org.au/batches/444425