### PR TITLE
Patch htslib vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM base AS bcftools_compiler
 
-ARG BCFTOOLS_VERSION=1.22
+ARG BCFTOOLS_VERSION=1.23.1
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     gcc \


### PR DESCRIPTION
# Fixes

  - htslib 1.22 is causing vulnerability CVE-2026-31966

## Proposed Changes

  - Upgrade htslib and bcftools to 1.23.1. 

## Checklist

- [ ] ChangeLog Updated
- [ ] Version Bumped
- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
