### PR TITLE
Change panelapp-ensembl parsing

### DIFF
--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -378,7 +378,6 @@ def main(output: str, mane_path: str | None = None):
         )
 
         for gene, gene_data in parsed_panel_data.items():
-            print(gene_data)
             # already seen - update some attributes
             if prev_gene_data := collected_panel_data.genes.get(gene):
                 prev_gene_data.panels[panel_id] = DownloadedPanelAppGenePanelDetail(

--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -240,12 +240,14 @@ async def get_single_panel(session: aiohttp.ClientSession, panel_id: int) -> dic
                 continue
 
             # find the latest available ensembl gene block
-            if latest_content := get_latest_ensembl_data(gene['gene_data'].get('ensembl_genes')):
+            if latest_content := get_latest_ensembl_data(gene['gene_data']['ensembl_genes'].get('GRch38', {})):
                 ensg, chrom = latest_content
                 if chrom == MITO_BAD:
                     chrom = MITO_GOOD
+
+            # Pydantic model won't tolerate None here, ENSG is pretty integral to downstream processes
             else:
-                ensg, chrom = None, None
+                continue
 
             gene_results.append(
                 {
@@ -376,6 +378,7 @@ def main(output: str, mane_path: str | None = None):
         )
 
         for gene, gene_data in parsed_panel_data.items():
+            print(gene_data)
             # already seen - update some attributes
             if prev_gene_data := collected_panel_data.genes.get(gene):
                 prev_gene_data.panels[panel_id] = DownloadedPanelAppGenePanelDetail(

--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -191,6 +191,28 @@ def parse_panel(
     return panel_gene_content
 
 
+def get_latest_ensembl_data(grch38_versions) -> tuple[str, str] | None:
+    """
+    Parsing method to choose the latest (highest version number) ensembl ID and contig
+
+    Args:
+        grch38_versions: the panel.gene_data.ensembl_genes data from the PanelApp API response
+
+    Returns:
+        either a String pair, the ensembl gene ID and the contig, or None
+    """
+    if not grch38_versions:
+        return None
+
+    def sort_key(k):
+        return (int(k), k) if k.isdigit() else (-1, k)
+
+    latest_key = max(grch38_versions.keys(), key=sort_key)
+    if ensembl_id := grch38_versions[latest_key].get('ensembl_id'):
+        return ensembl_id, grch38_versions[latest_key]['location'].split(':')[0]
+    return None
+
+
 async def get_single_panel(session: aiohttp.ClientSession, panel_id: int) -> dict[int, dict[str, str | list[dict]]]:
     """
     Async method to return data from a single panel.
@@ -217,20 +239,13 @@ async def get_single_panel(session: aiohttp.ClientSession, panel_id: int) -> dic
             if gene['entity_type'] != 'gene':
                 continue
 
-            chrom: str = ''
-            ensg: str | None = None
-
-            # for some reason the build is capitalised oddly in panelapp, so lower it
-            for build, content in gene['gene_data']['ensembl_genes'].items():
-                if build.lower() == 'grch38':
-                    # the ensembl version may alter over time, but will be singular
-                    ensembl_data = content[next(iter(content.keys()))]
-                    ensg = ensembl_data['ensembl_id']
-                    chrom = ensembl_data['location'].split(':')[0]
-
-                    # step this down to M, for Hail
-                    if chrom == MITO_BAD:
-                        chrom = MITO_GOOD
+            # find the latest available ensembl gene block
+            if latest_content := get_latest_ensembl_data(gene['gene_data'].get('ensembl_genes')):
+                ensg, chrom = latest_content
+                if chrom == MITO_BAD:
+                    chrom = MITO_GOOD
+            else:
+                ensg, chrom = None, None
 
             gene_results.append(
                 {

--- a/src/talos/download_panelapp.py
+++ b/src/talos/download_panelapp.py
@@ -204,7 +204,7 @@ def get_latest_ensembl_data(grch38_versions) -> tuple[str, str] | None:
     if not grch38_versions:
         return None
 
-    def sort_key(k):
+    def sort_key(k) -> tuple[int, str]:
         return (int(k), k) if k.isdigit() else (-1, k)
 
     latest_key = max(grch38_versions.keys(), key=sort_key)

--- a/test/test_panelapp_download.py
+++ b/test/test_panelapp_download.py
@@ -1,5 +1,6 @@
 from talos.download_panelapp import (
     PANELS_ENDPOINT,
+    get_latest_ensembl_data,
     get_panels_and_hpo_terms,
     parse_panel,
     parse_panel_activity,
@@ -204,3 +205,30 @@ def test_liftover_downloaded_panelapp_via_model():
     assert lifted['version'] == CURRENT_VERSION
     parsed = DownloadedPanelApp.model_validate(lifted)
     assert parsed.genes['ENSG001'].panels[137].confidence == 3
+
+
+def test_latest_ensembl_none():
+    assert get_latest_ensembl_data(None) is None
+
+
+def test_latest_ensembl_populated_none():
+    data = {
+        '1': {
+            'location': '1:123-456',
+        }
+    }
+    assert get_latest_ensembl_data(data) is None
+
+
+def test_latest_ensembl_populated():
+    data = {
+        '1': {
+            'ensembl_id': 'FISH',
+            'location': '1:123-456',
+        },
+        '100': {
+            'ensembl_id': 'CHIPS',
+            'location': '1:123-456',
+        },
+    }
+    assert get_latest_ensembl_data(data) == ('CHIPS', '1')


### PR DESCRIPTION
# Fixes

  - PanelApp backend is changing, and may potentially support multiple ensembl versions

## Proposed Changes

  - See https://github.com/broadinstitute/seqr/pull/5476/changes
  - Steals the proposed Seqr change, parse the Ensembl-genes block and choose the latest/highest numbered version available
  - This is expected to be a neutral change, as Talos' current parsing is relatively immune to the backend changes, but this adds future-proofing using the syntax proposed by the MCRI team