### PR TITLE
Enhance download management with partial file handling and summary reporting

### DIFF
--- a/large_files/gather_file.sh
+++ b/large_files/gather_file.sh
@@ -7,6 +7,7 @@ POLL_INTERVAL=1
 SESSION_NAME="download_manager"
 WINDOW_NAME="Downloads"
 TMX_WINDOW_ID=""
+declare -a DOWNLOAD_TARGETS=()
 
 if [ ! -z "$TMX" ] && [ -z "$TMUX" ]; then
   # tmux installed, but not in a tmux session. restart in tmux.
@@ -43,7 +44,26 @@ start_download() {
   if [ -z "$banner" ]; then
     banner="Downloading [$output]"
   fi
-  local cmd="echo \"$banner\"; echo; curl -C - -# -L --fail -o \"$output\" \"$url\";"
+  # Use a temporary partial file so incomplete downloads never appear at the final path.
+  # We keep resume ability by always resuming (-C -) against the .part file and only mv to final name on success.
+  local final="$output"
+  local part_file="${final}.part"
+
+  # Record expected final file for later summary (avoid duplicates)
+  DOWNLOAD_TARGETS+=("$final")
+
+  # If the final file already exists, skip (assume complete). Could add checksum logic here if desired.
+  if [ -f "$final" ]; then
+    echo "[INFO] $final already present, skipping download."
+    return 0
+  fi
+
+  # Banner shown once per (re)attempt.
+  # curl exit codes: 18 = partial file; we keep part_file for later resume.
+  # On success (exit 0) we atomically mv into place.
+  # NOTE: All internal $ variables are escaped (\$) so they are evaluated when the command runs, not now.
+  local script_name="$(basename "$0")"
+  local cmd="echo \"$banner\"; echo; curl -C - -# -L --fail -o \"$part_file\" \"$url\" && mv -f \"$part_file\" \"$final\" || { rc=\$?; if [ \"\$rc\" -ne 0 ]; then echo \"[WARN] $final Download failed for (exit \\${rc}). Restart ${script_name} to gracefully resume download.\"; fi; }"
   if [ -z $TMX ]; then
      ( eval "$cmd" ) &
   else
@@ -135,4 +155,20 @@ fi
 # same for the phenio files
 if [ ! -f "${DECOMPRESSED_PHENIO}" ] && [ -f "${COMPRESSED_PHENIO}" ]; then
     gunzip ${COMPRESSED_PHENIO}
+fi
+
+# Final status summary
+summary_fail=0
+script_name_summary="$(basename "$0")"
+for target in "${DOWNLOAD_TARGETS[@]}"; do
+  if [ ! -f "$target" ]; then
+    echo "[MISSING] $target"
+    summary_fail=$((summary_fail+1))
+  fi
+done
+
+if [ $summary_fail -eq 0 ]; then
+  echo "[SUCCESS] All ${#DOWNLOAD_TARGETS[@]} downloads completed successfully."
+else
+  echo "[SUMMARY] $summary_fail of ${#DOWNLOAD_TARGETS[@]} downloads missing. Restart ${script_name_summary} to gracefully resume."
 fi


### PR DESCRIPTION
# Fixes

  - Currently, if the gather_files.sh is interupted or encounters an error it will leave a partial file at the final expected file path. This could lead to bad things.

## Proposed Changes

  - This change downloads into <name>.part and atomically moves it into place only on success. Resume (-C -) still works by reusing the .part file. 
  - Adds clear warning message on failure with restart instruction.
  - Adds final summary reporting missing files and instructs the user to rerun the script to resume.
  

## Checklist

- [ ] ChangeLog Updated
- [ ] Version Bumped
- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
