### PR TITLE
Manually implement request backoff/retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-backoff>=2.2.1
 cloudpathlib[all]>=0.16.0
 cyvcf2>=0.30.18
 dill>=0.3.7


### PR DESCRIPTION
# Fixes

  - the backoff library doesn't work as expected - despite being configured (via the backoff decorator) to use a fibonacci backoff, expanding up to 200 seconds with each additional failure, it's really waiting only a fraction of a second between retries
  - instead of continually attempting to get blood from this particular stone, moving on to a manual reimplementation

## Proposed Changes

  - removes the backoff library as a dependency and in code
  - adds an exponential backoff retry, accepting a range of error modes