### PR TITLE
Fix for empty "Phenotype Match" tooltip

### DIFF
--- a/src/talos/HPOFlagging.py
+++ b/src/talos/HPOFlagging.py
@@ -138,7 +138,7 @@ def annotate_phenotype_matches(result_object: ResultData, gen_phen: dict[str, se
                     if float(match['ancestor_information_content']) > min_similarity
                 }
 
-                # skip if no matches
+                # skip if no matches - don't assign a date if there are no matches
                 if not pheno_matches:
                     continue
 

--- a/src/talos/HPOFlagging.py
+++ b/src/talos/HPOFlagging.py
@@ -137,6 +137,11 @@ def annotate_phenotype_matches(result_object: ResultData, gen_phen: dict[str, se
                     for match in termset_similarity['subject_best_matches']['similarity'].values()
                     if float(match['ancestor_information_content']) > min_similarity
                 }
+
+                # skip if no matches
+                if not pheno_matches:
+                    continue
+
                 if variant.date_of_phenotype_match is None:
                     variant.date_of_phenotype_match = get_granular_date()
 

--- a/src/talos/templates/variant_table.html.jinja
+++ b/src/talos/templates/variant_table.html.jinja
@@ -111,7 +111,7 @@
     </td>
     <td>
         {# Phenotype Match #}
-        {% if variant.phenotype_match_date %}
+        {% if variant.phenotype_matches %}
         Phenotype match!
         <i class="bi bi-file-earmark-medical-fill" data-bs-toggle="tooltip" data-bs-placement="top"
             data-bs-title="Phenotype match: {{variant.phenotype_matches|join(', ')}}"></i>


### PR DESCRIPTION
# Fixes

  - some variants are identified as having a phenotype match, even though they have no matching phenotypes, leading to a weird display
  - There was a little bug in the logic - if a test was being run, a phenotype match date was assigned, even if no matching terms were found

## Proposed Changes

  - only create the report hover-over if there are matching terms
  - don't assign a phenotype match date unless a match was found

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
