### PR TITLE
Fix model creation bug

### DIFF
--- a/reanalysis/hpo_panel_match.py
+++ b/reanalysis/hpo_panel_match.py
@@ -120,7 +120,7 @@ def get_participant_hpos(dataset: str) -> tuple[PhenotypeMatchedPanels, set[str]
             **{
                 'external_id': sg['sample']['participant']['externalId'],
                 'family_id': fam_id,
-                'hpo_terms': {hpo: '' for hpo in hpos},
+                'hpo_terms': [{hpo: ''} for hpo in hpos],
                 'panels': {137},
             },
         )


### PR DESCRIPTION
# Fixes

  - HPO terms need to be a list of dicts, not single long dict
  - Causes model validation failure

## Proposed Changes

  - This is a fault in parsing new data, not an issue requiring a model liftover method... yet