### PR TITLE
Allow non-green genes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,7 @@ build
 .coverage*
 .nextflow
 
-large_files
+large_files*
 nextflow/*_outputs
+nextflow/*test
+work

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 # hail logs
 hail*.log
 
-
 # scratch files
 /scratch/
 
@@ -97,7 +96,7 @@ dmypy.json
 #nextflow
 .nextflow/
 .nextflow.log*
-nextflow/cohort_outputs/
+nextflow/*test/
 nextflow/processed_annotations/
 work/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.15.12
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Added "Super Logging" functionality. Opt-in high rate logging to explain the rejection reason for each variant.
   * Talos previously only logged results, not rejections. This logs misses, and explanations e.g. threshold failure, family test, insufficient read depth, comp-het with only support categories
   * Using the "confidence_level" configuration setting can allow PanelApp genes with lower evidence levels (1 >= Red, 2 >= Amber) to be used in analysis. The default level remains 3/Green-only.
-  * The HTML report shows, for each gene, the panels it was found in, and the confidence level associated evidence level on each panel. Checkboxes can be used to filter to specific confidence levels. 
+  * The HTML report shows, for each gene, the panels it was found in, and the confidence level associated evidence level on each panel. Checkboxes can be used to filter to specific confidence levels.
 
 ### Changed
 
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
   * Swapped out the standard BCFtools build for a CPG-fork.
-  * This fork contains a single change - coding and non-coding genes are both annotated equally.
+  * This fork contains a single change - coding and non-coding genes are both annotated equally. This behaviour has been upstreamed into BCFtools, but not yet released (see [this commit](https://github.com/samtools/bcftools/commit/90e602563503e6daa524a36a61218a974253d6be))
   * In our local runs we have seen that the default behaviour of BCFtools (issue [here](https://github.com/samtools/bcftools/issues/2548)) lead to failure to annotate consequences in non-coding genes where they overlapped with a coding gene, even if the non-coding gene was of greater clinical relevance.
   * By moving to the CPG fork, we have altered this behaviour. This may result in slightly slower annotation times, but should always present both coding and non-coding gene annotations where appropriate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Removed some intermediate build layers from Dockerfiles
   * The Ensembl GFF3 file is now edited during the download script, to re-name chrMT -> chrM, which enables Mitochondrial analysis. This requires re-running the file download and preparation workflow.
   * The AlphaMissense category now allows users to set a pathogenic threshold (config.toml -> `RunHailFiltering.am_pathogenicity`). Each run can now set a manual threshold instead of deferring to the low default value of 0.564.
+  * PanelApp parsing can now pull Red, Amber, and Green genes. A config parameter `confidence_level` can be used to control this behaviour. N.b. MOI may not be as well curated for non-green genes.
 
 > NOTE! Since 10.0.0, Talos uses a `TSV` input file to drive analyses. As of this update, the optional columns (previous results as a history, seqr IDs, secondary IDs, now Mitochondrial VCF) are all truly optional. The workflow doesn't require them to be populated in the input file at all.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Test fixtures and demonstration data now includes more non-coding variants and Mitochondrial data.
   * Added "Super Logging" functionality. Opt-in high rate logging to explain the rejection reason for each variant.
   * Talos previously only logged results, not rejections. This logs misses, and explanations e.g. threshold failure, family test, insufficient read depth, comp-het with only support categories
+  * Using the "confidence_level" configuration setting can allow PanelApp genes with lower evidence levels (1 >= Red, 2 >= Amber) to be used in analysis. The default level remains 3/Green-only.
+  * The HTML report shows, for each gene, the panels it was found in, and the confidence level associated evidence level on each panel. Checkboxes can be used to filter to specific confidence levels. 
 
 ### Changed
 

--- a/nextflow/inputs/config.toml
+++ b/nextflow/inputs/config.toml
@@ -6,6 +6,12 @@ within_x_months = 24
 forbidden_genes = []
 forced_panels = [ 144,]
 
+# confidence level - set this to a lower value to allow non-green PanelApp genes into the analysis
+# 3 = Green only
+# 2 = Amber or Green only
+# 1 = Red, Amber, or Green
+confidence_level = 3
+
 [[GeneratePanelData.manual_overrides]]
 # this section permits the manual addition of genes to the panel data
 # each gene here will be folded into the panelapp data after standard API queries have taken place

--- a/nextflow/inputs/config.toml
+++ b/nextflow/inputs/config.toml
@@ -101,9 +101,7 @@ support_categories = ["alphamissense", "clinvar0star"]
 
 # variants where all applied categories are in this list are removed from the report unless the gene or variant is
 # flagged as being a good phenotypic fit for the specific case
-# This default value "6" (AlphaMissense) is redundant with the "support" category - variants which were only flagged by
-# AlphaMissense will be removed from consideration completely
-phenotype_match = ["AlphaMissense"]
+phenotype_match = ["alphamissense"]
 
 # un-comment this to apply a minimum GQ to all samples in the trio, including WT. This will reduce de Novo prediciton
 # if data was merged from single-sample VCFs (WTs/absent from single sample VCF will be inserted as WT/GQ=0)

--- a/nextflow/modules/talos/CreateTalosHTML/main.nf
+++ b/nextflow/modules/talos/CreateTalosHTML/main.nf
@@ -17,7 +17,6 @@ process CreateTalosHTML {
         set -euo pipefail
 
         export TALOS_CONFIG=${talos_config}
-        mkdir ${cohort}_report
         python -m talos.create_talos_html \
             --input ${talos_result_json} \
             --panelapp ${panelapp_data} \

--- a/src/talos/create_talos_html.py
+++ b/src/talos/create_talos_html.py
@@ -605,12 +605,17 @@ class Variant:
         # store if this variant is new in any of the other panels
         self.new_panels: set[str] = set()
 
+        # Panel IDs applied to this sample (base panel + HPO-matched + forced)
+        applied_panel_ids = match_ids | {html_builder.base_panel}
+
         # List of (gene_id, symbol, panel_confidence_tooltip_html)
         self.genes: list[tuple[str, str, str]] = []
         for gene_id in report_variant.gene.split(','):
             gene_panelapp_entry = html_builder.panelapp.genes.get(gene_id, PanelDetail(symbol=gene_id))
             tooltip_parts = []
             for panel_id, confidence in sorted(gene_panelapp_entry.panel_confidences.items()):
+                if panel_id not in applied_panel_ids:
+                    continue
                 panel_name = html_builder.panelapp.metadata.get(panel_id, PanelShort(id=panel_id)).name or str(panel_id)
                 tooltip_parts.append(f'{CONFIDENCE_EMOJI.get(confidence, "⚪")} {panel_name}')
             self.genes.append((gene_id, gene_panelapp_entry.symbol, '<br>'.join(tooltip_parts)))

--- a/src/talos/create_talos_html.py
+++ b/src/talos/create_talos_html.py
@@ -23,7 +23,7 @@ from cloudpathlib.anypath import to_anypath
 from loguru import logger
 
 from talos.config import config_retrieve
-from talos.models import PanelApp, PanelDetail, ReportVariant, ResultData, SmallVariant, StructuralVariant
+from talos.models import PanelApp, PanelDetail, PanelShort, ReportVariant, ResultData, SmallVariant, StructuralVariant
 from talos.utils import read_json_from_path
 
 JINJA_TEMPLATE_DIR = Path(__file__).absolute().parent / 'templates'
@@ -40,6 +40,8 @@ MEAN_SLASH_SAMPLE = 'Mean/sample'
 
 # reactive to different versions of gnomAD
 GNOMAD_POP = config_retrieve(['RunHailFilteringSv', 'gnomad_population'], 'gnomad_v4.1')
+
+CONFIDENCE_EMOJI: dict[int, str] = {3: '🟢', 2: '🟡', 1: '🔴'}
 GNOMAD_SV_KEY = f'{GNOMAD_POP}_sv_svid'
 
 
@@ -603,11 +605,15 @@ class Variant:
         # store if this variant is new in any of the other panels
         self.new_panels: set[str] = set()
 
-        # List of (gene_id, symbol)
-        self.genes: list[tuple[str, str]] = []
+        # List of (gene_id, symbol, panel_confidence_tooltip_html)
+        self.genes: list[tuple[str, str, str]] = []
         for gene_id in report_variant.gene.split(','):
             gene_panelapp_entry = html_builder.panelapp.genes.get(gene_id, PanelDetail(symbol=gene_id))
-            self.genes.append((gene_id, gene_panelapp_entry.symbol))
+            tooltip_parts = []
+            for panel_id, confidence in sorted(gene_panelapp_entry.panel_confidences.items()):
+                panel_name = html_builder.panelapp.metadata.get(panel_id, PanelShort(id=panel_id)).name or str(panel_id)
+                tooltip_parts.append(f'{CONFIDENCE_EMOJI.get(confidence, "⚪")} {panel_name}')
+            self.genes.append((gene_id, gene_panelapp_entry.symbol, '<br>'.join(tooltip_parts)))
 
             # is this a new gene?
             new_panels = gene_panelapp_entry.new

--- a/src/talos/create_talos_html.py
+++ b/src/talos/create_talos_html.py
@@ -608,6 +608,7 @@ class Variant:
         # Panel IDs applied to this sample (base panel + HPO-matched + forced)
         applied_panel_ids = match_ids | {html_builder.base_panel}
 
+        self.max_confidence: int = 0
         # List of (gene_id, symbol, panel_confidence_tooltip_html)
         self.genes: list[tuple[str, str, str]] = []
         for gene_id in report_variant.gene.split(','):
@@ -616,6 +617,7 @@ class Variant:
             for panel_id, confidence in sorted(gene_panelapp_entry.panel_confidences.items()):
                 if panel_id not in applied_panel_ids:
                     continue
+                self.max_confidence = max(self.max_confidence, confidence)
                 panel_name = html_builder.panelapp.metadata.get(panel_id, PanelShort(id=panel_id)).name or str(panel_id)
                 tooltip_parts.append(f'{CONFIDENCE_EMOJI.get(confidence, "⚪")} {panel_name}')
             self.genes.append((gene_id, gene_panelapp_entry.symbol, '<br>'.join(tooltip_parts)))

--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -58,13 +58,8 @@ REALLY_OLD = '1970-01-01'
 PANELS_ENDPOINT = 'https://panelapp-aus.org/api/v1/panels'
 DEFAULT_PANEL = 137
 
-# by default, we only want to retain Green genes (confidence=3)
-# the panelapp value is a String, so we need to convert it
-GENE_CONFIDENCE: int = 3
-
 try:
     DEFAULT_PANEL = config_retrieve(['GeneratePanelData', 'default_panel'], DEFAULT_PANEL)
-    GENE_CONFIDENCE = config_retrieve(['GeneratePanelData', 'confidence_level'], GENE_CONFIDENCE)
     PANELS_ENDPOINT = config_retrieve(['GeneratePanelData', 'panelapp'], PANELS_ENDPOINT)
 except (ConfigError, KeyError):
     logger.warning('Config environment variable TALOS_CONFIG not set, or keys missing, falling back to Aussie PanelApp')
@@ -194,11 +189,6 @@ def parse_panel(
         if gene['entity_type'] != 'gene':
             continue
 
-        # remove any variants lower than the current confidence_level
-        confidence_level = int(gene['confidence_level'])
-        if confidence_level < GENE_CONFIDENCE:
-            continue
-
         symbol: str = gene['entity_name']
 
         chrom = ''
@@ -234,7 +224,7 @@ def parse_panel(
                 'mane_symbol': ensg_dict.get(each_ensg, '') if ensg_dict else '',
                 'moi': exact_moi,
                 'green_date': green_dates.get(symbol, REALLY_OLD),
-                'confidence_level': confidence_level,
+                'confidence_level': int(gene['confidence_level']),
             }
 
     return panel_gene_content

--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -58,14 +58,19 @@ REALLY_OLD = '1970-01-01'
 PANELS_ENDPOINT = 'https://panelapp-aus.org/api/v1/panels'
 DEFAULT_PANEL = 137
 
+# by default, we only want to retain Green genes (confidence=3)
+# the panelapp value is a String, so we need to convert it
+GENE_CONFIDENCE: int = 3
+
 try:
-    PANELS_ENDPOINT = config_retrieve(['GeneratePanelData', 'panelapp'], PANELS_ENDPOINT)
     DEFAULT_PANEL = config_retrieve(['GeneratePanelData', 'default_panel'], DEFAULT_PANEL)
+    GENE_CONFIDENCE = config_retrieve(['GeneratePanelData', 'confidence_level'], GENE_CONFIDENCE)
+    PANELS_ENDPOINT = config_retrieve(['GeneratePanelData', 'panelapp'], PANELS_ENDPOINT)
 except (ConfigError, KeyError):
     logger.warning('Config environment variable TALOS_CONFIG not set, or keys missing, falling back to Aussie PanelApp')
 
 # if this is a massive result, it returns over a number of pages
-GREEN_TEMPLATE = f'{PANELS_ENDPOINT}/{{id}}/genes/?confidence_level=3'
+GENE_TEMPLATE_URL = f'{PANELS_ENDPOINT}/{{id}}/genes'
 ACTIVITY_TEMPLATE = f'{PANELS_ENDPOINT}/{{id}}/activities'
 MITO_BAD = 'MT'
 MITO_GOOD = 'M'
@@ -189,6 +194,11 @@ def parse_panel(
         if gene['entity_type'] != 'gene':
             continue
 
+        # remove any variants lower than the current confidence_level
+        confidence_level = int(gene['confidence_level'])
+        if confidence_level < GENE_CONFIDENCE:
+            continue
+
         symbol: str = gene['entity_name']
 
         chrom = ''
@@ -224,6 +234,7 @@ def parse_panel(
                 'mane_symbol': ensg_dict.get(each_ensg, '') if ensg_dict else '',
                 'moi': exact_moi,
                 'green_date': green_dates.get(symbol, REALLY_OLD),
+                'confidence_level': confidence_level,
             }
 
     return panel_gene_content
@@ -231,7 +242,7 @@ def parse_panel(
 
 async def get_single_panel(session: aiohttp.ClientSession, panel_id: int) -> dict[int, list[dict]]:
     """Async method to return data from a single panel"""
-    panel_url = GREEN_TEMPLATE.format(id=panel_id)
+    panel_url = GENE_TEMPLATE_URL.format(id=panel_id)
     panel_results: list[dict] = []
 
     while True:
@@ -367,6 +378,7 @@ def main(output: str, mane_path: str | None = None):
                 prev_gene_data.panels[panel_id] = DownloadedPanelAppGenePanelDetail(
                     moi=gene_data['moi'],
                     date=gene_data['green_date'],
+                    confidence=gene_data['confidence_level'],
                 )
                 # update if previous wasn't populated
                 prev_gene_data.mane_symbol = prev_gene_data.mane_symbol or gene_data['mane_symbol']
@@ -381,6 +393,7 @@ def main(output: str, mane_path: str | None = None):
                         panel_id: DownloadedPanelAppGenePanelDetail(
                             moi=gene_data['moi'],
                             date=gene_data['green_date'],
+                            confidence=gene_data['confidence_level'],
                         ),
                     },
                 )

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -15,6 +15,12 @@ forbidden_genes = ['a', 'list', 'of', 'forbidden', 'genes']  # symbols, ENSG, or
 # must exist in the relevant panelapp instance
 forced_panels = [1, 2, 3]
 
+# confidence level - set this to a lower value to allow non-green PanelApp genes into the analysis
+# 3 = Green only
+# 2 = Amber or Green only
+# 1 = Red, Amber, or Green
+confidence_level = 3
+
 # integer, when parsing panel data, this value determines whether a gene is 'recent'
 # we find the date each gene became Green/Ready, and if that is within X months of today
 # we treat the gene as new. New/Recent genes are highlighted in the report with a Star next to the symbol

--- a/src/talos/liftover/lift_2_2_0_to_2_3_0.py
+++ b/src/talos/liftover/lift_2_2_0_to_2_3_0.py
@@ -5,6 +5,7 @@ code for lifting over models from 2.2.0 to 2.3.0
 
 def dl_panelapp(data_dict: dict) -> dict:
     for _, gene_data in data_dict['genes'].items():
+        gene_data['panel_confidences'] = {}
         for _, panel_data in gene_data['panels'].items():
             panel_data['confidence'] = 3
     data_dict['version'] = '2.3.0'

--- a/src/talos/liftover/lift_2_2_0_to_2_3_0.py
+++ b/src/talos/liftover/lift_2_2_0_to_2_3_0.py
@@ -1,0 +1,15 @@
+"""
+code for lifting over models from 2.2.0 to 2.3.0
+"""
+
+from loguru import logger
+
+from talos.static_values import get_granular_date
+
+
+def dl_panelapp(data_dict: dict) -> dict:
+    for _, gene_data in data_dict['genes'].items():
+        for _, panel_data in gene_data['panels'].items():
+            panel_data['confidence'] = 3
+    data_dict['version'] = '2.3.0'
+    return data_dict

--- a/src/talos/liftover/lift_2_2_0_to_2_3_0.py
+++ b/src/talos/liftover/lift_2_2_0_to_2_3_0.py
@@ -2,10 +2,6 @@
 code for lifting over models from 2.2.0 to 2.3.0
 """
 
-from loguru import logger
-
-from talos.static_values import get_granular_date
-
 
 def dl_panelapp(data_dict: dict) -> dict:
     for _, gene_data in data_dict['genes'].items():

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -416,6 +416,7 @@ class PanelDetail(BaseModel):
     moi: str = Field(default_factory=str)
     new: set[int] = Field(default_factory=set)
     panels: set[int] = Field(default_factory=set)
+    panel_confidences: dict[int, int] = Field(default_factory=dict)
 
 
 class PanelShort(BaseModel):

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -19,6 +19,7 @@ from talos.liftover.lift_1_2_0_to_2_0_0 import resultdata as rd_120_to_200
 from talos.liftover.lift_2_0_0_to_2_1_0 import panelapp as pa_200_to_210
 from talos.liftover.lift_2_0_0_to_2_1_0 import resultdata as rd_200_to_210
 from talos.liftover.lift_2_1_0_to_2_2_0 import dl_panelapp as dl_pa_210_to_220
+from talos.liftover.lift_2_2_0_to_2_3_0 import dl_panelapp as dl_pa_220_to_230
 from talos.liftover.lift_2_1_0_to_2_2_0 import resultdata as rd_210_to_220
 from talos.liftover.lift_none_to_1_0_0 import resultdata as rd_none_to_1_0_0
 from talos.static_values import get_granular_date
@@ -27,8 +28,8 @@ NON_HOM_CHROM = ['X', 'Y', 'MT', 'M']
 CHROM_ORDER = list(map(str, range(1, 23))) + NON_HOM_CHROM
 
 # some kind of version tracking
-CURRENT_VERSION = '2.2.0'
-ALL_VERSIONS = [None, '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.1.0', '1.2.0', '2.0.0', '2.1.0', '2.2.0']
+CURRENT_VERSION = '2.3.0'
+ALL_VERSIONS = [None, '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.1.0', '1.2.0', '2.0.0', '2.1.0', '2.2.0', '2.3.0']
 
 # ratios for use in AB testing
 MAX_WT = 0.15
@@ -443,6 +444,7 @@ class DownloadedPanelAppGenePanelDetail(BaseModel):
 
     moi: str
     date: str = Field(default_factory=str)
+    confidence: int = Field(default_factory=int)
 
 
 class DownloadedPanelAppGene(BaseModel):
@@ -559,6 +561,7 @@ class PedigreeMember(BaseModel):
 LIFTOVER_METHODS: dict = {
     DownloadedPanelApp: {
         '2.1.0_2.2.0': dl_pa_210_to_220,
+        '2.2.0_2.3.0': dl_pa_220_to_230,
     },
     PanelApp: {
         '1.2.0_2.0.0': pa_120_to_200,

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -19,8 +19,8 @@ from talos.liftover.lift_1_2_0_to_2_0_0 import resultdata as rd_120_to_200
 from talos.liftover.lift_2_0_0_to_2_1_0 import panelapp as pa_200_to_210
 from talos.liftover.lift_2_0_0_to_2_1_0 import resultdata as rd_200_to_210
 from talos.liftover.lift_2_1_0_to_2_2_0 import dl_panelapp as dl_pa_210_to_220
-from talos.liftover.lift_2_2_0_to_2_3_0 import dl_panelapp as dl_pa_220_to_230
 from talos.liftover.lift_2_1_0_to_2_2_0 import resultdata as rd_210_to_220
+from talos.liftover.lift_2_2_0_to_2_3_0 import dl_panelapp as dl_pa_220_to_230
 from talos.liftover.lift_none_to_1_0_0 import resultdata as rd_none_to_1_0_0
 from talos.static_values import get_granular_date
 

--- a/src/talos/run_hail_filtering.py
+++ b/src/talos/run_hail_filtering.py
@@ -778,7 +778,7 @@ def csq_struct_to_string(tx_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpr
         return hl.delimit([hl.or_else(hl.str(fields.get(f, '')), '') for f in csq_fields], '|')
 
     csq = hl.empty_array(hl.tstr)
-    csq = csq.extend(hl.or_else(tx_expr.map(lambda x: get_csq_from_struct(x)), hl.empty_array(hl.tstr)))  # noqa: PLW0108
+    csq = csq.extend(hl.or_else(tx_expr.map(lambda x: get_csq_from_struct(x)), hl.empty_array(hl.tstr)))
 
     # previous consequence filters may make this caution unnecessary
     return hl.or_missing(hl.len(csq) > 0, csq)

--- a/src/talos/run_hail_filtering.py
+++ b/src/talos/run_hail_filtering.py
@@ -778,7 +778,7 @@ def csq_struct_to_string(tx_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpr
         return hl.delimit([hl.or_else(hl.str(fields.get(f, '')), '') for f in csq_fields], '|')
 
     csq = hl.empty_array(hl.tstr)
-    csq = csq.extend(hl.or_else(tx_expr.map(lambda x: get_csq_from_struct(x)), hl.empty_array(hl.tstr)))
+    csq = csq.extend(hl.or_else(tx_expr.map(lambda x: get_csq_from_struct(x)), hl.empty_array(hl.tstr)))  # noqa: PLW0108
 
     # previous consequence filters may make this caution unnecessary
     return hl.or_missing(hl.len(csq) > 0, csq)

--- a/src/talos/templates/index.html.jinja
+++ b/src/talos/templates/index.html.jinja
@@ -132,6 +132,27 @@
                         <option value="none">Without phenotype match</option>
                     </select>
                 </div>
+                <div class="mb-3">
+                    <label class="form-label">Panel confidence filter</label>
+                    <div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input conf-filter" type="checkbox" id="conf-3" value="3" checked>
+                            <label class="form-check-label" for="conf-3">🟢 Green</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input conf-filter" type="checkbox" id="conf-2" value="2" checked>
+                            <label class="form-check-label" for="conf-2">🟡 Yellow</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input conf-filter" type="checkbox" id="conf-1" value="1" checked>
+                            <label class="form-check-label" for="conf-1">🔴 Red</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input conf-filter" type="checkbox" id="conf-0" value="0" checked>
+                            <label class="form-check-label" for="conf-0">⚪ Unknown</label>
+                        </div>
+                    </div>
+                </div>
 
                 <table class="display" id="variant-table">
 
@@ -140,6 +161,7 @@
                             <th class="group-separator">Individual</th>
                             <th>Variant</th>
                             <th>Gene (MOI)</th>
+                            <th>Confidence</th>
                             <th>Categories</th>
                             <th>First Tagged</th>
                             <th>MANE CSQ</th>
@@ -150,6 +172,7 @@
                             <th><input type="text" placeholder="Search Individual"></th>
                             <th><input type="text" placeholder="Search Variant"></th>
                             <th><input type="text" placeholder="Search Gene (MOI)"></th>
+                            <th></th>
                             <th><input type="text" placeholder="Search Categories"></th>
                             <th><input type="text" placeholder="Search First Tagged"></th>
                             <th><input type="text" placeholder="Search MANE CSQ"></th>
@@ -380,6 +403,29 @@
             }
 
             return true;
+        });
+
+        $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+            if (settings.nTable !== $('#variant-table')[0]) {
+                return true;
+            }
+
+            var checkedValues = $('.conf-filter:checked').map(function() {
+                return this.value;
+            }).get();
+
+            if (checkedValues.length === 4) {
+                return true;
+            }
+
+            var aoData = settings.aoData[dataIndex];
+            var rowNode = aoData && aoData.nTr;
+            if (!rowNode) {
+                return true;
+            }
+
+            var conf = rowNode.getAttribute('data-max-confidence') || '0';
+            return checkedValues.indexOf(conf) !== -1;
         });
 
         function formatChildRow(rowData) {
@@ -720,6 +766,10 @@
         });
 
         phenotypeFilter.on('change', function () {
+            table.draw();
+        });
+
+        $('.conf-filter').on('change', function () {
             table.draw();
         });
 

--- a/src/talos/templates/index.html.jinja
+++ b/src/talos/templates/index.html.jinja
@@ -121,35 +121,50 @@
                             <span class="badge text-bg-warning">Affected female with heterozygous variant in XLR gene</span> for females, we evaluate biallelic genes under a pseudo-dominant model, to detect plausible variants in the event of skewed x-inactivation.
                         </p>
 
+                        <h5>Confidence</h5>
+                        <p class="mb-1">
+                            Talos can include non-green PanelApp genes, depending on configuration.
+                            See <a href="https://panelapp-aus.org/#!Guidelines" target="_blank">PanelApp Guidelines</a> for the full meaning of each confidence level.
+                        </p>
+                        <p class="mb-1">
+                            Hovering over a gene symbol shows all panels that match this participant, with the RAG confidence for the gene on each panel.
+                        </p>
+                        <p class="mb-0">
+                            The coloured button next to the gene symbol shows the highest confidence level across matched panels, and can be filtered using the checkboxes above the table.
+                        </p>
                     </div>
                 </div>
 
-                <div class="mb-3">
-                    <label for="phenotype-filter" class="form-label">Phenotype match filter</label>
-                    <select id="phenotype-filter" class="form-select form-select-sm" style="max-width: 240px;">
-                        <option value="all" selected>All variants</option>
-                        <option value="has">With phenotype match</option>
-                        <option value="none">Without phenotype match</option>
-                    </select>
-                </div>
-                <div class="mb-3">
-                    <label class="form-label">Panel confidence filter</label>
+                <div class="d-flex flex-wrap gap-4 mb-3">
                     <div>
-                        <div class="form-check form-check-inline">
-                            <input class="form-check-input conf-filter" type="checkbox" id="conf-3" value="3" checked>
-                            <label class="form-check-label" for="conf-3">🟢 Green</label>
+                        <label for="phenotype-filter" class="form-label">Phenotype match filter</label>
+                        <select id="phenotype-filter" class="form-select form-select-sm" style="max-width: 240px;">
+                            <option value="all" selected>All variants</option>
+                            <option value="has">With phenotype match</option>
+                            <option value="none">Without phenotype match</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="form-label">Panel confidence</label>
+                        <div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input conf-filter" type="checkbox" id="conf-3" value="3" checked>
+                                <label class="form-check-label" for="conf-3">🟢 Green</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input conf-filter" type="checkbox" id="conf-2" value="2" checked>
+                                <label class="form-check-label" for="conf-2">🟡 Amber</label>
+                            </div>
                         </div>
-                        <div class="form-check form-check-inline">
-                            <input class="form-check-input conf-filter" type="checkbox" id="conf-2" value="2" checked>
-                            <label class="form-check-label" for="conf-2">🟡 Yellow</label>
-                        </div>
-                        <div class="form-check form-check-inline">
-                            <input class="form-check-input conf-filter" type="checkbox" id="conf-1" value="1" checked>
-                            <label class="form-check-label" for="conf-1">🔴 Red</label>
-                        </div>
-                        <div class="form-check form-check-inline">
-                            <input class="form-check-input conf-filter" type="checkbox" id="conf-0" value="0" checked>
-                            <label class="form-check-label" for="conf-0">⚪ Unknown</label>
+                        <div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input conf-filter" type="checkbox" id="conf-1" value="1" checked>
+                                <label class="form-check-label" for="conf-1">🔴 Red</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input conf-filter" type="checkbox" id="conf-0" value="0" checked>
+                                <label class="form-check-label" for="conf-0">⚪ Unknown</label>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -161,7 +176,6 @@
                             <th class="group-separator">Individual</th>
                             <th>Variant</th>
                             <th>Gene (MOI)</th>
-                            <th>Confidence</th>
                             <th>Categories</th>
                             <th>First Tagged</th>
                             <th>MANE CSQ</th>
@@ -172,7 +186,6 @@
                             <th><input type="text" placeholder="Search Individual"></th>
                             <th><input type="text" placeholder="Search Variant"></th>
                             <th><input type="text" placeholder="Search Gene (MOI)"></th>
-                            <th></th>
                             <th><input type="text" placeholder="Search Categories"></th>
                             <th><input type="text" placeholder="Search First Tagged"></th>
                             <th><input type="text" placeholder="Search MANE CSQ"></th>

--- a/src/talos/templates/index.html.jinja
+++ b/src/talos/templates/index.html.jinja
@@ -714,7 +714,9 @@
         // Enable bootstrap tool tips
         var tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
         [].slice.call(tooltipTriggerList).forEach(function(tooltipTriggerEl) {
-            new bootstrap.Tooltip(tooltipTriggerEl);
+            new bootstrap.Tooltip(tooltipTriggerEl, {
+                html: tooltipTriggerEl.dataset.bsHtml === 'true',
+            });
         });
 
         phenotypeFilter.on('change', function () {

--- a/src/talos/templates/variant_table_row.html.jinja
+++ b/src/talos/templates/variant_table_row.html.jinja
@@ -63,8 +63,12 @@
         {% endif %}
     </td>
     <td>
-        {# Gene symbol #}
-        {% for gene in variant.genes %}
+        {# Gene symbol + confidence indicator #}
+        {% if variant.max_confidence == 3 %}{% set conf_emoji = "🟢" %}
+        {% elif variant.max_confidence == 2 %}{% set conf_emoji = "🟡" %}
+        {% elif variant.max_confidence == 1 %}{% set conf_emoji = "🔴" %}
+        {% else %}{% set conf_emoji = "⚪" %}{% endif %}
+        {{ conf_emoji }}{% for gene in variant.genes %}
         {% if gene[2] %}
         <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ gene[2] }}">
             <a href="https://panelapp-aus.org/panels/entities/{{gene[1]|urlencode}}" target="_blank">{{gene[1]|e}}</a>
@@ -103,13 +107,6 @@
         |replace("X_Male","XLR (Male)")
         | e }}
         </span>
-    </td>
-    <td class="text-center">
-        {# Highest panel confidence (applied panels only) #}
-        {% if variant.max_confidence == 3 %}🟢
-        {% elif variant.max_confidence == 2 %}🟡
-        {% elif variant.max_confidence == 1 %}🔴
-        {% else %}⚪{% endif %}
     </td>
     <td>
         {# Categories #}

--- a/src/talos/templates/variant_table_row.html.jinja
+++ b/src/talos/templates/variant_table_row.html.jinja
@@ -64,7 +64,13 @@
     <td>
         {# Gene symbol #}
         {% for gene in variant.genes %}
+        {% if gene[2] %}
+        <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ gene[2] }}">
+            <a href="https://panelapp-aus.org/panels/entities/{{gene[1]|urlencode}}" target="_blank">{{gene[1]|e}}</a>
+        </span>
+        {% else %}
         <a href="https://panelapp-aus.org/panels/entities/{{gene[1]|urlencode}}" target="_blank">{{gene[1]|e}}</a>
+        {% endif %}
         {% endfor %}
         {% if variant.forced_matches or variant.phenotype_matches or variant.pheno_matches %}
         {% if variant.pheno_matches %}

--- a/src/talos/templates/variant_table_row.html.jinja
+++ b/src/talos/templates/variant_table_row.html.jinja
@@ -15,6 +15,7 @@
     data-support-vars='{{variant.support_vars_json|tojson}}'
     data-transcript-consequences='{{variant.transcript_consequences_json|tojson}}'
     data-has-phenotype="{{ 1 if variant.forced_matches or variant.phenotype_matches or variant.pheno_matches else 0 }}"
+    data-max-confidence="{{ variant.max_confidence }}"
 >
     <td style="white-space: nowrap" class="details-control">
         {# Individual ID - Click to expand details #}
@@ -102,6 +103,13 @@
         |replace("X_Male","XLR (Male)")
         | e }}
         </span>
+    </td>
+    <td class="text-center">
+        {# Highest panel confidence (applied panels only) #}
+        {% if variant.max_confidence == 3 %}🟢
+        {% elif variant.max_confidence == 2 %}🟡
+        {% elif variant.max_confidence == 1 %}🔴
+        {% else %}⚪{% endif %}
     </td>
     <td>
         {# Categories #}

--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -47,9 +47,12 @@ IRRELEVANT_MOI = {'unknown', 'other'}
 # we consider a gene new, and worth flagging, if it was made Green in a panel within this time frame
 WITHIN_X_MONTHS = 6
 
+MIN_GENE_CONFIDENCE: int = 3
+
 try:
     DEFAULT_PANEL = config_retrieve(['GeneratePanelData', 'default_panel'], PANELAPP_BASE_PANEL)
     WITHIN_X_MONTHS = config_retrieve(['GeneratePanelData', 'within_x_months'], WITHIN_X_MONTHS)
+    MIN_GENE_CONFIDENCE = config_retrieve(['GeneratePanelData', 'confidence_level'], MIN_GENE_CONFIDENCE)
 except KeyError:
     logger.warning('Config environment variable TALOS_CONFIG not set, falling back to Aussie PanelApp')
     DEFAULT_PANEL = PANELAPP_BASE_PANEL
@@ -264,7 +267,13 @@ def fetch_genes_for_panels(panelapp_data: PanelApp, cached_panelapp: DownloadedP
     # now iterate over the genes we know about, and pull them into the panel details object
     for gene_data in cached_panelapp.genes.values():
         # check if this gene is in any of the panels we are interested in - retain the overlap
-        if not (panel_intersection := set(gene_data.panels.keys()).intersection(full_set_of_panels)):
+        # also enforce the confidence threshold: skip panel associations below the configured level
+        eligible_panels = {
+            panel_id
+            for panel_id, panel_detail in gene_data.panels.items()
+            if panel_detail.confidence >= MIN_GENE_CONFIDENCE
+        }
+        if not (panel_intersection := eligible_panels.intersection(full_set_of_panels)):
             continue
 
         # collect all the relevant MOIs based on the panels we're using

--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -250,7 +250,7 @@ def get_simple_moi(input_mois: set[str], chrom: str) -> str:
         return 'Hemi_Mono_In_Female'
 
     # take the more lenient of the gene MOI options
-    return sorted(simplified_mois, key=lambda x: ORDERED_MOIS.index(x))[0]  # noqa: PLW0108
+    return sorted(simplified_mois, key=lambda x: ORDERED_MOIS.index(x))[0]
 
 
 def fetch_genes_for_panels(panelapp_data: PanelApp, cached_panelapp: DownloadedPanelApp):

--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -250,7 +250,7 @@ def get_simple_moi(input_mois: set[str], chrom: str) -> str:
         return 'Hemi_Mono_In_Female'
 
     # take the more lenient of the gene MOI options
-    return sorted(simplified_mois, key=lambda x: ORDERED_MOIS.index(x))[0]
+    return sorted(simplified_mois, key=ORDERED_MOIS.index)[0]
 
 
 def fetch_genes_for_panels(panelapp_data: PanelApp, cached_panelapp: DownloadedPanelApp):

--- a/src/talos/unified_panelapp_parser.py
+++ b/src/talos/unified_panelapp_parser.py
@@ -296,6 +296,7 @@ def fetch_genes_for_panels(panelapp_data: PanelApp, cached_panelapp: DownloadedP
             moi=moi,
             new=new_panels,
             panels=panel_intersection,
+            panel_confidences={pid: gene_data.panels[pid].confidence for pid in panel_intersection},
         )
 
 

--- a/test/input/panelapp_current_137.json
+++ b/test/input/panelapp_current_137.json
@@ -12,6 +12,7 @@
       },
       "entity_type": "gene",
       "entity_name": "ABCD",
+      "confidence_level": "3",
       "mode_of_inheritance": "Biallelic"
     },
     {
@@ -27,6 +28,7 @@
       },
       "entity_type": "gene",
       "entity_name": "EFGH",
+      "confidence_level": "3",
       "mode_of_inheritance": "Monoallelic"
     },
     {
@@ -42,6 +44,7 @@
       },
       "entity_type": "gene",
       "entity_name": "IJKL",
+      "confidence_level": "3",
       "mode_of_inheritance": "BOTH"
     },
     {
@@ -51,6 +54,7 @@
       },
       "entity_type": "gene",
       "entity_name": "RNU12",
+      "confidence_level": "3",
       "mode_of_inheritance": "SPECIFIC"
     },
     {
@@ -66,6 +70,7 @@
       },
       "entity_type": "not_gene",
       "entity_name": "SKIP",
+      "confidence_level": "3",
       "mode_of_inheritance": "Mystery"
     }
 ]

--- a/test/test_panelapp_download.py
+++ b/test/test_panelapp_download.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from talos.download_panelapp import (
     PANELS_ENDPOINT,
     get_panels_and_hpo_terms,
@@ -141,46 +139,21 @@ _GENE_TEMPLATE = {
 
 
 def _make_gene(symbol: str, confidence: int) -> dict:
-    gene = {**_GENE_TEMPLATE, 'entity_name': symbol, 'confidence_level': str(confidence)}
-    gene['gene_data'] = {
-        'ensembl_genes': {
-            'GRch38': {
-                '90': {
-                    'ensembl_id': f'ENSG{symbol}',
-                    'location': '1:',
+    return {
+        **_GENE_TEMPLATE,
+        'entity_name': symbol,
+        'confidence_level': str(confidence),
+        'gene_data': {
+            'ensembl_genes': {
+                'GRch38': {
+                    '90': {
+                        'ensembl_id': f'ENSG{symbol}',
+                        'location': '1:',
+                    },
                 },
             },
         },
     }
-    return gene
-
-
-def test_parse_panel_excludes_low_confidence(panel_activities):
-    """genes below the default green threshold (3) must be filtered out"""
-    panel_data = [
-        _make_gene('GREEN', 3),
-        _make_gene('AMBER', 2),
-        _make_gene('RED', 1),
-    ]
-    result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
-    assert 'ENSGGREEN' in result
-    assert 'ENSGAMBER' not in result
-    assert 'ENSGRED' not in result
-
-
-def test_parse_panel_includes_amber_when_threshold_lowered(panel_activities):
-    """lowering GENE_CONFIDENCE to 2 admits amber genes but still rejects red"""
-    panel_data = [
-        _make_gene('GREEN', 3),
-        _make_gene('AMBER', 2),
-        _make_gene('RED', 1),
-    ]
-    with patch('talos.download_panelapp.GENE_CONFIDENCE', 2):
-        result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
-    assert 'ENSGGREEN' in result
-    assert 'ENSGAMBER' in result
-    assert 'ENSGRED' not in result
-    assert result['ENSGAMBER']['confidence_level'] == 2
 
 
 def test_parse_panel_includes_all_when_threshold_one(panel_activities):
@@ -190,8 +163,7 @@ def test_parse_panel_includes_all_when_threshold_one(panel_activities):
         _make_gene('AMBER', 2),
         _make_gene('RED', 1),
     ]
-    with patch('talos.download_panelapp.GENE_CONFIDENCE', 1):
-        result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
+    result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
     assert 'ENSGGREEN' in result
     assert 'ENSGAMBER' in result
     assert 'ENSGRED' in result

--- a/test/test_panelapp_download.py
+++ b/test/test_panelapp_download.py
@@ -1,10 +1,19 @@
+from unittest.mock import patch
+
 from talos.download_panelapp import (
     PANELS_ENDPOINT,
     get_panels_and_hpo_terms,
     parse_panel,
     parse_panel_activity,
 )
-from talos.models import HpoTerm
+from talos.liftover.lift_2_2_0_to_2_3_0 import dl_panelapp as dl_pa_220_to_230
+from talos.models import (
+    CURRENT_VERSION,
+    DownloadedPanelApp,
+    DownloadedPanelAppGenePanelDetail,
+    HpoTerm,
+    lift_up_model_version,
+)
 
 
 def test_panel_hpo_query(httpx_mock, panels_and_hpos):
@@ -54,6 +63,7 @@ def test_parse_panel(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'biallelic',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
         'ENSG00EFGH': {
             'symbol': 'EFGH',
@@ -61,6 +71,7 @@ def test_parse_panel(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'monoallelic',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
         'ENSG00IJKL': {
             'symbol': 'IJKL',
@@ -68,6 +79,7 @@ def test_parse_panel(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'both',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
     }
 
@@ -83,6 +95,7 @@ def test_parse_panel_with_mane(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'biallelic',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
         'ENSG00ABCD': {
             'symbol': 'ABCD',
@@ -90,6 +103,7 @@ def test_parse_panel_with_mane(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'biallelic',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
         'ENSG00EFGH': {
             'symbol': 'EFGH',
@@ -97,6 +111,7 @@ def test_parse_panel_with_mane(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'monoallelic',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
         'ENSG00IJKL': {
             'symbol': 'IJKL',
@@ -104,5 +119,138 @@ def test_parse_panel_with_mane(latest_mendeliome, panel_activities):
             'mane_symbol': '',
             'moi': 'both',
             'green_date': '1970-01-01',
+            'confidence_level': 3,
         },
     }
+
+
+_GENE_TEMPLATE = {
+    'gene_data': {
+        'ensembl_genes': {
+            'GRch38': {
+                '90': {
+                    'ensembl_id': 'ENSG{symbol}',
+                    'location': '1:',
+                },
+            },
+        },
+    },
+    'entity_type': 'gene',
+    'mode_of_inheritance': 'Biallelic',
+}
+
+
+def _make_gene(symbol: str, confidence: int) -> dict:
+    gene = {**_GENE_TEMPLATE, 'entity_name': symbol, 'confidence_level': str(confidence)}
+    gene['gene_data'] = {
+        'ensembl_genes': {
+            'GRch38': {
+                '90': {
+                    'ensembl_id': f'ENSG{symbol}',
+                    'location': '1:',
+                },
+            },
+        },
+    }
+    return gene
+
+
+def test_parse_panel_excludes_low_confidence(panel_activities):
+    """genes below the default green threshold (3) must be filtered out"""
+    panel_data = [
+        _make_gene('GREEN', 3),
+        _make_gene('AMBER', 2),
+        _make_gene('RED', 1),
+    ]
+    result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
+    assert 'ENSGGREEN' in result
+    assert 'ENSGAMBER' not in result
+    assert 'ENSGRED' not in result
+
+
+def test_parse_panel_includes_amber_when_threshold_lowered(panel_activities):
+    """lowering GENE_CONFIDENCE to 2 admits amber genes but still rejects red"""
+    panel_data = [
+        _make_gene('GREEN', 3),
+        _make_gene('AMBER', 2),
+        _make_gene('RED', 1),
+    ]
+    with patch('talos.download_panelapp.GENE_CONFIDENCE', 2):
+        result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
+    assert 'ENSGGREEN' in result
+    assert 'ENSGAMBER' in result
+    assert 'ENSGRED' not in result
+    assert result['ENSGAMBER']['confidence_level'] == 2
+
+
+def test_parse_panel_includes_all_when_threshold_one(panel_activities):
+    """setting GENE_CONFIDENCE to 1 admits red, amber, and green genes"""
+    panel_data = [
+        _make_gene('GREEN', 3),
+        _make_gene('AMBER', 2),
+        _make_gene('RED', 1),
+    ]
+    with patch('talos.download_panelapp.GENE_CONFIDENCE', 1):
+        result = parse_panel(panel_data=panel_data, panel_activities=panel_activities)
+    assert 'ENSGGREEN' in result
+    assert 'ENSGAMBER' in result
+    assert 'ENSGRED' in result
+    assert result['ENSGRED']['confidence_level'] == 1
+
+
+def test_downloaded_panel_app_gene_panel_detail_confidence():
+    """DownloadedPanelAppGenePanelDetail must persist the confidence field"""
+    detail = DownloadedPanelAppGenePanelDetail(moi='biallelic', date='2024-01-01', confidence=2)
+    assert detail.confidence == 2
+
+    detail_default = DownloadedPanelAppGenePanelDetail(moi='monoallelic')
+    assert detail_default.confidence == 0
+
+
+def test_liftover_dl_panelapp_220_to_230():
+    """liftover function must add confidence=3 to every panel entry and bump version"""
+    data = {
+        'version': '2.2.0',
+        'genes': {
+            'ENSG001': {
+                'panels': {
+                    137: {'moi': 'biallelic', 'date': '2023-01-01'},
+                    42: {'moi': 'monoallelic', 'date': '2022-06-15'},
+                },
+            },
+            'ENSG002': {
+                'panels': {
+                    137: {'moi': 'both', 'date': '2021-03-10'},
+                },
+            },
+        },
+    }
+    result = dl_pa_220_to_230(data)
+    assert result['version'] == '2.3.0'
+    for gene_data in result['genes'].values():
+        for panel_data in gene_data['panels'].values():
+            assert panel_data['confidence'] == 3
+
+
+def test_liftover_downloaded_panelapp_via_model():
+    """lift_up_model_version must walk the chain from 2.2.0 to current and produce a valid model"""
+    data = {
+        'version': '2.2.0',
+        'genes': {
+            'ENSG001': {
+                'symbol': 'GENE1',
+                'chrom': '1',
+                'mane_symbol': '',
+                'ensg': 'ENSG001',
+                'panels': {
+                    137: {'moi': 'biallelic', 'date': '2023-01-01'},
+                },
+            },
+        },
+        'versions': [],
+        'hpos': {},
+    }
+    lifted = lift_up_model_version(data, model=DownloadedPanelApp)
+    assert lifted['version'] == CURRENT_VERSION
+    parsed = DownloadedPanelApp.model_validate(lifted)
+    assert parsed.genes['ENSG001'].panels[137].confidence == 3

--- a/test/test_unified_panelapp_parser.py
+++ b/test/test_unified_panelapp_parser.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from obonet import read_obo
@@ -6,6 +6,8 @@ from obonet import read_obo
 from talos.models import (
     CURRENT_VERSION,
     DownloadedPanelApp,
+    DownloadedPanelAppGene,
+    DownloadedPanelAppGenePanelDetail,
     HpoTerm,
     PanelApp,
     PanelDetail,
@@ -188,9 +190,7 @@ def test_remove_blacklisted_genes():
     assert 'ENSG1' not in panelapp_data.genes
 
 
-def _make_downloaded_gene(ensg: str, panel_id: int, confidence: int, moi: str = 'biallelic'):
-    from talos.models import DownloadedPanelAppGene, DownloadedPanelAppGenePanelDetail
-
+def _make_downloaded_gene(ensg: str, panel_id: int, confidence: int, moi: str = 'biallelic') -> DownloadedPanelAppGene:
     return DownloadedPanelAppGene(
         symbol=ensg,
         chrom='1',
@@ -218,7 +218,6 @@ def test_fetch_genes_for_panels_excludes_low_confidence():
 
 def test_fetch_genes_for_panels_includes_amber_when_threshold_lowered():
     """lowering MIN_GENE_CONFIDENCE to 2 must include amber associations"""
-    from unittest.mock import patch
 
     panel_id = 137
     cached = DownloadedPanelApp(

--- a/test/test_unified_panelapp_parser.py
+++ b/test/test_unified_panelapp_parser.py
@@ -17,6 +17,7 @@ from talos.unified_panelapp_parser import (
     CUSTOM_PANEL_ID,
     ORDERED_MOIS,
     extract_participant_data_from_pedigree,
+    fetch_genes_for_panels,
     get_simple_moi,
     match_hpos_to_panels,
     match_participants_to_panels,
@@ -185,3 +186,53 @@ def test_remove_blacklisted_genes():
     panelapp_data.genes = {'ENSG1': PanelDetail(symbol='GENE1', moi='Monoallelic', panels={1}, chrom='1')}
     remove_blacklisted_genes(panelapp_data, {'ENSG1'})
     assert 'ENSG1' not in panelapp_data.genes
+
+
+def _make_downloaded_gene(ensg: str, panel_id: int, confidence: int, moi: str = 'biallelic'):
+    from talos.models import DownloadedPanelAppGene, DownloadedPanelAppGenePanelDetail
+
+    return DownloadedPanelAppGene(
+        symbol=ensg,
+        chrom='1',
+        ensg=ensg,
+        panels={panel_id: DownloadedPanelAppGenePanelDetail(moi=moi, date='2020-01-01', confidence=confidence)},
+    )
+
+
+def test_fetch_genes_for_panels_excludes_low_confidence():
+    """genes whose panel association is below the default threshold must not appear in the output"""
+    panel_id = 137
+    cached = DownloadedPanelApp(
+        genes={
+            'GREEN': _make_downloaded_gene('GREEN', panel_id, confidence=3),
+            'AMBER': _make_downloaded_gene('AMBER', panel_id, confidence=2),
+        },
+    )
+    papp = PanelApp(participants={'S1': ParticipantHPOPanels(panels={panel_id})})
+
+    fetch_genes_for_panels(panelapp_data=papp, cached_panelapp=cached)
+
+    assert 'GREEN' in papp.genes
+    assert 'AMBER' not in papp.genes
+
+
+def test_fetch_genes_for_panels_includes_amber_when_threshold_lowered():
+    """lowering MIN_GENE_CONFIDENCE to 2 must include amber associations"""
+    from unittest.mock import patch
+
+    panel_id = 137
+    cached = DownloadedPanelApp(
+        genes={
+            'GREEN': _make_downloaded_gene('GREEN', panel_id, confidence=3),
+            'AMBER': _make_downloaded_gene('AMBER', panel_id, confidence=2),
+            'RED': _make_downloaded_gene('RED', panel_id, confidence=1),
+        },
+    )
+    papp = PanelApp(participants={'S1': ParticipantHPOPanels(panels={panel_id})})
+
+    with patch('talos.unified_panelapp_parser.MIN_GENE_CONFIDENCE', 2):
+        fetch_genes_for_panels(panelapp_data=papp, cached_panelapp=cached)
+
+    assert 'GREEN' in papp.genes
+    assert 'AMBER' in papp.genes
+    assert 'RED' not in papp.genes


### PR DESCRIPTION
# Fixes

  - So far the PanelApp querying has only been able to pick up green genes
  - Closes #528 
  - See https://cpg-populationanalysis.atlassian.net/browse/RD-1158

## Proposed Changes

  - Use a config parameter to select a confidence level
  - Default level == 3, Green only
  - 2 == Amber and Green
  - 1 == Red, Amber, Green
  - 3/Green remains the default

## Checklist

- [x] ChangeLog Updated
- [x] Version Bumped
- [x] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass
