### PR TITLE
Never modify the global config during run setup

### DIFF
--- a/src/talos/cpg_internal_scripts/cpgflow_jobs/make_config.py
+++ b/src/talos/cpg_internal_scripts/cpgflow_jobs/make_config.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import json
 
@@ -91,11 +92,11 @@ def create_config(cohort: targets.Cohort, seqr_out: Path, config_out: Path):
     dataset = cohort.dataset.name
     # start off with a fresh config dictionary, including generic content
     new_config = {
-        'GeneratePanelData': config.config_retrieve(['GeneratePanelData']),
-        'RunHailFiltering': config.config_retrieve(['RunHailFiltering']),
-        'RunHailFilteringSv': config.config_retrieve(['RunHailFilteringSv']),
-        'ValidateMOI': config.config_retrieve(['ValidateMOI']),
-        'HPOFlagging': config.config_retrieve(['HPOFlagging']),
+        'GeneratePanelData': copy.deepcopy(config.config_retrieve(['GeneratePanelData'])),
+        'RunHailFiltering': copy.deepcopy(config.config_retrieve(['RunHailFiltering'])),
+        'RunHailFilteringSv': copy.deepcopy(config.config_retrieve(['RunHailFilteringSv'])),
+        'ValidateMOI': copy.deepcopy(config.config_retrieve(['ValidateMOI'])),
+        'HPOFlagging': copy.deepcopy(config.config_retrieve(['HPOFlagging'])),
         'CreateTalosHTML': {},  # populate from a separate part of config
         'splice_ai_ht': config.config_retrieve(['references', 'splice_ai_ht']),
         'dataset': dataset,


### PR DESCRIPTION
# Fixes

  - The CPG-internal implementation is mixing up config settings across projects
  - Root cause - blocks of config were being referenced, but also `update`d within a loop. e.g. the `GeneratePanelData` part of config was being `updated` to include a specific project's forced_panels. 
  - If the next project didn't have any forced panels, the previous project's panels would be inherited due to the base config having been updated.

## Proposed Changes

  - use copy - each project pulls it's part of the config as a separate dictionary
  - if the project has specific updates to make (e.g. forced panels), those changes are made to a private copy of the config, instead of potentially affecting all projects processed after

Chocolate fish for @SamBryen 🐟 