### PR TITLE
Process all AlphaMissense files

### DIFF
--- a/talos/vep_vcf_to_mt.py
+++ b/talos/vep_vcf_to_mt.py
@@ -196,18 +196,18 @@ def insert_am_annotations_if_missing(mt: hl.MatrixTable, am_table: str | None = 
     # read in the hail table containing alpha missense annotations
     am_ht = hl.read_table(am_table)
 
-    # gross - this needs a conditional application based on the specific transcript
+    # gross - this needs a conditional application based on the specific transcript_id
     mt = mt.annotate_rows(
         vep=mt.vep.annotate(
             transcript_consequences=hl.map(
                 lambda x: x.annotate(
                     am_class=hl.if_else(
-                        x.feature == am_ht[mt.row_key].transcript,
+                        x.feature == am_ht[mt.row_key].transcript_id,
                         am_ht[mt.row_key].am_class,
                         hl.str(''),
                     ),
                     am_pathogenicity=hl.if_else(
-                        x.feature == am_ht[mt.row_key].transcript,
+                        x.feature == am_ht[mt.row_key].transcript_id,
                         am_ht[mt.row_key].am_pathogenicity,
                         hl.float64(0),
                     ),


### PR DESCRIPTION
# Fixes

  - The TSV -> HT script I wrote works for the main-transcript only file, but the all-isoforms file contains an extra column

## Proposed Changes

  - adds a new method to detect the appropriate column to pull data from using the header line
  - flexible for both input files without explicitly requiring a user choice

## Checklist

- [x] Linting checks pass
