### PR TITLE
Feature 433: Remove HPO tree limit

### DIFF
--- a/src/talos/GeneratePanelData.py
+++ b/src/talos/GeneratePanelData.py
@@ -20,7 +20,6 @@ from talos.models import ParticipantHPOPanels, PhenoPacketHpo, PhenotypeMatchedP
 from talos.static_values import get_logger
 
 HPO_RE = re.compile(r'HP:[0-9]+')
-MAX_DEPTH = 3
 
 PANELAPP_HARD_CODED_DEFAULT = 'https://panelapp.agha.umccr.org/api/v1/panels'
 try:
@@ -117,7 +116,6 @@ def match_hpo_terms(
     panel_map: dict[str, set[int]],
     hpo_tree: nx.MultiDiGraph,
     hpo_str: str,
-    layers_scanned: int = 0,
     selections: set[int] | None = None,
 ) -> set[int]:
     """
@@ -132,7 +130,6 @@ def match_hpo_terms(
         panel_map (dict):
         hpo_tree (): a graph object representing the HPO tree
         hpo_str (str): the query HPO term
-        layers_scanned (int): number of layers traversed so far
         selections (set[int]): collected panel IDs so far
 
     Returns:
@@ -146,12 +143,6 @@ def match_hpo_terms(
     if hpo_str in panel_map:
         selections.update(panel_map[hpo_str])
 
-    # at time of writing the constant MAX_DEPTH is 3
-    # i.e. once the HPO tree traversal has reached 3 layers up, stop
-    # layers in this context represents a reduction in term specificity
-    if layers_scanned >= MAX_DEPTH:
-        return selections
-
     # if a node is invalid, recursively call this method for each replacement D:
     # there are simpler ways, just none that are as fun to write
     if not hpo_tree.has_node(hpo_str):
@@ -161,10 +152,10 @@ def match_hpo_terms(
     hpo_node = hpo_tree.nodes[hpo_str]
     if hpo_node.get('is_obsolete', 'false') == 'true':
         for hpo_term in hpo_node.get('replaced_by', []):
-            selections.update(match_hpo_terms(panel_map, hpo_tree, hpo_term, layers_scanned + 1, selections))
+            selections.update(match_hpo_terms(panel_map, hpo_tree, hpo_term, selections))
     # search for parent(s), even if the term is obsolete
     for hpo_term in hpo_node.get('is_a', []):
-        selections.update(match_hpo_terms(panel_map, hpo_tree, hpo_term, layers_scanned + 1, selections))
+        selections.update(match_hpo_terms(panel_map, hpo_tree, hpo_term, selections))
     return selections
 
 

--- a/src/talos/GeneratePanelData.py
+++ b/src/talos/GeneratePanelData.py
@@ -159,11 +159,11 @@ def match_hpo_terms(
     return selections
 
 
-def match_hpos_to_panels(hpo_to_panel_map: dict, hpo_file: str, all_hpos: set[str]) -> tuple[dict, dict[str, str]]:
+def match_hpos_to_panels(hpo_panel_map: dict, hpo_file: str, all_hpos: set[str]) -> tuple[dict, dict[str, str]]:
     """
     take the HPO terms from the participant metadata, and match to panels
     Args:
-        hpo_to_panel_map (dict): panel IDs to all related panels
+        hpo_panel_map (dict): panel IDs to all related panels
         hpo_file (str): path to an obo file containing HPO tree
         all_hpos (set[str]): collection of all unique HPO terms
 
@@ -185,7 +185,7 @@ def match_hpos_to_panels(hpo_to_panel_map: dict, hpo_file: str, all_hpos: set[st
 
     hpo_to_panels = {}
     for hpo in all_hpos:
-        panel_ids = match_hpo_terms(panel_map=hpo_to_panel_map, hpo_tree=hpo_graph, hpo_str=hpo)
+        panel_ids = match_hpo_terms(panel_map=hpo_panel_map, hpo_tree=hpo_graph, hpo_str=hpo)
         hpo_to_panels[hpo] = panel_ids
 
     return hpo_to_panels, hpo_to_text
@@ -252,11 +252,7 @@ def main(ped_file: str, hpo_file: str, panel_out: str | None):
     """
     panels_by_hpo = get_panels()
     hpo_dict, all_hpo = get_participant_hpos(pedigree=ped_file)
-    hpo_to_panels, hpo_to_text = match_hpos_to_panels(
-        hpo_to_panel_map=panels_by_hpo,
-        hpo_file=hpo_file,
-        all_hpos=all_hpo,
-    )
+    hpo_to_panels, hpo_to_text = match_hpos_to_panels(hpo_panel_map=panels_by_hpo, hpo_file=hpo_file, all_hpos=all_hpo)
     match_participants_to_panels(hpo_dict, hpo_to_panels)
 
     # update the HPO terms to be {'id': 'HPO:#', 'label': 'Description'}

--- a/test/test_metamist_hpo.py
+++ b/test/test_metamist_hpo.py
@@ -48,15 +48,16 @@ def test_match_hpo_terms(fake_obo_path):
 def test_match_hpos_to_panels(fake_obo_path):
     """
     test the hpo-to-panel matching
+    this has now been adjusted to account for the full leaf-to-root traversal, instead of stopping at 3 layers
     """
     panel_map = {'HP:2': {1, 2}, 'HP:5': {5}}
     assert match_hpos_to_panels(panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}) == (
-        {'HP:4': {1, 2}, 'HP:7a': {5}},
+        {'HP:4': {1, 2}, 'HP:7a': {1, 2, 5}},
         {'HP:4': 'Goblet of Fire', 'HP:7a': 'Deathly Hallows'},
     )
     # full depth from the terminal node should capture all panels
     assert match_hpos_to_panels(panel_map, fake_obo_path, all_hpos={'HP:4', 'HP:7a'}) == (
-        {'HP:4': {1, 2}, 'HP:7a': {5}},
+        {'HP:4': {1, 2}, 'HP:7a': {1, 2, 5}},
         {'HP:4': 'Goblet of Fire', 'HP:7a': 'Deathly Hallows'},
     )
 


### PR DESCRIPTION
# Fixes

Closes #433 

  - When fuzzy-matching between participant and panel HPO terms we search 3 levels apart in the HPO ontology tree. If no matches are found within that 3-level search, quit searching and move on to the next
  - This 3-level search limit was never based in anything, and nothing has been done to validate that 3 is a good number
  - Limiting the search to 3 tiers also implicitly requires a degree of coordination between recruiting sites and PanelApp curators, which we do not have in place. There's nothing to suggest that the data we process from participant cohorts and PanelApp have tuned matches to within 3 levels of HPO hierarchy, so it's likely we've been missing out on valid matches by cutting our searches short.

## Proposed Changes

  - Removes the max-level cap of 3 completely. The search now becomes 'unbounded', all the way from query term to HPO root

## Checklist

- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
