### PR TITLE
Change HPO storage

### DIFF
--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -315,7 +315,7 @@ class ReportVariant(BaseModel):
     independent: bool = Field(default=False)
     labels: set[str] = Field(default_factory=set)
     panels: ReportPanel = Field(default_factory=ReportPanel)
-    phenotypes: set[str] = Field(default_factory=set)
+    phenotypes: list[dict[str, str]] = Field(default_factory=list)
     reasons: set[str] = Field(default_factory=set)
     support_vars: set[str] = Field(default_factory=set)
 
@@ -427,7 +427,7 @@ class ParticipantMeta(BaseModel):
     ext_id: str
     family_id: str
     members: dict[str, FamilyMembers] = Field(default_factory=dict)
-    phenotypes: list[str] = Field(default_factory=list)
+    phenotypes: list[dict[str, str]] = Field(default_factory=list)
     panel_ids: list[int] = Field(default_factory=list)
     panel_names: list[str] = Field(default_factory=list)
     solved: bool = Field(default=False)
@@ -460,7 +460,7 @@ class ModelVariant(BaseModel):
 class ParticipantHPOPanels(BaseModel):
     external_id: str = Field(default_factory=str)
     family_id: str = Field(default_factory=str)
-    hpo_terms: set[str] = Field(default_factory=set)
+    hpo_terms: list[dict[str, str]] = Field(default_factory=list)
     panels: set[int] = Field(default_factory=set)
 
 

--- a/reanalysis/models.py
+++ b/reanalysis/models.py
@@ -15,6 +15,7 @@ AIP_CONF = toml.load(str(to_path(__file__).parent / 'reanalysis_global.toml'))
 CATEGORY_DICT = AIP_CONF['categories']
 NON_HOM_CHROM = ['X', 'Y', 'MT', 'M']
 CHROM_ORDER = list(map(str, range(1, 23))) + NON_HOM_CHROM
+MODEL_VERSION = '1.0.0'
 
 
 class FileTypes(Enum):
@@ -358,10 +359,12 @@ class PanelShort(BaseModel):
 class PanelApp(BaseModel):
     metadata: list[PanelShort] = Field(default_factory=list)
     genes: dict[str, PanelDetail]
+    model_version: str = MODEL_VERSION
 
 
 class HistoricPanels(BaseModel):
     genes: dict[str, set[int]] = Field(default_factory=dict)
+    model_version: str = MODEL_VERSION
 
 
 class CategoryMeta(BaseModel):
@@ -394,6 +397,7 @@ class HistoricVariants(BaseModel):
     metadata: CategoryMeta = Field(default_factory=CategoryMeta)
     # dict - participant ID -> variant -> variant data
     results: dict[str, dict[str, HistoricSampleVariant]] = Field(default_factory=dict)
+    model_version: str = MODEL_VERSION
 
 
 class ResultMeta(BaseModel):
@@ -449,6 +453,7 @@ class ResultData(BaseModel):
 
     results: dict[str, ParticipantResults] = Field(default_factory=dict)
     metadata: ResultMeta = Field(default_factory=ResultMeta)
+    model_version: str = MODEL_VERSION
 
 
 class ModelVariant(BaseModel):
@@ -467,6 +472,7 @@ class ParticipantHPOPanels(BaseModel):
 class PhenotypeMatchedPanels(BaseModel):
     samples: dict[str, ParticipantHPOPanels] = Field(default_factory=dict)
     all_panels: set[int] = Field(default_factory=set)
+    model_version: str = MODEL_VERSION
 
 
 class MiniVariant(BaseModel):

--- a/reanalysis/templates/variant_table_child_row.html.jinja
+++ b/reanalysis/templates/variant_table_child_row.html.jinja
@@ -173,7 +173,7 @@
                             </dt>
                             <dd class="col-sm-9">
                             {% for phenotype in sample.phenotypes %}
-                                {{ phenotype }}<br>
+                                {{ phenotype['id'] }} - {{ phenotype['description'] }}<br>
                             {% endfor %}
                             </dd>
 

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -106,13 +106,13 @@ def test_match_participants_to_panels():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {'HP:1', 'HP:2'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
                     'panels': {137},
                 },
                 'participant2': {
                     'external_id': 'participant2',
                     'family_id': 'fam2',
-                    'hpo_terms': {'HP:1', 'HP:6'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:6', 'label': ''}],
                     'panels': {137},
                 },
             },
@@ -129,7 +129,7 @@ def test_match_participants_to_panels():
         **{
             'external_id': 'participant1',
             'family_id': 'fam1',
-            'hpo_terms': {'HP:1', 'HP:2'},
+            'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
             'panels': {137, 101, 102, 2002},
         },
     )
@@ -137,7 +137,7 @@ def test_match_participants_to_panels():
         **{
             'external_id': 'participant2',
             'family_id': 'fam2',
-            'hpo_terms': {'HP:1', 'HP:6'},
+            'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:6', 'label': ''}],
             'panels': {137, 101, 102, 666},
         },
     )
@@ -153,7 +153,7 @@ def test_update_hpo_with_description():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {'HP:1', 'HP:2'},
+                    'hpo_terms': [{'id': 'HP:1', 'label': ''}, {'id': 'HP:2', 'label': ''}],
                     'panels': {137},
                 },
             },
@@ -167,10 +167,10 @@ def test_update_hpo_with_description():
                 'luke_skywalker': {
                     'external_id': 'participant1',
                     'family_id': 'fam1',
-                    'hpo_terms': {
-                        'HP:1 - Philosopher\'s Stone',
-                        'HP:2 - Chamber of Secrets',
-                    },
+                    'hpo_terms': [
+                        {'id': 'HP:1', 'label': 'Philosopher\'s Stone'},
+                        {'id': 'HP:2', 'label': 'Chamber of Secrets'},
+                    ],
                     'panels': {137},
                 },
             },

--- a/test/test_validate_methods.py
+++ b/test/test_validate_methods.py
@@ -60,12 +60,12 @@ def test_results_shell(peddy_ped):
                 'male': {
                     'panels': {1, 3},
                     'external_id': 'MALE!',
-                    'hpo_terms': {'Boneitis'},
+                    'hpo_terms': [{'id': 'HBP', 'label': 'Boneitis'}],
                 },
                 'female': {
                     'panels': {1, 2},
                     'external_id': 'FEMALE!',
-                    'hpo_terms': {'HPfemale'},
+                    'hpo_terms': [{'id': 'HBF', 'label': 'Female'}],
                 },
             },
             'all_panels': {1, 2, 3},
@@ -116,7 +116,7 @@ def test_results_shell(peddy_ped):
                                 'ext_id': 'mother_1',
                             },
                         },
-                        'phenotypes': ['Boneitis'],
+                        'phenotypes': [{'id': 'HBP', 'label': 'Boneitis'}],
                         'panel_ids': [1, 3],
                         'panel_names': ['lorem', 'etc'],
                     },
@@ -142,7 +142,7 @@ def test_results_shell(peddy_ped):
                                 'ext_id': 'mother_2',
                             },
                         },
-                        'phenotypes': ['HPfemale'],
+                        'phenotypes': [{'id': 'HBF', 'label': 'Female'}],
                         'panel_ids': [1, 2],
                         'panel_names': ['lorem', 'ipsum'],
                         'solved': True,
@@ -215,9 +215,9 @@ def test_gene_clean_results_personal():
     personal_panels = PhenotypeMatchedPanels(
         **{
             'samples': {
-                'sam1': {'panels': {1}, 'hpo_terms': {'HP1'}},
-                'sam2': {'hpo_terms': {'HP2'}},
-                'sam3': {'panels': {3, 4}, 'hpo_terms': {'HP3'}},
+                'sam1': {'panels': {1}, 'hpo_terms': [{'id': 'HP1', 'label': 'hp1_description'}]},
+                'sam2': {'hpo_terms': [{'id': 'HP2', 'label': 'hp2_description'}]},
+                'sam3': {'panels': {3, 4}, 'hpo_terms': [{'id': 'HP3', 'label': 'hp3_description'}]},
             },
         },
     )


### PR DESCRIPTION
# Fixes

  - #378, but clean
  - Currently we have `HPO - description` compound strings in the stored data, which causes issues when we want just HPO IDs downstream

## Proposed Changes

  - Implements a phenopacket entity structure: a dictionary of ID and LABEL
  - all relevant test and model changes to accommodate that
  - I've stacked a PR [here](https://github.com/populationgenomics/automated-interpretation-pipeline/pull/392) which would add model versioning (so model changes like this can be tracked, and the parsing changed to be backwards compatible)

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
