### PR TITLE
Fix sneaky panelapp bug

### DIFF
--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -382,7 +382,10 @@ def main(panel_data: str, output_file: str, pedigree_path: str, hpo_file: str | 
     panelapp_data, all_hpos = extract_participant_data_from_pedigree(pedigree=pedigree, hpo_lookup=hpo_label_lookup)
 
     # chuck in the default Mendeliome metadata
-    panelapp_data.metadata = {DEFAULT_PANEL: cached_panelapp.versions[DEFAULT_PANEL]}
+    panelapp_data.metadata = {}
+    for panel_data in cached_panelapp.versions:
+        if panel_data.id == DEFAULT_PANEL:
+            panelapp_data.metadata[DEFAULT_PANEL] = panel_data
 
     if hpo_graph is not None:
         # match HPO terms to panel IDs

--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -383,9 +383,9 @@ def main(panel_data: str, output_file: str, pedigree_path: str, hpo_file: str | 
 
     # chuck in the default Mendeliome metadata
     panelapp_data.metadata = {}
-    for panel_data in cached_panelapp.versions:
-        if panel_data.id == DEFAULT_PANEL:
-            panelapp_data.metadata[DEFAULT_PANEL] = panel_data
+    for panel_entry in cached_panelapp.versions:
+        if panel_entry.id == DEFAULT_PANEL:
+            panelapp_data.metadata[DEFAULT_PANEL] = panel_entry
 
     if hpo_graph is not None:
         # match HPO terms to panel IDs


### PR DESCRIPTION
# Fixes

  - this one has been around a whiiiiile
  - during the panelapp parsing module we first collect the base panel (typically 137, the mendeliome) and add its metadata to the final output
  - this has always had a bug in it... `cached_panelapp` was a list, not a dict, so `cached_panelapp.versions[DEFAULT_PANEL]` was pulling the 137th value in the list and attributing it to the Mendeliome.

This was overwritten with the correct values later, but this error became apparent when generating some stub test data - the list had to be at least 138 panels long for this not to fail 😅 

## Proposed Changes

  - Swaps out the [index 137] for an iteration over the panel metadata list, picking the one that corresponds with the base panel of choice in the analysis