### PR TITLE
left-aligns column sorting, describe pseudodominant label

### DIFF
--- a/src/talos/templates/index.html.jinja
+++ b/src/talos/templates/index.html.jinja
@@ -118,7 +118,7 @@
                             <span class="badge text-bg-warning">Ambiguous Cat.1 MOI</span> applied to AD Talos candidates that are P/LP in ClinVar but the gene is associated with both dominant and recessive disorders inheritance in PanelApp.
                         </p>
                         <p class="mb-1">
-                            <span class="badge text-bg-warning">Affected female with heterozygous variant in XLR gene</span> for females, we evaluate biallelic genes under a pseudo-dominant model, to detect plausible variants in the event of healthy-allele inactivation .
+                            <span class="badge text-bg-warning">Affected female with heterozygous variant in XLR gene</span> for females, we evaluate biallelic genes under a pseudo-dominant model, to detect plausible variants in the event of skewed x-inactivation.
                         </p>
 
                     </div>

--- a/src/talos/templates/index.html.jinja
+++ b/src/talos/templates/index.html.jinja
@@ -19,13 +19,9 @@
     <script src="https://cdn.datatables.net/rowgroup/1.0.2/js/dataTables.rowGroup.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 
-    <style type="text/css">
+    <style>
         a {
             text-decoration: none;
-        }
-
-        .group-name {
-            font-weight: normal;
         }
 
         .child-row-content {
@@ -34,6 +30,18 @@
             margin-right: auto;
             text-align: left;
         }
+
+        /*Source https://stackoverflow.com/a/29682843*/
+        table.dataTable thead .sorting_asc {
+          background: url("http://cdn.datatables.net/1.10.0/images/sort_asc.png") no-repeat center left;
+        }
+        table.dataTable thead .sorting_desc {
+          background: url("http://cdn.datatables.net/1.10.0/images/sort_desc.png") no-repeat center left;
+        }
+        table.dataTable thead .sorting {
+          background: url("http://cdn.datatables.net/1.10.0/images/sort_both.png") no-repeat center left;
+        }
+
     </style>
   </head>
 
@@ -107,7 +115,10 @@
                             <span class="badge text-bg-warning">Low Read Depth</span> read depth (AD) for the sample is below the minimum threshold (default: 10)
                         </p>
                         <p class="mb-1">
-                            <span class="badge text-bg-warning">Ambiguous MOI</span> applied to AD Talos candidates that are P/LP in ClinVar but the gene is associated with both dominant and recessive disorders inheritance in PanelApp.
+                            <span class="badge text-bg-warning">Ambiguous Cat.1 MOI</span> applied to AD Talos candidates that are P/LP in ClinVar but the gene is associated with both dominant and recessive disorders inheritance in PanelApp.
+                        </p>
+                        <p class="mb-1">
+                            <span class="badge text-bg-warning">Affected female with heterozygous variant in XLR gene</span> for females, we evaluate biallelic genes under a pseudo-dominant model, to detect plausible variants in the event of healthy-allele inactivation .
                         </p>
 
                     </div>


### PR DESCRIPTION
# Fixes

  - the Pseudo-dominant MOI model and corresponding Flag weren't described in the report header
  - the column sorting arrows were right-aligned, and appeared pretty far from the column title they sort

## Proposed Changes

  * added new line to help box for pseudo label
  * left-align sorting arrow

<img width="1455" height="217" alt="Screenshot 2026-04-29 at 1 01 15 pm" src="https://github.com/user-attachments/assets/6de6eab2-8ef8-4fea-8f47-a7d83f75a87b" />
<img width="276" height="146" alt="Screenshot 2026-04-29 at 1 01 18 pm" src="https://github.com/user-attachments/assets/a7ebd5be-03c3-4406-9afc-3f1e88f3b595" />
