### PR TITLE
Adapt to improved meta, consolidate discovery methods

### DIFF
--- a/src/talos/cpg_internal_scripts/cpg_flow_utils.py
+++ b/src/talos/cpg_internal_scripts/cpg_flow_utils.py
@@ -196,11 +196,15 @@ def query_for_latest_analysis(
     analysis_by_date = {}
     for analysis in result['project']['analyses']:
         outputs_block = analysis['outputs']
+        output_path: str | None = None
         if isinstance(outputs_block, dict):
-            output_path = outputs_block['path']
+            if (opath := outputs_block.get('path')) and isinstance(opath, str):
+                output_path = opath
+            elif (opath := outputs_block.get('output')) and isinstance(opath, list):
+                output_path = opath[0]
         elif isinstance(outputs_block, str):
             output_path = outputs_block
-        else:
+        if output_path is None:
             loguru.logger.debug(f'Skipping {outputs_block} in dataset {query_dataset}, unexpected type.')
             continue
 
@@ -267,14 +271,15 @@ def query_for_latest_lrs_mt(
     analysis_by_date = {}
     for analysis in result['project']['analyses']:
         outputs_block = analysis['outputs']
+        output_path: str | None = None
         if isinstance(outputs_block, dict):
-            if 'path' in outputs_block and isinstance(outputs_block.get('path'), str):
-              output_path = outputs_block['path']
-            elif 'output' in outputs_block and isinstance(outputs_block.get('output'), list):
-              output_path = outputs_block['output'][0]
+            if (opath := outputs_block.get('path')) and isinstance(opath, str):
+                output_path = opath
+            elif (opath := outputs_block.get('output')) and isinstance(opath, list):
+                output_path = opath[0]
         elif isinstance(outputs_block, str):
             output_path = outputs_block
-        else:
+        if output_path is None:
             loguru.logger.debug(f'Skipping {outputs_block} in dataset {query_dataset}, unexpected type.')
             continue
 

--- a/src/talos/cpg_internal_scripts/cpg_flow_utils.py
+++ b/src/talos/cpg_internal_scripts/cpg_flow_utils.py
@@ -268,7 +268,10 @@ def query_for_latest_lrs_mt(
     for analysis in result['project']['analyses']:
         outputs_block = analysis['outputs']
         if isinstance(outputs_block, dict):
-            output_path = outputs_block['path']
+            if 'path' in outputs_block and isinstance(outputs_block.get('path'), str):
+              output_path = outputs_block['path']
+            elif 'output' in outputs_block and isinstance(outputs_block.get('output'), list):
+              output_path = outputs_block['output'][0]
         elif isinstance(outputs_block, str):
             output_path = outputs_block
         else:

--- a/src/talos/cpg_internal_scripts/cpg_flow_utils.py
+++ b/src/talos/cpg_internal_scripts/cpg_flow_utils.py
@@ -6,7 +6,6 @@ from cpg_flow import targets, workflow
 from cpg_utils import Path, config, to_path
 from metamist import graphql
 
-LONG_READ_STRING = 'LongRead'
 METAMIST_ANALYSIS_QUERY = graphql.gql(
     """
     query MyQuery($dataset: String!, $type: String!, $meta: JSON) {
@@ -173,101 +172,47 @@ def query_for_latest_analysis(
 
     loguru.logger.info(f'Querying for {analysis_type} in {query_dataset}')
 
+    # all long-read objects are tagged with this in their meta dict
+    meta_query: dict[str, str] = {}
+    if stage_name:
+        meta_query['stage'] = stage_name
+
+    if long_read:
+        meta_query['sequencing_technology'] = 'long-read'
+
+    if sequencing_type != 'all':
+        meta_query['sequencing_type'] = sequencing_type
+
     result = graphql.query(
         METAMIST_ANALYSIS_QUERY,
         variables={
             'dataset': query_dataset,
             'type': analysis_type,
-            'meta': {'stage': stage_name} if stage_name else {},
+            'meta': meta_query,
         },
     )
 
     # get all the relevant entries, and bin by date
     analysis_by_date = {}
     for analysis in result['project']['analyses']:
-        if analysis['output'] and (sequencing_type in {'all', analysis['meta'].get('sequencing_type')}):
-            # skip over the partial-cohort AnnotateDataset objects
-            if '_families-' in analysis['output']:
-                loguru.logger.debug(
-                    f'Skipping analysis {analysis["output"]} for dataset {query_dataset}. '
-                    f'It is a partial-cohort AnnotateDataset object',
-                )
-                continue
+        outputs_block = analysis['outputs']
+        if isinstance(outputs_block, dict):
+            output_path = outputs_block['path']
+        elif isinstance(outputs_block, str):
+            output_path = outputs_block
+        else:
+            loguru.logger.debug(f'Skipping {outputs_block} in dataset {query_dataset}, unexpected type.')
+            continue
 
-            # manually implementing an XOR check - long read (bool) and LongRead in output must match
-            if long_read != (LONG_READ_STRING in analysis['output']):
-                loguru.logger.debug(
-                    f'Skipping analysis {analysis["output"]} for dataset {query_dataset}. '
-                    f'It does not match query parameter long_read={long_read}',
-                )
-                continue
+        # skip over the partial-cohort AnnotateDataset objects
+        if '_families-' in output_path:
+            loguru.logger.debug(
+                f'Skipping analysis {output_path} for dataset {query_dataset}. '
+                f'It is a partial-cohort AnnotateDataset object',
+            )
+            continue
 
-            analysis_by_date[analysis['timestampCompleted']] = analysis['output']
-
-    if not analysis_by_date:
-        loguru.logger.warning(f'No Analysis Entries found for dataset {query_dataset}')
-        return None
-
-    # return the latest, determined by a sort on timestamp
-    # 2023-10-10... > 2023-10-09..., so sort on strings
-    return analysis_by_date[sorted(analysis_by_date)[-1]]
-
-
-@cache
-def ideal_query_for_latest_lrs_mt(
-    cohort: targets.Cohort,
-    sequencing_type: str = 'all',
-    stage_name: str | None = 'ExportSnpsIndelsVcfToMt',
-    overlap: str = 'any',
-) -> str | None:
-    """
-    Query for the latest analysis object for LRS data in the requested project.
-
-    Args:
-        cohort (str):          cohort object to use for SG IDs and dataset name
-        sequencing_type (str): optional, if set, only return entries with meta.sequencing_type == this
-        stage_name (str):      optional, if set, will only return entries with meta.stage == this
-        overlap (str):         mechanic for SG ID matching; "exact" = SG IDs in Cohort and Analysis must match exactly.
-    Returns:
-        str, the path to the latest object for the given type, or log a warning and return None
-    """
-
-    query_dataset = config.dataset_for_access_level(cohort.dataset.name)
-
-    loguru.logger.info(f'Querying for matrix table in {query_dataset}')
-
-    result = graphql.query(
-        LRS_ANALYSIS_QUERY,
-        variables={
-            'dataset': query_dataset,
-            'type': 'matrixtable',
-            'meta': {'stage': stage_name} if stage_name else {},
-        },
-    )
-
-    cohort_sgids = set(cohort.get_sequencing_group_ids())
-
-    # get all the relevant entries, and bin by date
-    analysis_by_date = {}
-    for analysis in result['project']['analyses']:
-        output_block = analysis['outputs']
-
-        if isinstance(output_block, dict) and (sequencing_type in {'all', analysis['meta'].get('sequencing_type')}):
-            output_path = output_block['path']
-            # manually implementing an XOR check - long read (bool) and LongRead in output must match
-            if 'long_read' not in output_path:
-                loguru.logger.debug(f'Skipping {output_block} in dataset {query_dataset} - not long read.')
-                continue
-
-            analysis_sgids = {sgid['id'] for sgid in analysis['sequencingGroups']}
-
-            # restrict on common samples, complete or partial overlap
-            if overlap == 'exact' and cohort_sgids != analysis_sgids:
-                continue
-            if overlap == 'any' and not cohort_sgids & analysis_sgids:
-                continue
-
-            analysis_by_date[analysis['timestampCompleted']] = output_path
+        analysis_by_date[analysis['timestampCompleted']] = output_path
 
     if not analysis_by_date:
         loguru.logger.warning(f'No Analysis Entries found for dataset {query_dataset}')
@@ -302,12 +247,17 @@ def query_for_latest_lrs_mt(
 
     loguru.logger.info(f'Querying for matrix table in {query_dataset}')
 
+    # all long-read objects are tagged with this in their meta dict
+    meta_query = {'sequencing_technology': 'long-read'}
+    if stage_name:
+        meta_query['stage'] = stage_name
+
     result = graphql.query(
         LRS_ANALYSIS_QUERY,
         variables={
             'dataset': query_dataset,
             'type': 'matrixtable',
-            'meta': {'stage': stage_name} if stage_name else {},
+            'meta': meta_query,
         },
     )
 
@@ -316,11 +266,13 @@ def query_for_latest_lrs_mt(
     # get all the relevant entries, and bin by date
     analysis_by_date = {}
     for analysis in result['project']['analyses']:
-        output_path = analysis['output']
-
-        # manually implementing an XOR check - long read (bool) and LongRead in output must match
-        if LONG_READ_STRING not in output_path:
-            loguru.logger.debug(f'Skipping {output_path} in dataset {query_dataset} - not long read.')
+        outputs_block = analysis['outputs']
+        if isinstance(outputs_block, dict):
+            output_path = outputs_block['path']
+        elif isinstance(outputs_block, str):
+            output_path = outputs_block
+        else:
+            loguru.logger.debug(f'Skipping {outputs_block} in dataset {query_dataset}, unexpected type.')
             continue
 
         analysis_sgids = {sgid['id'] for sgid in analysis['sequencingGroups']}


### PR DESCRIPTION
# Fixes

  - long read analysis entry discovery was being done implicitly, through identification of `long_read` or `LongRead` in the file paths. We may not retain this convention

## Proposed Changes

  - analysis entries relating to long-read are now tagged using the convention `sequencing-technology=long-read` in the meta block of the analysis. This is now fed into the metamist queries where appropriate
  - I'd retained two methods, one for the MT records we have `analysis.outputs` as a String, and one for the records we will have once https://github.com/populationgenomics/metamist/pull/1306 is merged (`analysis.outputs.path` as a String). Instead of maintaining two methods, there is now an `isinstance` check done on the returned objects, so one method handles both cases

n.b. due to the deletion of a whole method, the diff here looks a little misleading. The file was previously:

  - general method
  - future LRS method
  - current LRS method

and is now

  - general method (with a block of indentation removed)
  - current LRS method 
