### PR TITLE
Add gene level hpo matching to main workflow.

### DIFF
--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -297,6 +297,7 @@ class ReportPanel(BaseModel):
 
     forced: set[str] = Field(default_factory=set)
     matched: set[str] = Field(default_factory=set)
+    gene_level_phenotype_matches: set[str] = Field(default_factory=set)
 
 
 class ReportVariant(BaseModel):

--- a/reanalysis/validate_categories.py
+++ b/reanalysis/validate_categories.py
@@ -270,11 +270,14 @@ def clean_and_filter(
         # Find gene level phenotypes matches
         gene_level_phenotype_matches = set()
         if phenotypes_by_gene_symbol and semsimian:
+
+            # TODO: This will fails phenotypes_by_gene_symbol is indexed by symbol and
+            # each_event.gene is ENSGID. Need to fix it here or when we create phenotypes_by_gene_symbol.
             gene_phenotypes = phenotypes_by_gene_symbol.get(each_event.gene)
 
             if each_event.phenotypes and gene_phenotypes:
                 # Compare two sets of phenotypes. For each patient phenotype ("subject set"),
-                # find the closest term in the gene associated phenotypes ("subject set")
+                # find the closest term in the gene associated phenotypes ("object set")
                 # and annotate with a IC similarity score.
                 termset_similarity = semsimian.termset_pairwise_similarity(
                     each_event.phenotypes,


### PR DESCRIPTION
## Proposed Changes

Attempts to add genlevel phenotype matching to main workflow. This is currently broken, but I thought it might help discussion. 

Uses Semsimian package to compare patient phenotypes with phenotypes associated with gene. If one or more terms are above the similarity threshold then it is considered a phenotype match.

Currently reports the result as part of the panels object. This "fits" in terms of being functionally similar, but we may want to think about renaming this.

Questions:
- Is this the right place to put this, or should it go somewhere else?
- where do we handle regular downolad up to date versions of phenotype and hpo db files? Needs to ne done each month-ish.
- genes_to_phenotype file has gene symbol and NCBI gene ID. How/where do we map to ENSGIDs

Todo:
- [ ] Add  Semsimian package as a dependency
- [ ] Download up to date versions of phenotype and hpo db files. 
- [ ] Localise phenotype and hpo db files and pass paths
- [ ] Add min similarity score to config
