### PR TITLE
Adds versions to models

### DIFF
--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -15,6 +15,7 @@ AIP_CONF = toml.load(str(to_path(__file__).parent / 'reanalysis_global.toml'))
 CATEGORY_DICT = AIP_CONF['categories']
 NON_HOM_CHROM = ['X', 'Y', 'MT', 'M']
 CHROM_ORDER = list(map(str, range(1, 23))) + NON_HOM_CHROM
+MODEL_VERSION = '1.0.0'
 
 
 class FileTypes(Enum):
@@ -358,10 +359,12 @@ class PanelShort(BaseModel):
 class PanelApp(BaseModel):
     metadata: list[PanelShort] = Field(default_factory=list)
     genes: dict[str, PanelDetail]
+    model_version: str = MODEL_VERSION
 
 
 class HistoricPanels(BaseModel):
     genes: dict[str, set[int]] = Field(default_factory=dict)
+    model_version: str = MODEL_VERSION
 
 
 class CategoryMeta(BaseModel):
@@ -394,6 +397,7 @@ class HistoricVariants(BaseModel):
     metadata: CategoryMeta = Field(default_factory=CategoryMeta)
     # dict - participant ID -> variant -> variant data
     results: dict[str, dict[str, HistoricSampleVariant]] = Field(default_factory=dict)
+    model_version: str = MODEL_VERSION
 
 
 class ResultMeta(BaseModel):
@@ -449,6 +453,7 @@ class ResultData(BaseModel):
 
     results: dict[str, ParticipantResults] = Field(default_factory=dict)
     metadata: ResultMeta = Field(default_factory=ResultMeta)
+    model_version: str = MODEL_VERSION
 
 
 class ModelVariant(BaseModel):
@@ -467,6 +472,7 @@ class ParticipantHPOPanels(BaseModel):
 class PhenotypeMatchedPanels(BaseModel):
     samples: dict[str, ParticipantHPOPanels] = Field(default_factory=dict)
     all_panels: set[int] = Field(default_factory=set)
+    model_version: str = MODEL_VERSION
 
 
 class MiniVariant(BaseModel):


### PR DESCRIPTION
# Fixes

  - The Models used are defined in code, but on file as JSON. We currently have no way of determining whether the current code is correct to parse the model JSON

## Proposed Changes

  - adds a separate model version ID in the codebase (in models.py)
  - adds this model version ID to the JSON objects written to file as a top-level attribute
  - Future changes to the models can cause a change in version number, so reading an object from file becomes a multi-step process:

1. read the model version attr from the JSON data
2. if current != version in file, read as JSON, pass through an adapter method, then parse as a current object (e.g. adding in missing mandatory fields, or changing a string to a list of strings)
4. if current == version in file, parse JSON directly

This will be a starting point, and any breaking future changes to the models will have to come with a method to preserve backwards compatibility

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
