### PR TITLE
Various docker improvements

### DIFF
--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -13,7 +13,7 @@ def extract_version_from_file(file_path: str) -> str | None:
     """
     with open(file_path) as f:
         content = f.read()
-    pattern = re.compile(r'^\s*ENV\s+VERSION\s*=\s*([^\s]+)', re.MULTILINE)
+    pattern = re.compile(r'^\s*ARG\s+VERSION\s*=\s*([^\s]+)', re.MULTILINE)
     match = pattern.search(content)
     return match.group(1) if match else None
 

--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -9,7 +9,7 @@ import sys
 def extract_version_from_file(file_path: str) -> str | None:
     """
     Extract the version from a Dockerfile by searching for a line like:
-    ENV VERSION=1.0.0
+    ARG VERSION=1.0.0
     """
     with open(file_path) as f:
         content = f.read()
@@ -77,7 +77,7 @@ def main():
     current_version = extract_version_from_file(dockerfile_name)
     if current_version is None:
         # Throw an error here
-        raise NotImplementedError('The Dockerfile needs to contain a version string in the format "ENV VERSION=x.x.x"')
+        raise NotImplementedError('The Dockerfile needs to contain a version string in the format "ARG VERSION=x.x.x"')
 
     # Determine the next available tag based on current_version.
     new_tag = get_next_version_tag(container_name, current_version)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl-dev \
     make \
     zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
-RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    rm -rf /var/lib/apt/lists/* \
+    wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --enable-libcurl --enable-s3 --enable-gcs && \
     make && \
@@ -48,6 +47,7 @@ COPY --from=bcftools_compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
 COPY --from=bcftools_compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/
 
 ARG ECHTVAR_VERSION=v0.2.2
+ARG ECH_SHA=b66eb33ef787a712c911f8206243b310b03615720b00336430f399b9d197d235
 ARG VERSION=10.0.1
 
 RUN wget -q -O /bin/echtvar "https://github.com/brentp/echtvar/releases/download/${ECHTVAR_VERSION}/echtvar" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,18 @@ FROM python:3.11-slim-bullseye AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y --no-install-recommends \
-        apt-transport-https \
-        bzip2 \
-        ca-certificates \
-        gnupg \
-        libbz2-1.0 \
-        libcurl4 \
-        liblzma5 \
-        openjdk-11-jdk-headless \
-        procps \
-        wget \
-        zip \
-        zlib1g && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    gnupg \
+    libbz2-1.0 \
+    libcurl4 \
+    liblzma5 \
+    openjdk-11-jdk-headless \
+    procps \
+    wget \
+    zip \
+    zlib1g && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/*
 
@@ -23,15 +22,16 @@ FROM base AS bcftools_compiler
 ARG BCFTOOLS_VERSION=1.22
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        gcc \
-        libbz2-dev \
-        libcurl4-openssl-dev \
-        liblzma-dev \
-        libssl-dev \
-        make \
-        zlib1g-dev && \
-    wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
-    tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    gcc \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    liblzma-dev \
+    libssl-dev \
+    make \
+    zlib1g-dev
+
+RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
+RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --enable-libcurl --enable-s3 --enable-gcs && \
     make && \
@@ -39,27 +39,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make DESTDIR=/bcftools_install install && \
     cd htslib-${BCFTOOLS_VERSION} && \
     make && \
-    wget https://github.com/samtools/htslib/releases/download/${BCFTOOLS_VERSION}/htslib-${BCFTOOLS_VERSION}.tar.bz2 && \
-    tar -xf htslib-${BCFTOOLS_VERSION}.tar.bz2 && \
-    cd htslib-${BCFTOOLS_VERSION} && \
-    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
-    make && \
-    mv bgzip tabix /bcftools_install/usr/local/bin/
+    make DESTDIR=/bcftools_install install
 
-FROM base AS base_bcftools
+FROM base AS talos
 
 COPY --from=bcftools_compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
 COPY --from=bcftools_compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/
 
-FROM base_bcftools AS base_bcftools_echtvar
-
 ARG ECHTVAR_VERSION=v0.2.2
+ARG VERSION=10.0.1
 
-ADD "https://github.com/brentp/echtvar/releases/download/${ECHTVAR_VERSION}/echtvar" /bin/echtvar
-
-RUN chmod +x /bin/echtvar
-
-FROM base_bcftools_echtvar AS talos
+RUN wget -q -O /bin/echtvar "https://github.com/brentp/echtvar/releases/download/${ECHTVAR_VERSION}/echtvar" && \
+    chmod +x /bin/echtvar
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /bin/
 
@@ -81,11 +72,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY LICENSE pyproject.toml uv.lock README.md ./
 COPY src src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install ".[cpg]"
+    uv sync --frozen --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/talos/.venv/bin:$PATH"
 
 COPY echtvar echtvar/
-
-ENV VERSION=10.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,13 +67,13 @@ WORKDIR /talos
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev
+    uv sync --all-extras --frozen --no-install-project --no-dev
 
 # Add in the additional requirements that are most likely to change.
 COPY LICENSE pyproject.toml uv.lock README.md ./
 COPY src src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --all-extras --frozen --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/talos/.venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     liblzma-dev \
     libssl-dev \
     make \
-    zlib1g-dev
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
 RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,8 @@ dependencies=[
 ]
 
 [project.optional-dependencies]
-# various requirements when running cpg-flow/analysis-runner
 cpg = [
-    'cpg-flow~=1.3.1',
+    'cpg-flow~=1.3',
     'google-cloud-storage==2.14.0',
 ]
 test = [

--- a/src/talos/cpg_internal_scripts/CPG_Dockerfile
+++ b/src/talos/cpg_internal_scripts/CPG_Dockerfile
@@ -2,13 +2,13 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y --no-install-recommends \
-        libbz2-1.0 \
-        libcurl4 \
-        liblzma5 \
-        make \
-        procps \
-        zlib1g && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libbz2-1.0 \
+    libcurl4 \
+    liblzma5 \
+    make \
+    procps \
+    zlib1g && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/*
 
@@ -19,14 +19,16 @@ FROM base AS bcftools_compiler
 ARG BCFTOOLS_VERSION=1.22
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        gcc \
-        libbz2-dev \
-        libcurl4-openssl-dev \
-        liblzma-dev \
-        libssl-dev \
-        zlib1g-dev && \
-    wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
-    tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    gcc \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    liblzma-dev \
+    libssl-dev \
+    make \
+    zlib1g-dev
+
+RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
+RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --enable-libcurl --enable-s3 --enable-gcs && \
     make && \
@@ -34,27 +36,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make DESTDIR=/bcftools_install install && \
     cd htslib-${BCFTOOLS_VERSION} && \
     make && \
-    wget https://github.com/samtools/htslib/releases/download/${BCFTOOLS_VERSION}/htslib-${BCFTOOLS_VERSION}.tar.bz2 && \
-    tar -xf htslib-${BCFTOOLS_VERSION}.tar.bz2 && \
-    cd htslib-${BCFTOOLS_VERSION} && \
-    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
-    make && \
-    mv bgzip tabix /bcftools_install/usr/local/bin/
+    make DESTDIR=/bcftools_install install
 
-FROM base AS base_bcftools
+FROM base AS talos
 
 COPY --from=bcftools_compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
 COPY --from=bcftools_compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/
 
-FROM base_bcftools AS base_bcftools_echtvar
-
 ARG ECHTVAR_VERSION=v0.2.2
+ARG VERSION=10.0.1
 
-ADD "https://github.com/brentp/echtvar/releases/download/${ECHTVAR_VERSION}/echtvar" /bin/echtvar
-
-RUN chmod +x /bin/echtvar
-
-FROM base_bcftools_echtvar
+RUN wget -q -O /bin/echtvar "https://github.com/brentp/echtvar/releases/download/${ECHTVAR_VERSION}/echtvar" && \
+    chmod +x /bin/echtvar
 
 WORKDIR /talos
 
@@ -64,5 +57,3 @@ COPY nextflow nextflow/
 COPY echtvar echtvar/
 
 RUN pip install --no-cache-dir ".[cpg]"
-
-ENV VERSION=10.0.1

--- a/src/talos/cpg_internal_scripts/CPG_Dockerfile
+++ b/src/talos/cpg_internal_scripts/CPG_Dockerfile
@@ -26,10 +26,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl-dev \
     zlib1g-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
-
-RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
-RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    rm -rf /var/cache/apt/* && \
+    wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
+    tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --enable-libcurl --enable-s3 --enable-gcs && \
     make && \

--- a/src/talos/cpg_internal_scripts/CPG_Dockerfile
+++ b/src/talos/cpg_internal_scripts/CPG_Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libcurl4-openssl-dev \
     liblzma-dev \
     libssl-dev \
-    make \
     zlib1g-dev
 
 RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2

--- a/src/talos/cpg_internal_scripts/CPG_Dockerfile
+++ b/src/talos/cpg_internal_scripts/CPG_Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libcurl4-openssl-dev \
     liblzma-dev \
     libssl-dev \
-    zlib1g-dev
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/*
 
 RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2
 RUN tar -xf bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \


### PR DESCRIPTION
# Fixes

  - Improvements to the docker build process

## Proposed Changes

  - Removes the redundant second download of htslib, already bundled in the bcftools download. Instead, build bcftools, cd, then build tabix/bgzip to the same location
  - Removes a couple of build layers, there's no benefit as they're all intended to be ephemoral
  - Update the UV install command to install all extras. Not 100% sure this is required, as the CPG install doesn't use this installation command, but best to update this while it's been spotted, instead of working back to try and discover why dependencies aren't satisfied
  - Removes a couple of libraries which are standard in linux, so a manual install is no-op
  - Swaps `ENV VERSION` for `ARG VERSION` - this isn't really meaningful here as we're currently using the Dockerfile line and a regular expression to extract the version value to make a build tag. If we do use this in future, an ENV variable can be changed during the build process, an ARG variable can't.

## Extension plans

A more meaningful/beneficial change would be to split the dockerfiles into Tools and Talos. There are no nextflow or Hail Batch stages which require both Talos code and CLI tools, and the vast majority of docker build time is rebuilding bcftools from scratch each time the cache is invalidated. 

A skinny image, featuring bcftools and echtvar, would be used during the preparation steps. The Talos image would be used for the final workflow. Both can be maintained separately, i.e. the tools image may never need updating, and the Talos image would build quickly.

Currently being tested locally