### PR TITLE
fix(pip-audit): use specific python version

### DIFF
--- a/.github/workflows/security-checks.yaml
+++ b/.github/workflows/security-checks.yaml
@@ -19,3 +19,5 @@ jobs:
           summary: true
           ignore-vulns: |
             GHSA-8qvm-5x2c-j2w7  # Denial of service in protobuf=3.20.2; hail pins this version.
+            CVE-2026-4539  # inefficient RegEx in pygments
+            CVE-2026-21883  # a vuln in bokeh, which is only relevant to bokeh server instances. Hard pin for Hail so can't resolve with pathed version

--- a/.github/workflows/security-checks.yaml
+++ b/.github/workflows/security-checks.yaml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Pip Audit
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
       - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           inputs: .


### PR DESCRIPTION
# Fixes

  - recurrent pip-audit failures as the python version being used can't find the appropriate packages (defaulted to 3.12?)

## Proposed Changes

  - uses the setup-python github action to control the version
  - adds a couple of excluded failures now that tests run properly - one doesn't have a known fix, and the other has a fixed version higher than Hail will accept. In both instances the failure modes won't be encountered by Talos

## Checklist

- ignoring checklist - this is a non-package change, it's just tidying up the repo