### PR TITLE
Always download the latest ClinvArbitration data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@ build
 .github
 .coverage*
 .nextflow
+.git
 
 large_files
+nextflow

--- a/large_files/gather_file.sh
+++ b/large_files/gather_file.sh
@@ -137,10 +137,6 @@ start_download https://github.com/obophenotype/human-phenotype-ontology/releases
 
 start_download https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2025-05-06/genes_to_phenotype.txt
 
-# latest clinvarbitration data
-CLINVAR="clinvarbitration.tar.gz"
-start_download https://zenodo.org/records/17577130/files/ClinvArbitration_Nov_2025_clinvar_decisions.release.tar.gz?download=1 "${CLINVAR}"
-
 # AlphaMissense raw data
 AM="AlphaMissense_hg38.tsv.gz"
 start_download "https://zenodo.org/records/8208688/files/AlphaMissense_hg38.tsv.gz?download=1" "${AM}"

--- a/nextflow/modules/talos/GetLatestClinvArbitrationFile/main.nf
+++ b/nextflow/modules/talos/GetLatestClinvArbitrationFile/main.nf
@@ -1,0 +1,17 @@
+process GetLatestClinvArbitrationFile {
+    publishDir params.large_files, mode: 'copy'
+
+    container params.container
+
+    input:
+        val current_zenodo
+
+    output:
+        path "clinvarbitration_${current_zenodo}.tar.gz"
+
+    shell:
+    '''
+    download_link=$(python -m talos.check_clinvarbitration_zenodo !{current_zenodo} --download)
+    wget "${download_link}" -O clinvarbitration_!{current_zenodo}.tar.gz`
+    '''
+}

--- a/nextflow/modules/talos/GetLatestClinvArbitrationId/main.nf
+++ b/nextflow/modules/talos/GetLatestClinvArbitrationId/main.nf
@@ -1,0 +1,13 @@
+process GetLatestClinvArbitrationId {
+    container params.container
+
+    input:
+        val current_zenodo
+
+    output:
+        stdout
+
+    """
+    python -m talos.check_clinvarbitration_zenodo ${current_zenodo}
+    """
+}

--- a/nextflow/talos.config
+++ b/nextflow/talos.config
@@ -37,8 +37,10 @@ params.panelapp = "${params.processed_annotations}/panelapp_download.json"
 // large files, download these separately! Talos does not provide these
 // see `large_files/README.md` for details
 params.large_files = "large_files"
-// grab the latest release from ClinvArbitration and go
-params.clinvar = "${params.large_files}/clinvarbitration.tar.gz"
+
+// grab the latest release from ClinvArbitration, download if required
+params.clinvar_zenodo = "18218150"
+
 // https://purl.obolibrary.org/obo/hp.obo
 params.hpo = "${params.large_files}/hp.obo"
 // download from https://hpo.jax.org/data/annotations

--- a/src/talos/check_clinvarbitration_zenodo.py
+++ b/src/talos/check_clinvarbitration_zenodo.py
@@ -1,0 +1,59 @@
+"""
+One script to entertain two different behaviours in the ClinvArbitration/Zenodo process
+
+1. given a zenodo ID, we want to locate the latest version of the record
+2. given the latest version of the record, we want to get the download URL for the record's file
+
+This is split into two steps as (AFAIK) Nextflow doesn't handle dynamic output names particularly well, and once we find
+the latest name for a file, we want to check if we already have that downloaded. That makes the process flow:
+
+- start with a zenodo ID
+- use the script to get the latest version of the same record
+- do we already have a file called "clinvarbitration_<that ID>.tar.gz"
+  - if yes, use it as an input channel
+  - if no, rerun this step to get the URL for that file/content, download, and return as a channel
+"""
+
+from argparse import ArgumentParser
+
+import httpx
+
+
+def get_latest_zenodo_record_id(record_id: int, download: bool = False) -> str:
+    """
+    Take a zenodo record ID, find the latest version of that record, return latest ID.
+    Optionally if the behaviour switch `--download` is used, print out the file/content link.
+    """
+
+    manual_retries = 3
+
+    # use this record ID to find the content if we're downloading, or the latest version if we're searching
+    record_url = f'https://zenodo.org/api/records/{record_id}'
+    if not download:
+        record_url += '/versions/latest'
+
+    data = None
+    while manual_retries > 0:
+        manual_retries -= 1
+        try:
+            response = httpx.get(record_url, headers={'Accept': 'application/json'}, timeout=60, follow_redirects=True)
+            data = response.json()
+            if not download:
+                return str(data['recid'])
+        except (httpx.ConnectTimeout, httpx.DecodingError):
+            # Failed to get latest zenodo record ID, retrying
+            continue
+
+    if data is None:
+        raise httpx.DecodingError(f'Failed to get latest zenodo record ID: {record_id}, exhausted retries')
+
+    # navigate to the files, and find the content URL we can use to download
+    return str(data['files'][0]['links']['self'])
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('zenodo_id', type=int)
+    parser.add_argument('--download', action='store_true')
+    args = parser.parse_args()
+    print(get_latest_zenodo_record_id(args.zenodo_id, download=args.download))


### PR DESCRIPTION
# Fixes

  - Currently the codebase is set up to download the ClinvArbitration data once upon initial set up using the [large files download script](https://github.com/populationgenomics/talos/blob/main/large_files/gather_file.sh#L140-L142)
  - [A startup check](https://github.com/populationgenomics/talos/blob/main/src/talos/StartupChecks.py#L287-L290) will fail if the downloaded data is > 2 months old - this check makes sense, but is a PITA for users as the process to download a new one isn't clear.
  - I've partially solved this issue before in TalosAf [here](https://github.com/populationgenomics/talos_af/blob/f05544c7572778d0cc27a5a70acc3457208ffe46/src/talos_af/utils.py#L498-L522), but haven't yet tried to implement that in NextFlow

## Proposed Changes

  - Instead of storing a hard link to an exact ClinvArbitration file, we give the numerical ID of the ClinvArbitration record (e.g. for `https://zenodo.org/records/18218150` - 18218150)
  - First new pipeline step - using the Zenodo API, query for the latest version of that record, return the ID
  - Dynamically put the returned ID into a file Path, and check if it exists (e.g. `<large_files>/clinvarbitration_18218150.tar.gz`)
      - If the file exists (previously downloaded), use that file as the workflow's clinvar input
      - If the file doesn't exist, use the second new pipeline step - take the Zenodo ID, use it to get a URL for the latest record's download link, and pipe that into `wget` to download the file

I ran into issues pretty early on trying to apply conditional syntax predicated on a file existence check. My first naive shot at this looked like:

```
GetLatestClinvArbitrationId(params.clinvar)

if file("${params.large_files}/clinvarbitration_${GetLatestClinvArbitrationId.out}.tar.gz").exists() { 
    ch_clinvar = channel.fromPath("${params.large_files}/clinvarbitration_${GetLatestClinvArbitrationId.out}.tar.gz")
} else {
    ch_clinvar = GetLatestClinvArbitrationFile(GetLatestClinvArbitrationId.out)
}
```

It turns out that `if ... {` and `file("{variables}").exists()` logic is applied at compile time, so it didn't work at all with generating on-the-fly file paths using the value returned from `GetLatestClinvArbitrationId`, so I recruited Gemini.

This now makes use of some NF syntax which blew my little mind. Specifically:

```
// 2. Route the ID based on whether the local file exists
ch_id_route = GetLatestClinvArbitrationId.out.map{ it.trim() }
    .branch { id ->
        def targetFile = file("${params.large_files}/clinvarbitration_${id}.tar.gz")
        exists: targetFile.exists()
            return targetFile
        download: !targetFile.exists()
            return id
    }

// 3. Only run the download process for the 'download' branch
GetLatestClinvArbitrationFile(ch_id_route.download)

// 4. Combine them back: use the existing file OR the newly downloaded one
ch_clinvar_tar = ch_id_route.exists.mix(GetLatestClinvArbitrationFile.out)
```

This is mapping the output of `GetLatestClinvArbitrationId` (plus a newline.trim() on the String) into a `.branch` closure. This applies asynchronous logic to the resulting file path, and has two labelled output branches.

The next step only executes at all if the `!exists` branch was selected. The final output channel is then generated by `mix`ing the previously-existed (file) and didn't-exist (fresh download) channels. 

```bash
executor >  local (2)
[8b/276a0f] process > GetLatestClinvArbitrationId   [100%] 1 of 1, cached: 1 ✔
[f0/2e4e1d] process > GetLatestClinvArbitrationFile [100%] 1 of 1 ✔
[ab/158c62] process > StartupChecks (1)             [100%] 1 of 1 ✔

# second run
executor >  local (7)
[32/97aaca] process > GetLatestClinvArbitrationId   [100%] 1 of 1 ✔
[-        ] process > GetLatestClinvArbitrationFile -
[14/4fc15c] process > StartupChecks (1)             [100%] 1 of 1 ✔
```

## As-yet unresolved

- First, we'll need to get people to use this change before their 2-month grace period is up. There is a config option to disable this clinvar date check, but we really want people to be using the latest & greatest.
- Second, we'll either want to tie the generation of the latest monthly data, and then its subsequent upload to zenodo, to a routinely triggered job, or we want to remove the zenodo connection as a requirement.

The second is spicy, I'm actually not sure if a new version of an existing zenodo record can be created entirely via the API. If we can't do that, we're stuck having to pump out a new version of the ClinvArbitration data each month or two, otherwise even this automated download will fall foul of the download-latest rule.

Currently we're doing this on a routine basis for our internal use of the tool, but it's something worth considering in terms of long-term support. This is still a more user friendly version of what we have, but it's more like a really good band aid than a solution.

A _solution_ would be installing/cloning the ClinvArbitration source code into this repository and calling it on a regular basis to make the first step of the Talos workflow:

 - do we have a file called `<Year>_ <Month>_Clinvarbitration.tar.gz` matching the current year and month?
   - if so use it
   - if not, make it

That would probably be easier than what I've done here, and more sustainable, but leads to the duplication of effort (every site downloads the whole of Clinvar every month).

Basically I was thrilled at the nextflow syntax here, and even if we don't go with this solution, I wanted y'all to look at it. It's cool.

## Checklist

- [ ] ChangeLog Updated
- [ ] Version Bumped
- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
