### PR TITLE
Cc nf corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The input TSV uses two columns to locate variant input; `path` and `type`. `path
 2. **shards** a directory of pre-sharded multisample VCF fragments, each shard containing all samples.
 3. **ss_vcf_dir** single-sample VCFs, to be merged in the workflow, then sharded. These are detected using a glob, with the file extension controlled by `params.input_vcf_extension` (defaults to "vcf.bgz")
 
-All results from the workflow will be written to a path pattern `{params.outdir}/{cohort}_outputs`. This argument should point to a directory outside this repository, though for demonstration purposes the default is `./nextflow`.
+All results from the workflow will be written to a path pattern `{outputDir}/{cohort}_outputs`. This argument should point to a directory outside this repository, though for demonstration purposes the default is `./nextflow`.
 
 The [main.nf](main.nf) workflow can be used to run both the main workflows, or where the data has been annotated previously, just the Talos workflow:
 

--- a/docs/NextflowConfiguration.md
+++ b/docs/NextflowConfiguration.md
@@ -7,7 +7,6 @@ This README documents the parameters used in the nextflow configuration file. So
 | `large_files`           | Directory containing large external resources (e.g. gnomAD, MANE, AlphaMissense). See [large_files README](../large_files/README.md) for instructions on how to source this content |
 | `processed_annotations` | Output directory for all processed/reformatted data. Cohort/callset independent, to be used across multiple runs.                                                                   |
 | `outputDir`             | Defaults to `processed_annotations`, required for the 'workflow outputs' NextFlow functionality. Override for Annotation/Talos workflow using `-output-dir <path>`                  |
-| `outdir`                | Used to create an output path for all cohort-specific outputs, resulting folder is `{params.outdir}/{cohort}_outputs`                                                               |
 | `input_vcf_extension`   | Linked to `shards`. If a sharded VCF is provided, this argument is the file extension to glob for. By default this is `vcf.bgz`, but could be altered to `vcf.gz`.                  |
 | `alphamissense_tsv`     | Path in `large_files` to the AlphaMissense raw data, reformatted to be used in Hail annotation                                                                                      |
 | `alphamissense_zip`     | Path in `processed_annotations` to the reformatted AlphaMissense data, ready to be used by Echtvar for annotation                                                                   |

--- a/main.nf
+++ b/main.nf
@@ -13,6 +13,8 @@
     nextflow run nextflow/main.nf --input_tsv [path] [other params...]
 */
 
+nextflow.enable.dsl=2
+
 // Import specific workflows
 include { ANNOTATION } from './nextflow/annotation'
 include { TALOS } from './nextflow/talos'

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,6 @@ params {
     // global output directories - should be changed for each deployment
     // the paths in this repository are really just for the test workflow
     processed_annotations = "nextflow/processed_annotations"
-    outdir = "nextflow"
 
     // Large files directory
     large_files = "large_files"
@@ -58,7 +57,6 @@ params {
 }
 
 // Docker configuration - "docker build -t talos:10.0.1 ."
-params.container = 'talos:10.0.1'
 docker.enabled = true
 
 // currently this is only used in the preparation workflow
@@ -72,37 +70,41 @@ process {
 
     // Specific process resource requirements
     withName: 'SplitVcf' {
-        memory = '2 GB'
+        memory = 2.GB
         cpus = 1
     }
     withName: 'AnnotateCsqWithBcftools' {
-        memory = '1 GB'
+        memory = 1.GB
         cpus = 1
     }
     withName: 'AnnotateWithEchtvar' {
         cpus = 1
-        memory = '1 GB'
+        memory = 1.GB
     }
     withName: 'AnnotatedVcfIntoMatrixTable' {
-        memory = '8 GB'
+        memory = 8.GB
         cpus = 4
     }
     withName: 'NormaliseAndRegionFilterVcf' {
-        memory = '1 GB'
+        memory = 1.GB
         cpus = 1
     }
     withName: 'CreateRoiFromGff3' {
-        memory = '2 GB'
+        memory = 2.GB
         cpus = 1
     }
     withName: 'DownloadClinVarFiles' {
-        memory = '2 GB'
+        memory = 2.GB
     }
     withName: 'EncodeAlphaMissense' {
-        memory = '16 GB'
+        memory = 16.GB
     }
     withName: 'ParseAlphaMissense' {
-        memory = '2 GB'
+        memory = 2.GB
+        cpus = 4
+    }
+	withName: 'ResummariseRawSubmissions' {
+        memory = 16.GB
         cpus = 4
     }
 }

--- a/nextflow/annotation.nf
+++ b/nextflow/annotation.nf
@@ -34,17 +34,17 @@ workflow ANNOTATION {
         println "AlphaMissense data must be encoded for echtvar, run the Talos Prep workflow (talos_preparation.nf)"
         exit 1
     }
-    ch_alphamissense_zip = channel.fromPath(params.alphamissense_zip, checkIfExists: true)
+    ch_alphamissense_zip = Channel.fromPath(params.alphamissense_zip, checkIfExists: true)
 
     // check the ensembl BED file has been generated
     if (!file(params.ensembl_bed).exists()) {
         println "Region-Of-Interest BED file has not been prepared, run the Talos Prep workflow (talos_preparation.nf)"
         exit 1
     }
-    ch_bed = channel.fromPath(params.ensembl_bed, checkIfExists: true)
-    ch_merged_bed = channel.fromPath(params.ensembl_merged_bed, checkIfExists: true)
+    ch_bed = Channel.fromPath(params.ensembl_bed, checkIfExists: true)
+    ch_merged_bed = Channel.fromPath(params.ensembl_merged_bed, checkIfExists: true)
 
-    ch_gnomad_zip = channel.fromPath(params.gnomad_zip, checkIfExists: true)
+    ch_gnomad_zip = Channel.fromPath(params.gnomad_zip, checkIfExists: true)
 
     ch_inputs_branched = ch_inputs.branch {
         shards: it[2] == 'shards'

--- a/nextflow/modules/annotation/AnnotateCsqWithBcftools/main.nf
+++ b/nextflow/modules/annotation/AnnotateCsqWithBcftools/main.nf
@@ -6,13 +6,12 @@ process AnnotateCsqWithBcftools {
         path gff3
         path reference
 
-    // publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     output:
         tuple val(cohort), path("${vcf.simpleName}_csq.vcf.bgz")
 
     script:
     """
+    set -euo pipefail
     bcftools index -t ${vcf}
     bcftools csq --force -f "${reference}" \
         --local-csq \

--- a/nextflow/modules/annotation/AnnotateWithEchtvar/main.nf
+++ b/nextflow/modules/annotation/AnnotateWithEchtvar/main.nf
@@ -6,14 +6,12 @@ process AnnotateWithEchtvar {
         path gnomad_zip
         path am_zip
 
-    // publishDir "${params.outdir}/${cohort}_outputs"
-
     output:
         tuple val(cohort), path("${vcf.simpleName}_echtvar.vcf.bgz")
 
     script:
         """
-        set -ex
+        set -euo pipefail
         echtvar anno \
             -e ${gnomad_zip} \
             -e ${am_zip} \

--- a/nextflow/modules/annotation/AnnotatedVcfIntoMatrixTable/main.nf
+++ b/nextflow/modules/annotation/AnnotatedVcfIntoMatrixTable/main.nf
@@ -19,6 +19,6 @@ process AnnotatedVcfIntoMatrixTable {
             --mane ${mane}
 
         # tidy up all checkpoints
-        rm -r checkpoint*
+        rm -rf checkpoint*
         """
 }

--- a/nextflow/modules/annotation/AnnotatedVcfIntoMatrixTable/main.nf
+++ b/nextflow/modules/annotation/AnnotatedVcfIntoMatrixTable/main.nf
@@ -6,15 +6,12 @@ process AnnotatedVcfIntoMatrixTable {
         path gene_bed
         path mane
 
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     output:
         tuple val(cohort), path("${vcf.simpleName}_annotations.mt")
 
     script:
         """
-        set -ex
-
+        set -euo pipefail
         python -m talos.annotation_scripts.annotated_vcf_into_matrixtable \
             --input ${vcf} \
             --gene_bed ${gene_bed} \

--- a/nextflow/modules/annotation/MergeVcfsWithBcftools/main.nf
+++ b/nextflow/modules/annotation/MergeVcfsWithBcftools/main.nf
@@ -1,8 +1,6 @@
 process MergeVcfsWithBcftools {
     container params.container
 
-//     publishDir "${params.outdir}/${cohort}_outputs"
-
     input:
         tuple val(cohort), path(vcfs), path(tbis)
         path ref_genome
@@ -14,7 +12,7 @@ process MergeVcfsWithBcftools {
         // should bump this check earlier tbh - if one VCF don't call this. Maybe just trust users
         def input = (vcfs.collect().size() > 1) ? vcfs.sort{ it.name } : vcfs
         """
-        set -e
+        set -euo pipefail
         # https://github.com/samtools/bcftools/issues/1189
         # "-m none" means don't merge multi-allelic sites, keep everything atomic, we're splitting in the next step
         # -0 to set all missing genotypes to HomWT - gap-filling with Missing (default) reduces the AN, so callset
@@ -23,7 +21,7 @@ process MergeVcfsWithBcftools {
         	--force-single \
         	-m none \
         	-0 \
-        	-Ou \
+        	-Oz \
         	--no-version \
         	-o "${cohort}_merged.vcf.bgz" \
         	$input

--- a/nextflow/modules/annotation/NormaliseAndRegionFilterVcf/main.nf
+++ b/nextflow/modules/annotation/NormaliseAndRegionFilterVcf/main.nf
@@ -9,13 +9,12 @@ process NormaliseAndRegionFilterVcf {
         path bed_file
         path ref_genome
 
-    // publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     output:
         tuple val(cohort), path("${vcf.simpleName}_merged_filtered.vcf.bgz"), path("${vcf.simpleName}_merged_filtered.vcf.bgz.tbi")
 
     script:
     """
+    set -euo pipefail
     tabix ${vcf}
     bcftools norm \
     	-m -any \

--- a/nextflow/modules/annotation/SplitVcf/main.nf
+++ b/nextflow/modules/annotation/SplitVcf/main.nf
@@ -4,13 +4,12 @@ process SplitVcf {
     input:
         tuple val(cohort), path(vcf)
 
-    // publishDir "${params.outdir}/${cohort}_outputs"
-
     output:
         tuple val(cohort), path("split_*.bgz")
 
     script:
     """
+    set -euo pipefail
     # save the header
     bcftools view -h ${vcf} > header.txt
 

--- a/nextflow/modules/prep/AnnotateClinvarWithBcftools/main.nf
+++ b/nextflow/modules/prep/AnnotateClinvarWithBcftools/main.nf
@@ -2,7 +2,7 @@ process AnnotateClinvarWithBcftools {
     container params.container
 
     input:
-        path vcf
+        tuple path(vcf), path(vcf_idx)
         path ref_fa
         path gff3
 
@@ -11,6 +11,7 @@ process AnnotateClinvarWithBcftools {
 
     script:
     """
+    set -euo pipefail
     bcftools csq \
         --force \
         -f "${ref_fa}" \

--- a/nextflow/modules/prep/ConvertSpliceVarDb/main.nf
+++ b/nextflow/modules/prep/ConvertSpliceVarDb/main.nf
@@ -10,6 +10,7 @@ process ConvertSpliceVarDb {
 
 	script:
 		"""
+		set -euo pipefail
 		python -m talos.convert_splice_var_db \
 			--input ${svdb} \
 			--output svdb.ht

--- a/nextflow/modules/prep/CreateRoiFromGff3/main.nf
+++ b/nextflow/modules/prep/CreateRoiFromGff3/main.nf
@@ -2,7 +2,6 @@ process CreateRoiFromGff3 {
     container params.container
 
     // this file is not downloaded at runtime - that presents issues for execution environments
-    // disconnected from the internet
     input:
 		path gff
 
@@ -15,6 +14,7 @@ process CreateRoiFromGff3 {
 
     script:
         """
+        set -euo pipefail
         python -m talos.annotation_scripts.create_roi_from_gff3 \
             --gff3 ${gff} \
             --unmerged_output unsorted_GRCh38.bed \

--- a/nextflow/modules/prep/DownloadClinVarFiles/main.nf
+++ b/nextflow/modules/prep/DownloadClinVarFiles/main.nf
@@ -10,6 +10,7 @@ process DownloadClinVarFiles {
 
     shell:
     """
+    set -euo pipefail
     wget '!{params.submission_summary}' -O submissions_!{timestamp}.txt.gz
     wget '!{params.variant_summary}' -O variants_!{timestamp}.txt.gz
     wget '!{params.submission_summary}.md5' -O submissions.md5

--- a/nextflow/modules/prep/DownloadPanelApp/main.nf
+++ b/nextflow/modules/prep/DownloadPanelApp/main.nf
@@ -10,6 +10,7 @@ process DownloadPanelApp {
 
     script:
     """
+    set -euo pipefail
     python -m talos.download_panelapp \
         --output panelapp_${timestamp}.json \
         --mane ${mane}

--- a/nextflow/modules/prep/EncodeAlphaMissense/main.nf
+++ b/nextflow/modules/prep/EncodeAlphaMissense/main.nf
@@ -9,6 +9,7 @@ process EncodeAlphaMissense {
 
     script:
         """
+        set -euo pipefail
         echtvar encode alphamissense.zip /talos/echtvar/am_config.json ${vcf}
         """
 }

--- a/nextflow/modules/prep/MakeClinvarbitrationPm5/main.nf
+++ b/nextflow/modules/prep/MakeClinvarbitrationPm5/main.nf
@@ -10,6 +10,7 @@ process MakeClinvarbitrationPm5 {
 
     script:
     """
+    set -euo pipefail
     python3 -m clinvarbitration.scripts.clinvar_by_codon \
         -i "${annotated_snv}" \
         -o "clinvarbitration_${timestamp}.pm5"

--- a/nextflow/modules/prep/MakeClinvarbitrationPm5/main.nf
+++ b/nextflow/modules/prep/MakeClinvarbitrationPm5/main.nf
@@ -13,6 +13,6 @@ process MakeClinvarbitrationPm5 {
     python3 -m clinvarbitration.scripts.clinvar_by_codon \
         -i "${annotated_snv}" \
         -o "clinvarbitration_${timestamp}.pm5"
-    rm clinvarbitration_${timestamp}.pm5.tsv
+    rm -f clinvarbitration_${timestamp}.pm5.tsv
     """
 }

--- a/nextflow/modules/prep/ParseAlphaMissense/main.nf
+++ b/nextflow/modules/prep/ParseAlphaMissense/main.nf
@@ -9,6 +9,7 @@ process ParseAlphaMissense {
 
     script:
         """
+        set -euo pipefail
         python -m talos.annotation_scripts.parse_alphamissense \
             --input ${am_tsv} \
             --output alphamissense.vcf.gz

--- a/nextflow/modules/prep/ParseManeIntoJson/main.nf
+++ b/nextflow/modules/prep/ParseManeIntoJson/main.nf
@@ -9,6 +9,7 @@ process ParseManeIntoJson {
 
     script:
     """
+    set -euo pipefail
     python -m talos.annotation_scripts.parse_mane_into_json \
         --input ${mane_summary} \
         --output mane.json \

--- a/nextflow/modules/prep/ResummariseRawSubmissions/main.nf
+++ b/nextflow/modules/prep/ResummariseRawSubmissions/main.nf
@@ -7,8 +7,7 @@ process ResummariseRawSubmissions {
         val timestamp
 
     output:
-        path "clinvarbitration_${timestamp}.vcf.bgz", emit: "vcf"
-        path "clinvarbitration_${timestamp}.vcf.bgz.tbi", emit: "vcf_idx"
+        tuple path("clinvarbitration_${timestamp}.vcf.bgz"), path("clinvarbitration_${timestamp}.vcf.bgz.tbi"), emit: "vcf"
         path "clinvarbitration_${timestamp}.ht", emit: "ht"
 
     // Generates
@@ -16,6 +15,7 @@ process ResummariseRawSubmissions {
     // clinvarbitration_XX.ht - a Hail Table containing the summarised data entries
     script:
     """
+    set -euo pipefail
     python3 -m clinvarbitration.scripts.resummarise_clinvar \
         -v "${variant_summary}" \
         -s "${submission_summary}" \
@@ -23,6 +23,6 @@ process ResummariseRawSubmissions {
         -b "${params.clinvar_blacklist}"
 
     # remove the byproduct TSV which was read into a HT
-    rm clinvarbitration_${timestamp}.tsv
+    rm -f clinvarbitration_${timestamp}.tsv
     """
 }

--- a/nextflow/modules/prep/ResummariseRawSubmissions/main.nf
+++ b/nextflow/modules/prep/ResummariseRawSubmissions/main.nf
@@ -22,6 +22,8 @@ process ResummariseRawSubmissions {
         -o "clinvarbitration_${timestamp}" \
         -b "${params.clinvar_blacklist}"
 
+    tabix "clinvarbitration_${timestamp}.vcf.bgz"
+
     # remove the byproduct TSV which was read into a HT
     rm -f clinvarbitration_${timestamp}.tsv
     """

--- a/nextflow/modules/talos/CreateTalosHTML/main.nf
+++ b/nextflow/modules/talos/CreateTalosHTML/main.nf
@@ -1,8 +1,6 @@
 process CreateTalosHTML {
     container params.container
 
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(talos_result_json), path(panelapp_data), path(talos_config), path(ext_ids), path(seqr_ids)
         val timestamp
@@ -16,8 +14,8 @@ process CreateTalosHTML {
         def seqr_arg = seqr_ids.name != 'NO_SEQR_FILE' ? "--seqr_ids $seqr_ids" : ''
 
         """
+        set -euo pipefail
         export TALOS_CONFIG=${talos_config}
-        mkdir ${cohort}_report
         python -m talos.create_talos_html \
             --input ${talos_result_json} \
             --panelapp ${panelapp_data} \

--- a/nextflow/modules/talos/HPOFlagging/main.nf
+++ b/nextflow/modules/talos/HPOFlagging/main.nf
@@ -1,9 +1,6 @@
 process HPOFlagging {
     container params.container
 
-    // flag results in the result JSON which are good phenotypic matches
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(talos_result_json), path(talos_config)
         path gene_symbol_map
@@ -14,7 +11,9 @@ process HPOFlagging {
     output:
         tuple val(cohort), path("${cohort}_full_report_${timestamp}.json")
 
+	script:
     """
+    set -euo pipefail
     export TALOS_CONFIG=${talos_config}
     python -m talos.hpo_flagging \
          --input ${talos_result_json} \

--- a/nextflow/modules/talos/RunHailFiltering/main.nf
+++ b/nextflow/modules/talos/RunHailFiltering/main.nf
@@ -1,8 +1,6 @@
 process RunHailFiltering {
     container params.container
 
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(mts), path(panelapp_data), path(check_file), path(pedigree), path(talos_config)
         path clinvar_all
@@ -14,6 +12,7 @@ process RunHailFiltering {
     script:
         def mt_string = (mts.collect().size() > 1) ? mts.sort{ it.name } : mts
         """
+        set -euo pipefail
         export TALOS_CONFIG=${talos_config}
 
         python -m talos.run_hail_filtering \

--- a/nextflow/modules/talos/StartupChecks/main.nf
+++ b/nextflow/modules/talos/StartupChecks/main.nf
@@ -1,8 +1,6 @@
 process StartupChecks {
     container params.container
 
-    // publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(mts), path(pedigree), path(talos_config), path(history), path(ext), path(seqr)
         path clinvar
@@ -14,7 +12,7 @@ process StartupChecks {
         def mt_string = (mts.collect().size() > 1) ? mts.sort{ it.name } : mts
 
         """
-        set -e
+        set -euo pipefail
         export TALOS_CONFIG=${talos_config}
 
         python -m talos.startup_checks \\

--- a/nextflow/modules/talos/UnifiedPanelAppParser/main.nf
+++ b/nextflow/modules/talos/UnifiedPanelAppParser/main.nf
@@ -2,8 +2,6 @@
 process UnifiedPanelAppParser {
     container params.container
 
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(check_file), path(talos_config), path(pedigree)
         path panelapp_cache
@@ -12,7 +10,9 @@ process UnifiedPanelAppParser {
     output:
         tuple val(cohort), path("${cohort}_panelapp.json")
 
+	script:
     """
+    set -euo pipefail
     export TALOS_CONFIG=${talos_config}
     python -m talos.unified_panelapp_parser \
         --input $panelapp_cache \

--- a/nextflow/modules/talos/ValidateMOI/main.nf
+++ b/nextflow/modules/talos/ValidateMOI/main.nf
@@ -2,8 +2,6 @@
 process ValidateMOI {
     container params.container
 
-    publishDir "${params.outdir}/${cohort}_outputs", mode: 'copy'
-
     input:
         tuple val(cohort), path(labelled_vcf), path(labelled_vcf_index), path(panelapp), path(pedigree), path(talos_config), path(previous_results)
         val timestamp
@@ -15,8 +13,8 @@ process ValidateMOI {
 		def history_arg = previous_results.name != 'NO_HISTORY' ? "--previous $previous_results" : ''
 
     """
+    set -euo pipefail
     export TALOS_CONFIG=${talos_config}
-
     python -m talos.validate_moi \
         --labelled_vcf ${labelled_vcf} \
         --panelapp ${panelapp} \

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -33,7 +33,7 @@
         },
         "container": {
           "type": "string",
-          "default": "talos:10.0.0",
+          "default": "talos:10.0.1",
           "description": "Docker container used by processes."
         },
         "mane": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/populationgenomics/talos/main/nextflow_schema.json",
+  "title": "Talos pipeline parameters",
+  "description": "Nextflow configuration parameters for the Talos pipeline.",
+  "type": "object",
+  "definitions": {
+    "default": {
+      "title": "Default parameters",
+      "type": "object",
+      "description": "Parameters found in `nextflow.config`.",
+      "required": [
+        "input_tsv",
+        "processed_annotations",
+        "large_files"
+      ],
+      "properties": {
+        "input_tsv": {
+          "type": "string",
+          "description": "Input runs as a TSV of `cohort`, `path`, and `type`"
+        },
+        "processed_annotations": {
+          "type": "string",
+          "description": "Global output directories - should be changed for each deployment."
+        },
+        "large_files": {
+          "type": "string",
+          "description": "Large files directory"
+        },
+        "ref_genome": {
+          "type": "string",
+          "description": "Reference genome, default is in large_files."
+        },
+        "container": {
+          "type": "string",
+          "default": "talos:10.0.0",
+          "description": "Docker container used by processes."
+        },
+        "mane": {
+          "type": "string",
+          "description": "MANE transcript resource, default is in large_files."
+        },
+        "mane_json": {
+          "type": "string",
+          "description": "Result file from running ParseManeIntoJson on the MANE summary file, default is in processed_annotations."
+        },
+        "ensembl_gff": {
+          "type": "string",
+          "description": "Ensembl gene feature file, default is in large_files."
+        },
+        "ensembl_bed": {
+          "type": "string",
+          "description": "Result files from the CreateRoiFromGff3 nextflow module, default is in processed_annotations."
+        },
+        "ensembl_merged_bed": {
+          "type": "string",
+          "description": "Result files (merged bed) from the CreateRoiFromGff3 nextflow module, default is in processed_annotations."
+        },
+        "alphamissense_tsv": {
+          "type": "string",
+          "description": "AlphaMissense raw data, default is in large_files."
+        },
+        "alphamissense_zip": {
+          "type": "string",
+          "description": "AlphaMissense reformatted as an echtvar-compatible zip, default is in processed_annotations."
+        },
+        "submission_summary": {
+          "type": "string",
+          "default": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/submission_summary.txt.gz",
+          "description": "ClinVar download URL for submission summary."
+        },
+        "variant_summary": {
+          "type": "string",
+          "default": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz",
+          "description": "ClinVar download URL for variant summary."
+        },
+        "clinvar_blacklist": {
+          "type": "string",
+          "default": "'not' 'applicable'",
+          "description": "ClinVar blacklist."
+        },
+        "hpo": {
+          "type": "string",
+          "description": "HPO and Phenotype file, default is in large_files."
+        },
+        "gen2phen": {
+          "type": "string",
+          "description": "Genes to phenotype file, default is in large_files."
+        },
+        "phenio_db": {
+          "type": "string",
+          "description": "Phenio database, default is in large_files."
+        },
+        "input_vcf_extension": {
+          "type": "string",
+          "default": "vcf.bgz",
+          "description": "Input VCF extension and location logic."
+        },
+        "vcf_split_n": {
+          "type": "integer",
+          "default": 1000000,
+          "description": "Number of lines to split VCFs by."
+        },
+        "gnomad_zip": {
+          "type": "string",
+          "default": "${params.large_files}/gnomad_4.1_region_merged_GRCh38_whole_genome",
+          "description": "Echtvar-formatted annotation data for gnomAD, default is in large_files."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/default"
+    }
+  ]
+}

--- a/preparation.nf
+++ b/preparation.nf
@@ -77,6 +77,7 @@ workflow {
         // annotate the SNV VCF using BCFtools
         AnnotateClinvarWithBcftools(
             ResummariseRawSubmissions.out.vcf,
+            ResummariseRawSubmissions.out.vcf_idx,
             ch_ref_fa,
             ch_gff,
         )

--- a/preparation.nf
+++ b/preparation.nf
@@ -77,7 +77,6 @@ workflow {
         // annotate the SNV VCF using BCFtools
         AnnotateClinvarWithBcftools(
             ResummariseRawSubmissions.out.vcf,
-            ResummariseRawSubmissions.out.vcf_idx,
             ch_ref_fa,
             ch_gff,
         )

--- a/src/talos/cpg_internal_scripts/cpgflow_jobs/make_config.py
+++ b/src/talos/cpg_internal_scripts/cpgflow_jobs/make_config.py
@@ -65,7 +65,7 @@ def get_hyperlink_section(cohort: targets.Cohort, seq_type: str, mapping_path: P
         # get the mapping of SG ID to Family ID
         sg_to_fam = cpg_flow_utils.query_for_sg_family_id_map(dataset)
 
-        # mix them up to get SG ID: Seqr ID. Allow for missing samples in a fault tolerant way
+        # mix them up to get SG ID: Seqr ID. Allow for missing samples in a fault-tolerant way
         cpg_to_seqr_id = {}
         for sg in cohort.get_sequencing_groups():
             if sg.id in sg_to_fam and sg_to_fam[sg.id] in mapping:

--- a/talos_only.nf
+++ b/talos_only.nf
@@ -1,3 +1,5 @@
+nextflow.enable.dsl=2
+
 include { TALOS } from './nextflow/talos'
 
 workflow {

--- a/talos_only.nf
+++ b/talos_only.nf
@@ -1,3 +1,4 @@
+#!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
 include { TALOS } from './nextflow/talos'
@@ -18,7 +19,7 @@ workflow {
 		.splitCsv(header: true, sep: '\t')
 		.map { row -> tuple(
 			row.cohort,
-			files("${params.outdir}/${row.cohort}_outputs/*.mt", type: 'dir'),
+			Channel.fromPath("${outputDir}/${row.cohort}_outputs/*.mt", checkIfExists: true),
 			file(row.pedigree, checkIfExists: true),
 			file(row.config, checkIfExists: true),
 			file(row.history, checkIfExists: true),


### PR DESCRIPTION
# Fixes

  - Various issues identified through analysis with claude. 
  - Some are soft inconsistencies (mixed use of case, missing shebangs, missing `nextflow.enable.dsl=2` etc.)
  - Some are hard bugs (bcftools output written using wrong flag)
  - Some are incomplete changes (mix of workflow publishing and output directives, addressed by unmerged https://github.com/populationgenomics/talos/pull/645)
  - Some are functional but incorrect (Memory setting of `"1 GB"` instead of `1.GB` - same result, but though string parsing instead of plain Groovy
  - Some are ideal but not essential (`set -euo pipefail` added to all script blocks), `rm -f` to prevent failure if files (which are definitely written) stop being written
  - Some corrections (indexing files during correct stage and passing VCF with index, instead of indexing an input, so the index would be lost in the working directory)
  - Adds missing `script:` directives to some files

## Proposed Changes

  - Solve all of the above. Test in progress
  -
  -

## Checklist

- [ ] ChangeLog Updated
- [ ] Version Bumped
- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
